### PR TITLE
fix uuid toString

### DIFF
--- a/api/src/values/DuckDBUUIDValue.ts
+++ b/api/src/values/DuckDBUUIDValue.ts
@@ -6,14 +6,16 @@ export class DuckDBUUIDValue {
   }
 
   public toString(): string {
+    // UUID values are stored with their MSB flipped so their numeric ordering matches their string ordering.
+    const flipped = this.hugeint ^ 0x80000000000000000000000000000000n
     // Truncate to 32 hex digits, then prepend with a hex 1, before converting to a hex string.
     // This ensures the trailing 32 characters are the hex digits we want, left padded with zeros as needed.
-    const hex = ((this.hugeint & 0xffffffffffffffffffffffffffffffffn) | 0x100000000000000000000000000000000n).toString(16);
+    const hex = ((flipped & 0xffffffffffffffffffffffffffffffffn) | 0x100000000000000000000000000000000n).toString(16);
     return `${hex.substring(1, 9)}-${hex.substring(9, 13)}-${hex.substring(13, 17)}-${hex.substring(17, 21)}-${hex.substring(21, 33)}`;
   }
 
-  public static readonly Max = new DuckDBUUIDValue(2n ** 127n - 1n);
-  public static readonly Min = new DuckDBUUIDValue(-(2n ** 127n));
+  public static readonly Max = new DuckDBUUIDValue(2n ** 127n - 1n); //  7fffffffffffffffffffffffffffffff
+  public static readonly Min = new DuckDBUUIDValue(-(2n ** 127n));   //  80000000000000000000000000000000
 }
 
 export function uuidValue(hugeint: bigint): DuckDBUUIDValue {

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -115,7 +115,6 @@ import {
   timestampTZValue,
   timestampValue,
   unionValue,
-  uuidValue,
   version
 } from '../src';
 
@@ -920,8 +919,8 @@ describe('api', () => {
     assert.equal(unionValue('b', 'duck').toString(), 'duck');
 
     // uuid
-    assert.equal(uuidValue(0n).toString(), '00000000-0000-0000-0000-000000000000');
-    assert.equal(uuidValue(2n ** 128n - 1n).toString(), 'ffffffff-ffff-ffff-ffff-ffffffffffff');
+    assert.equal(DuckDBUUIDValue.Min.toString(), '00000000-0000-0000-0000-000000000000');
+    assert.equal(DuckDBUUIDValue.Max.toString(), 'ffffffff-ffff-ffff-ffff-ffffffffffff');
   });
   test('date isFinite', () => {
     assert.isTrue(DuckDBDateValue.Epoch.isFinite);


### PR DESCRIPTION
Fix a bug in DuckDBUUIDValue.toString where the MSB wasn't being flipped before display. DuckDB UUID values are stored with the MSB flipped so that numeric ordering matches string ordering.

Also fixed the tests to actually compare the correct values. (This mistake in the tests covered up the mistake in the code, unfortunately.)