### PR TITLE
value conversion in api

### DIFF
--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -264,13 +264,13 @@ if (columnType.typeId === DuckDBTypeId.TIMESTAMP) {
 }
 
 if (columnType.typeId === DuckDBTypeId.TIME_TZ) {
-  const timeTZMicros = columnValue.microseconds;
+  const timeTZMicros = columnValue.micros; // bigint
   const timeTZOffset = columnValue.offset;
   const timeTZString = columnValue.toString();
 }
 
 if (columnType.typeId === DuckDBTypeId.TIME) {
-  const timeMicros = columnValue.microseconds; // bigint
+  const timeMicros = columnValue.micros; // bigint
   const timeString = columnValue.toString();
 }
 

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -1,3 +1,9 @@
+export {
+  hugeint_to_double,
+  double_to_hugeint,
+  uhugeint_to_double,
+  double_to_uhugeint,
+} from '@duckdb/node-bindings';
 export * from './DuckDBAppender';
 export * from './DuckDBConnection';
 export * from './DuckDBDataChunk';

--- a/api/src/values/DuckDBDateValue.ts
+++ b/api/src/values/DuckDBDateValue.ts
@@ -1,5 +1,7 @@
-import { Date_ } from '@duckdb/node-bindings';
+import duckdb, { Date_, DateParts } from '@duckdb/node-bindings';
 import { getDuckDBDateStringFromDays } from '../conversion/dateTimeStringConversion';
