### PR TITLE
upgrade duckdb to v1.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ node test.mjs
 Expected output for above example:
 
 ```
-v1.1.1
+v1.1.2
 [col 0] bool::BOOLEAN
   [row 0] false
   [row 1] true

--- a/bindings/scripts/fetch_libduckdb_linux.py
+++ b/bindings/scripts/fetch_libduckdb_linux.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.1/libduckdb-linux-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.2/libduckdb-linux-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_mac.py
+++ b/bindings/scripts/fetch_libduckdb_mac.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.1/libduckdb-osx-universal.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.2/libduckdb-osx-universal.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_win.py
+++ b/bindings/scripts/fetch_libduckdb_win.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.1/libduckdb-windows-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.2/libduckdb-windows-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/test/constants.test.ts
+++ b/bindings/test/constants.test.ts
@@ -6,7 +6,7 @@ suite('constants', () => {
     expect(duckdb.sizeof_bool).toBe(1);
   });
   test('library_version', () => {
-    expect(duckdb.library_version()).toBe('v1.1.1');
+    expect(duckdb.library_version()).toBe('v1.1.2');
   });
   test('vector_size', () => {
     expect(duckdb.vector_size()).toBe(2048);


### PR DESCRIPTION
No C API changes going from v1.1.1 -> v1.1.2, except for one addition of `const` that doesn't affect these bindings.
All tests pass; no other changes needed.