### PR TITLE
default duckdb_api config

### DIFF
--- a/api/src/DuckDBInstance.ts
+++ b/api/src/DuckDBInstance.ts
@@ -10,16 +10,16 @@ export class DuckDBInstance {
     path?: string,
     options?: Record<string, string>
   ): Promise<DuckDBInstance> {
+    const config = duckdb.create_config();
+    // Set the default duckdb_api value for the api. Can be overridden.
+    duckdb.set_config(config, 'duckdb_api', 'node-neo-api');
     if (options) {
-      const config = duckdb.create_config();
       for (const optionName in options) {
         const optionValue = String(options[optionName]);
         duckdb.set_config(config, optionName, optionValue);
       }
-      return new DuckDBInstance(await duckdb.open(path, config));
-    } else {
-      return new DuckDBInstance(await duckdb.open(path));
     }
+    return new DuckDBInstance(await duckdb.open(path, config));
   }
   public async connect(): Promise<DuckDBConnection> {
     return new DuckDBConnection(await duckdb.connect(this.db));

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -973,4 +973,34 @@ describe('api', () => {
       assert.deepEqual(rows[4999], [4999, 14999]);
     });
   });
+  test('default duckdb_api without explicit options', async () => {
+    const instance = await DuckDBInstance.create();
+    const connection = await instance.connect();
+    const result = await connection.run(`select current_setting('duckdb_api') as duckdb_api`);
+    assertColumns(result, [{ name: 'duckdb_api', type: DuckDBVarCharType.instance }]);
+    const chunk = await result.fetchChunk();
+    assert.strictEqual(chunk.columnCount, 1);
+    assert.strictEqual(chunk.rowCount, 1);
+    assertValues<string, DuckDBVarCharVector>(chunk, 0, DuckDBVarCharVector, ['node-neo-api']);
+  });
+  test('default duckdb_api with explicit options', async () => {
+    const instance = await DuckDBInstance.create(undefined, {});
+    const connection = await instance.connect();
+    const result = await connection.run(`select current_setting('duckdb_api') as duckdb_api`);
+    assertColumns(result, [{ name: 'duckdb_api', type: DuckDBVarCharType.instance }]);
+    const chunk = await result.fetchChunk();
+    assert.strictEqual(chunk.columnCount, 1);
+    assert.strictEqual(chunk.rowCount, 1);
+    assertValues<string, DuckDBVarCharVector>(chunk, 0, DuckDBVarCharVector, ['node-neo-api']);
+  });
+  test('overriding duckdb_api', async () => {
+    const instance = await DuckDBInstance.create(undefined, { 'duckdb_api': 'custom-duckdb-api' });
+    const connection = await instance.connect();
+    const result = await connection.run(`select current_setting('duckdb_api') as duckdb_api`);
+    assertColumns(result, [{ name: 'duckdb_api', type: DuckDBVarCharType.instance }]);
+    const chunk = await result.fetchChunk();
+    assert.strictEqual(chunk.columnCount, 1);
+    assert.strictEqual(chunk.rowCount, 1);
+    assertValues<string, DuckDBVarCharVector>(chunk, 0, DuckDBVarCharVector, ['custom-duckdb-api']);
+  });
 });

--- a/bindings/test/config.test.ts
+++ b/bindings/test/config.test.ts
@@ -1,5 +1,7 @@
 import duckdb from '@duckdb/node-bindings';
 import { expect, suite, test } from 'vitest';
+import { expectResult } from './utils/expectResult';
+import { data } from './utils/expectedVectors';
 
 suite('config', () => {
   test('config_count', () => {
@@ -13,8 +15,50 @@ suite('config', () => {
     expect(() => duckdb.get_config_flag(-1)).toThrowError(/^Config option not found$/);
   });
   test('create, set, and destroy', () => {
-    const config = duckdb.create_config()
+    const config = duckdb.create_config();
     expect(config).toBeTruthy();
     duckdb.set_config(config, 'custom_user_agent', 'my_user_agent');
+  });
+  test('default duckdb_api without explicit config', async () => {
+    const db = await duckdb.open();
+    const connection = await duckdb.connect(db);
+    const result = await duckdb.query(connection, `select current_setting('duckdb_api') as duckdb_api`);
+      await expectResult(result, {
+        columns: [
+          { name: 'duckdb_api', logicalType: { typeId: duckdb.Type.VARCHAR } },
+        ],
+        chunks: [
+          { rowCount: 1, vectors: [data(16, [true], ['node-neo-bindings'])]},
+        ],
+      });
+  });
+  test('default duckdb_api with explicit config', async () => {
+    const config = duckdb.create_config();
+    const db = await duckdb.open(undefined, config);
+    const connection = await duckdb.connect(db);
+    const result = await duckdb.query(connection, `select current_setting('duckdb_api') as duckdb_api`);
+      await expectResult(result, {
+        columns: [
+          { name: 'duckdb_api', logicalType: { typeId: duckdb.Type.VARCHAR } },
+        ],
+        chunks: [
+          { rowCount: 1, vectors: [data(16, [true], ['node-neo-bindings'])]},
+        ],
+      });
+  });
+  test('overriding duckdb_api', async () => {
+    const config = duckdb.create_config();
+    duckdb.set_config(config, 'duckdb_api', 'custom-duckdb-api');
+    const db = await duckdb.open(undefined, config);
+    const connection = await duckdb.connect(db);
+    const result = await duckdb.query(connection, `select current_setting('duckdb_api') as duckdb_api`);
+      await expectResult(result, {
+        columns: [
+          { name: 'duckdb_api', logicalType: { typeId: duckdb.Type.VARCHAR } },
+        ],
+        chunks: [
+          { rowCount: 1, vectors: [data(16, [true], ['custom-duckdb-api'])]},
+        ],
+      });
   });
 });


### PR DESCRIPTION
In both the bindings and the api layers, set a (different) default value for the `duckdb_api` config.
Ensure this works whether or not the user provides an explicit config; if they do, ensure it's overridable.

The default `duckdb_api` value for the bindings layer is: `node-neo-bindings`
The default for the api layer (which most people will use) is: `node-neo-api`