### PR TITLE
upgrade to duckdb 1.1.3 and bump pkg versions

### DIFF
--- a/api/pkgs/@duckdb/node-api/package.json
+++ b/api/pkgs/@duckdb/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-api",
-  "version": "1.1.2-alpha.4",
+  "version": "1.1.3-alpha.4",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-arm64",
-  "version": "1.1.2-alpha.4",
+  "version": "1.1.3-alpha.4",
   "os": [
     "darwin"
   ],

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-x64",
-  "version": "1.1.2-alpha.4",
+  "version": "1.1.3-alpha.4",
   "os": [
     "linux"
   ],

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-x64",
-  "version": "1.1.2-alpha.4",
+  "version": "1.1.3-alpha.4",
   "os": [
     "win32"
   ],

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings",
-  "version": "1.1.2-alpha.4",
+  "version": "1.1.3-alpha.4",
   "main": "./duckdb.js",
   "types": "./duckdb.d.ts",
   "optionalDependencies": {

--- a/bindings/scripts/fetch_libduckdb_linux.py
+++ b/bindings/scripts/fetch_libduckdb_linux.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.2/libduckdb-linux-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.3/libduckdb-linux-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_mac.py
+++ b/bindings/scripts/fetch_libduckdb_mac.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.2/libduckdb-osx-universal.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.3/libduckdb-osx-universal.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_win.py
+++ b/bindings/scripts/fetch_libduckdb_win.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.2/libduckdb-windows-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.3/libduckdb-windows-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/test/constants.test.ts
+++ b/bindings/test/constants.test.ts
@@ -6,7 +6,7 @@ suite('constants', () => {
     expect(duckdb.sizeof_bool).toBe(1);
   });
   test('library_version', () => {
-    expect(duckdb.library_version()).toBe('v1.1.2');
+    expect(duckdb.library_version()).toBe('v1.1.3');
   });
   test('vector_size', () => {
     expect(duckdb.vector_size()).toBe(2048);


### PR DESCRIPTION
No changes to C API. No code changes to bindings or API needed. Keeping Neo version at alpha.4