### PR TITLE
convert config values to string

### DIFF
--- a/api/src/DuckDBInstance.ts
+++ b/api/src/DuckDBInstance.ts
@@ -14,7 +14,7 @@ export class DuckDBInstance {
       const config = duckdb.create_config();
       try {
         for (const optionName in options) {
-          const optionValue = options[optionName];
+          const optionValue = String(options[optionName]);
           duckdb.set_config(config, optionName, optionValue);
         }
         return new DuckDBInstance(await duckdb.open(path, config));


### PR DESCRIPTION
When using JS (instead of TS), it's not uncommon to try to set config options to non-string values (such as numbers). This results in an error. Convert the values to strings to allow this case and avoid the error.