+
+export type { DateParts };
 
 export class DuckDBDateValue implements Date_ {
   public readonly days: number;
@@ -8,8 +10,20 @@ export class DuckDBDateValue implements Date_ {
     this.days = days;
   }
 
+  public get isFinite(): boolean {
+    return duckdb.is_finite_date(this);
+  }
+
   public toString(): string {
     return getDuckDBDateStringFromDays(this.days);
+  }
+
+  public toParts(): DateParts {
+    return duckdb.from_date(this);
+  }
+
+  public static fromParts(parts: DateParts): DuckDBDateValue {
+    return new DuckDBDateValue(duckdb.to_date(parts).days);
   }
 
   public static readonly Epoch = new DuckDBDateValue(0);

--- a/api/src/values/DuckDBTimeTZValue.ts
+++ b/api/src/values/DuckDBTimeTZValue.ts
@@ -1,49 +1,70 @@
-import { TimeTZ } from '@duckdb/node-bindings';
+import duckdb, { TimeTZ, TimeTZParts } from '@duckdb/node-bindings';
 import { getDuckDBTimeStringFromMicrosecondsInDay } from '../conversion/dateTimeStringConversion';
 
+export type { TimeTZParts };
+
 export class DuckDBTimeTZValue implements TimeTZ {
+  /**
+  * 40 bits for micros, then 24 bits for encoded offset in seconds.
+  * 
+  * Max absolute unencoded offset = 15:59:59 = 60 * (60 * 15 + 59) + 59 = 57599.
+  * 
+  * Encoded offset is unencoded offset inverted then shifted (by +57599) to unsigned.
+  * 
+  * Max unencoded offset = 57599 -> -57599 -> 0 encoded.
+  * 
+  * Min unencoded offset = -57599 -> 57599 -> 115198 encoded.
+  */
   public readonly bits: bigint;
 
   /** Ranges from 0 to 86400000000 (= 24 * 60 * 60 * 1000 * 1000) */
-  public readonly microseconds: number;
+  public readonly micros: bigint;
 
   /** In seconds, ranges from -57599 to 57599 (= 16 * 60 * 60 - 1) */
   public readonly offset: number;
 
-  public constructor(bits: bigint, microseconds: number, offset: number) {
+  public constructor(bits: bigint, micros: bigint, offset: number) {
     this.bits = bits;
-    this.microseconds = microseconds;
+    this.micros = micros;
     this.offset = offset;
   }
 
   public toString(): string {
     // TODO: display offset
-    return getDuckDBTimeStringFromMicrosecondsInDay(BigInt(this.microseconds));
+    return getDuckDBTimeStringFromMicrosecondsInDay(this.micros);
+  }
+
+  public toParts(): TimeTZParts {
+    return duckdb.from_time_tz(this);
   }
 
   public static TimeBits = 40;
 	public static OffsetBits = 24;
 	public static MaxOffset = 16 * 60 * 60 - 1; // ±15:59:59 = 57599 seconds
   public static MinOffset = -DuckDBTimeTZValue.MaxOffset;
-  public static MaxMicroseconds = 24 * 60 * 60 * 1000 * 1000; // 86400000000
-  public static MinMicroseconds = 0;
+  public static MaxMicros = 24n * 60n * 60n * 1000n * 1000n; // 86400000000
+  public static MinMicros = 0n;
 
   public static fromBits(bits: bigint): DuckDBTimeTZValue {
-    const microseconds = Number(BigInt.asUintN(DuckDBTimeTZValue.TimeBits, bits >> BigInt(DuckDBTimeTZValue.OffsetBits)));
+    const micros = BigInt.asUintN(DuckDBTimeTZValue.TimeBits, bits >> BigInt(DuckDBTimeTZValue.OffsetBits));
     const offset = DuckDBTimeTZValue.MaxOffset - Number(BigInt.asUintN(DuckDBTimeTZValue.OffsetBits, bits));
-    return new DuckDBTimeTZValue(bits, microseconds, offset);
+    return new DuckDBTimeTZValue(bits, micros, offset);
   }
 
-  public static fromParts(microseconds: number, offset: number): DuckDBTimeTZValue {
-    const bits = BigInt.asUintN(DuckDBTimeTZValue.TimeBits, BigInt(microseconds)) << BigInt(DuckDBTimeTZValue.OffsetBits)
+  public static fromMicrosAndOffset(micros: bigint, offset: number): DuckDBTimeTZValue {
+    const bits = BigInt.asUintN(DuckDBTimeTZValue.TimeBits, micros) << BigInt(DuckDBTimeTZValue.OffsetBits)
                | BigInt.asUintN(DuckDBTimeTZValue.OffsetBits, BigInt(DuckDBTimeTZValue.MaxOffset - offset));
-    return new DuckDBTimeTZValue(bits, microseconds, offset);
+    return new DuckDBTimeTZValue(bits, micros, offset);
   }
 
-  public static readonly Max = DuckDBTimeTZValue.fromParts(DuckDBTimeTZValue.MaxMicroseconds, DuckDBTimeTZValue.MinOffset);
-  public static readonly Min = DuckDBTimeTZValue.fromParts(DuckDBTimeTZValue.MinMicroseconds, DuckDBTimeTZValue.MaxOffset);
+  public static fromParts(parts: TimeTZParts): DuckDBTimeTZValue {
+    return DuckDBTimeTZValue.fromMicrosAndOffset(duckdb.to_time(parts.time).micros, parts.offset);
+  }
+
+  public static readonly Max = DuckDBTimeTZValue.fromMicrosAndOffset(DuckDBTimeTZValue.MaxMicros, DuckDBTimeTZValue.MinOffset);
+  public static readonly Min = DuckDBTimeTZValue.fromMicrosAndOffset(DuckDBTimeTZValue.MinMicros, DuckDBTimeTZValue.MaxOffset);
 }
 
-export function timeTZValue(microseconds: number, offset: number): DuckDBTimeTZValue {
-  return DuckDBTimeTZValue.fromParts(microseconds, offset);
+export function timeTZValue(micros: bigint, offset: number): DuckDBTimeTZValue {
+  return DuckDBTimeTZValue.fromMicrosAndOffset(micros, offset);
 }

--- a/api/src/values/DuckDBTimeValue.ts
+++ b/api/src/values/DuckDBTimeValue.ts
@@ -1,5 +1,7 @@
-import { Time } from '@duckdb/node-bindings';
+import duckdb, { Time, TimeParts } from '@duckdb/node-bindings';
 import { getDuckDBTimeStringFromMicrosecondsInDay } from '../conversion/dateTimeStringConversion';
+
+export type { TimeParts };
 
 export class DuckDBTimeValue implements Time {
   public readonly micros: bigint;
@@ -10,6 +12,14 @@ export class DuckDBTimeValue implements Time {
 
   public toString(): string {
     return getDuckDBTimeStringFromMicrosecondsInDay(this.micros);
+  }
+
+  public toParts(): TimeParts {
+    return duckdb.from_time(this);
+  }
+
+  public static fromParts(parts: TimeParts): DuckDBTimeValue {
+    return new DuckDBTimeValue(duckdb.to_time(parts).micros);
   }
 
   public static readonly Max = new DuckDBTimeValue(24n * 60n * 60n * 1000n * 1000n);

--- a/api/src/values/DuckDBTimestampTZValue.ts
+++ b/api/src/values/DuckDBTimestampTZValue.ts
@@ -1,7 +1,8 @@
+import duckdb, { Timestamp, TimestampParts } from '@duckdb/node-bindings';
 import { getDuckDBTimestampStringFromMicroseconds } from '../conversion/dateTimeStringConversion';
 import { DuckDBTimestampValue } from './DuckDBTimestampValue';
 
-export class DuckDBTimestampTZValue {
+export class DuckDBTimestampTZValue implements Timestamp {
   public readonly micros: bigint;
 
   public constructor(micros: bigint) {
@@ -11,6 +12,14 @@ export class DuckDBTimestampTZValue {
   public toString(): string {
     // TODO: adjust micros for local timezone offset, and pass in timezone string
     return getDuckDBTimestampStringFromMicroseconds(this.micros);
+  }
+
+  public toParts(): TimestampParts {
+    return duckdb.from_timestamp(this);
+  }
+
+  public static fromParts(parts: TimestampParts): DuckDBTimestampTZValue {
+    return new DuckDBTimestampTZValue(duckdb.to_timestamp(parts).micros);
   }
 
   public static readonly Epoch = new DuckDBTimestampTZValue(0n);

--- a/api/src/values/DuckDBTimestampValue.ts
+++ b/api/src/values/DuckDBTimestampValue.ts
@@ -1,6 +1,8 @@
-import { Timestamp } from '@duckdb/node-bindings';
-import { DuckDBTimestampMillisecondsValue } from './DuckDBTimestampMillisecondsValue';
+import duckdb, { Timestamp, TimestampParts } from '@duckdb/node-bindings';
 import { getDuckDBTimestampStringFromMicroseconds } from '../conversion/dateTimeStringConversion';
+import { DuckDBTimestampMillisecondsValue } from './DuckDBTimestampMillisecondsValue';
+
+export type { TimestampParts };
 
 export class DuckDBTimestampValue implements Timestamp {
   public readonly micros: bigint;
@@ -11,6 +13,14 @@ export class DuckDBTimestampValue implements Timestamp {
 
   public toString(): string {
     return getDuckDBTimestampStringFromMicroseconds(this.micros);
+  }
+
+  public toParts(): TimestampParts {
+    return duckdb.from_timestamp(this);
+  }
+
+  public static fromParts(parts: TimestampParts): DuckDBTimestampValue {
+    return new DuckDBTimestampValue(duckdb.to_timestamp(parts).micros);
   }
   
   public static readonly Epoch = new DuckDBTimestampValue(0n);

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -1,5 +1,6 @@
 import { assert, describe, test } from 'vitest';
 import {
+  DateParts,
   DuckDBAnyType,
   DuckDBArrayType,
   DuckDBArrayVector,
@@ -22,6 +23,7 @@ import {
   DuckDBDecimal4Vector,
   DuckDBDecimal8Vector,
   DuckDBDecimalType,
+  DuckDBDecimalValue,
   DuckDBDoubleType,
   DuckDBDoubleVector,
   DuckDBEnum1Vector,
@@ -96,12 +98,14 @@ import {
   DuckDBVector,
   ResultReturnType,
   StatementType,
+  TimeParts,
+  TimeTZParts,
+  TimestampParts,
   arrayValue,
   bitValue,
   configurationOptionDescriptions,
   dateValue,
-  decimalBigint,
-  decimalNumber,
+  decimalValue,
   intervalValue,
   listValue,
   mapValue,
@@ -525,23 +529,23 @@ describe('api', () => {
       assertValues(chunk, 20, DuckDBFloatVector, [DuckDBFloatType.Min, DuckDBFloatType.Max, null]);
       assertValues(chunk, 21, DuckDBDoubleVector, [DuckDBDoubleType.Min, DuckDBDoubleType.Max, null]);
       assertValues(chunk, 22, DuckDBDecimal2Vector, [
-        decimalNumber(4, 1, -9999),
-        decimalNumber(4, 1, 9999),
+        decimalValue(-9999n, 4, 1),
+        decimalValue( 9999n, 4, 1),
         null,
       ]);
       assertValues(chunk, 23, DuckDBDecimal4Vector, [
-        decimalNumber(9, 4, -999999999),
-        decimalNumber(9, 4, 999999999),
+        decimalValue(-999999999n, 9, 4),
+        decimalValue( 999999999n, 9, 4),
         null,
       ]);
       assertValues(chunk, 24, DuckDBDecimal8Vector, [
-        decimalBigint(18, 6, -BI_18_9s),
-        decimalBigint(18, 6, BI_18_9s),
+        decimalValue(-BI_18_9s, 18, 6),
+        decimalValue( BI_18_9s, 18, 6),
         null,
       ]);
       assertValues(chunk, 25, DuckDBDecimal16Vector, [
-        decimalBigint(38, 10, -BI_38_9s),
-        decimalBigint(38, 10, BI_38_9s),
+        decimalValue(-BI_38_9s, 38, 10),
+        decimalValue( BI_38_9s, 38, 10),
         null,
       ]);
       assertValues(chunk, 26, DuckDBUUIDVector, [DuckDBUUIDValue.Min, DuckDBUUIDValue.Max, null]);
@@ -792,21 +796,21 @@ describe('api', () => {
     assert.equal(DuckDBDateValue.Min.toString(), '5877642-06-25 (BC)');
 
     // decimal
-    assert.equal(decimalNumber(4, 1, 0).toString(), '0.0');
-    assert.equal(decimalNumber(4, 1,  9876).toString(),  '987.6');
-    assert.equal(decimalNumber(4, 1, -9876).toString(), '-987.6');
+    assert.equal(decimalValue(0n, 4, 1).toString(), '0.0');
+    assert.equal(decimalValue( 9876n, 4, 1).toString(),  '987.6');
+    assert.equal(decimalValue(-9876n, 4, 1).toString(), '-987.6');
 
-    assert.equal(decimalNumber(9, 4, 0).toString(), '0.0000');
-    assert.equal(decimalNumber(9, 4,  987654321).toString(),  '98765.4321');
-    assert.equal(decimalNumber(9, 4, -987654321).toString(), '-98765.4321');
+    assert.equal(decimalValue(0n, 9, 4).toString(), '0.0000');
+    assert.equal(decimalValue( 987654321n, 9, 4).toString(),  '98765.4321');
+    assert.equal(decimalValue(-987654321n, 9, 4).toString(), '-98765.4321');
 
-    assert.equal(decimalNumber(18, 6, 0).toString(), '0.000000');
-    assert.equal(decimalBigint(18, 6,  987654321098765432n).toString(),  '987654321098.765432');
-    assert.equal(decimalBigint(18, 6, -987654321098765432n).toString(), '-987654321098.765432');
+    assert.equal(decimalValue(0n, 18, 6).toString(), '0.000000');
+    assert.equal(decimalValue( 987654321098765432n, 18, 6).toString(),  '987654321098.765432');
+    assert.equal(decimalValue(-987654321098765432n, 18, 6).toString(), '-987654321098.765432');
 
-    assert.equal(decimalNumber(38, 10, 0).toString(), '0.0000000000');
-    assert.equal(decimalBigint(38, 10,  98765432109876543210987654321098765432n).toString(),  '9876543210987654321098765432.1098765432');
-    assert.equal(decimalBigint(38, 10, -98765432109876543210987654321098765432n).toString(), '-9876543210987654321098765432.1098765432');
+    assert.equal(decimalValue(0n, 38, 10).toString(), '0.0000000000');
+    assert.equal(decimalValue( 98765432109876543210987654321098765432n, 38, 10).toString(),  '9876543210987654321098765432.1098765432');
+    assert.equal(decimalValue(-98765432109876543210987654321098765432n, 38, 10).toString(), '-9876543210987654321098765432.1098765432');
 
     // interval
     assert.equal(intervalValue(0, 0, 0n).toString(), '00:00:00');
@@ -900,7 +904,7 @@ describe('api', () => {
     assert.equal(DuckDBTimestampValue.NegInf.toString(), '-infinity');
 
     // time tz
-    assert.equal(timeTZValue(0, 0).toString(), '00:00:00');
+    assert.equal(timeTZValue(0n, 0).toString(), '00:00:00');
     // assert.equal(DuckDBTimeTZValue.Max.toString(), '24:00:00-15:59:59'); 
     assert.equal(DuckDBTimeTZValue.Max.toString(), '24:00:00'); // TODO TZ
     // assert.equal(DuckDBTimeTZValue.Max.toString(), '00:00:00+15:59:59'); 
@@ -918,5 +922,27 @@ describe('api', () => {
     // uuid
     assert.equal(uuidValue(0n).toString(), '00000000-0000-0000-0000-000000000000');
     assert.equal(uuidValue(2n ** 128n - 1n).toString(), 'ffffffff-ffff-ffff-ffff-ffffffffffff');
+  });
+  test('date isFinite', () => {
+    assert.isTrue(DuckDBDateValue.Epoch.isFinite);
+    assert.isTrue(DuckDBDateValue.Max.isFinite);
+    assert.isTrue(DuckDBDateValue.Min.isFinite);
+    assert.isFalse(DuckDBDateValue.PosInf.isFinite);
+    assert.isFalse(DuckDBDateValue.NegInf.isFinite);
+  });
+  test('value conversion', () => {
+    const dateParts: DateParts = { year: 2024, month: 6, day: 3 };
+    const timeParts: TimeParts = { hour: 12, min: 34, sec: 56, micros: 789123 };
+    const timeTZParts: TimeTZParts = { time: timeParts, offset: DuckDBTimeTZValue.MinOffset };
+    const timestampParts: TimestampParts = { date: dateParts, time: timeParts };
+
+    assert.deepEqual(DuckDBDateValue.fromParts(dateParts).toParts(), dateParts);
+    assert.deepEqual(DuckDBTimeValue.fromParts(timeParts).toParts(), timeParts);
+    assert.deepEqual(DuckDBTimeTZValue.fromParts(timeTZParts).toParts(), timeTZParts);
+    assert.deepEqual(DuckDBTimestampValue.fromParts(timestampParts).toParts(), timestampParts);
+    assert.deepEqual(DuckDBTimestampTZValue.fromParts(timestampParts).toParts(), timestampParts);
+
+    assert.deepEqual(DuckDBDecimalValue.fromDouble(3.14159, 6, 5), decimalValue(314159n, 6, 5));
+    assert.deepEqual(decimalValue(314159n, 6, 5).toDouble(), 3.14159);
   });
 });


### PR DESCRIPTION
- Add methods to some value types (Date, Time[TZ], Timestamp[TZ], Decimal) to convert from and to primitive values.
- Expose some primitive-to-primitive conversion functions from the bindings.
- Rename a few parameters and add some doc comments.
- Add some unit tests for new API functions.