### PR TITLE
build linux arm64

### DIFF
--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -33,6 +33,11 @@ on:
         type: boolean
         required: true
         default: false
+      publish_linux_arm64:
+        description: 'Publish Bindings for Linux arm64'
+        type: boolean
+        required: true
+        default: false
       macos_arm64:
         description: 'Run on Mac OS X arm64'
         type: boolean
@@ -141,9 +146,16 @@ jobs:
         working-directory: bindings
         run: pnpm run build
       
-      - name: Bindings - Test
-        working-directory: bindings
-        run: pnpm test
+      - name: Git Status
+        if: ${{ inputs.publish_linux_arm64 }}
+        run: git status
+      
+      - name: Publish - Bindings - Linux arm64
+        if: ${{ inputs.publish_linux_arm64 }}
+        working-directory: bindings/pkgs/@duckdb/node-bindings-linux-arm64
+        run: pnpm publish ${{ inputs.publish_dry_run && '--dry-run' || '' }} --publish-branch ${{ github.ref_name }} --access public
+        env:
+          NPM_AUTH_TOKEN: ${{ secrets.DUCKDB_NPM_TOKEN }}
 
   macos_arm64:
     name: Mac OS X arm64

--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -28,6 +28,11 @@ on:
         type: boolean
         required: true
         default: false
+      linux_arm64:
+        description: 'Run on Linux arm64'
+        type: boolean
+        required: true
+        default: false
       macos_arm64:
         description: 'Run on Mac OS X arm64'
         type: boolean
@@ -110,6 +115,30 @@ jobs:
         run: pnpm publish ${{ inputs.publish_dry_run && '--dry-run' || '' }} --publish-branch ${{ github.ref_name }} --access public
         env:
           NPM_AUTH_TOKEN: ${{ secrets.DUCKDB_NPM_TOKEN }}
+
+  linux_arm64:
+    name: Linux arm64
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_arm64 }}
+    env:
+      TARGET_ARCH: 'arm64'
+    steps:
+      - uses: actions/checkout@v4
+      
+      - uses: pnpm/action-setup@v3
+        with:
+          version: 9
+      
+      - name: Workspace - Install
+        run: pnpm install --ignore-scripts
+
+      - name: Bindings - Build
+        working-directory: bindings
+        run: pnpm run build
+      
+      - name: Bindings - Test
+        working-directory: bindings
+        run: pnpm test
 
   macos_arm64:
     name: Mac OS X arm64

--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -125,6 +125,9 @@ jobs:
       CC: aarch64-linux-gnu-gcc
       CXX: aarch64-linux-gnu-g++
     steps:
+      - name: Install aarch64 compilers
+        run: apt install binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+      
       - uses: actions/checkout@v4
       
       - uses: pnpm/action-setup@v3

--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -121,7 +121,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_arm64 }}
     env:
-      TARGET_ARCH: ${{ 'arm64' }}
+      TARGET_ARCH: arm64
+      CC: aarch64-linux-gnu-gcc
+      CXX: aarch64-linux-gnu-g++
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -126,7 +126,7 @@ jobs:
       CXX: aarch64-linux-gnu-g++
     steps:
       - name: Install aarch64 compilers
-        run: apt install binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
+        run: sudo apt install binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu g++-aarch64-linux-gnu
       
       - uses: actions/checkout@v4
       

--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -121,7 +121,7 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event_name != 'workflow_dispatch' || inputs.linux_arm64 }}
     env:
-      TARGET_ARCH: 'arm64'
+      TARGET_ARCH: ${{ 'arm64' }}
     steps:
       - uses: actions/checkout@v4
       

--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -123,9 +123,6 @@ jobs:
     env:
       TARGET_ARCH: ${{ 'arm64' }}
     steps:
-      - name: Echo TARGET_ARGH
-        run: echo $TARGET_ARCH
-
       - uses: actions/checkout@v4
       
       - uses: pnpm/action-setup@v3
@@ -138,8 +135,6 @@ jobs:
       - name: Bindings - Build
         working-directory: bindings
         run: pnpm run build
-        env:
-          TARGET_ARCH: ${{ 'arm64' }}
       
       - name: Bindings - Test
         working-directory: bindings

--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -123,6 +123,9 @@ jobs:
     env:
       TARGET_ARCH: ${{ 'arm64' }}
     steps:
+      - name: Echo TARGET_ARGH
+        run: echo $TARGET_ARCH
+
       - uses: actions/checkout@v4
       
       - uses: pnpm/action-setup@v3
@@ -135,6 +138,8 @@ jobs:
       - name: Bindings - Build
         working-directory: bindings
         run: pnpm run build
+        env:
+          TARGET_ARCH: ${{ 'arm64' }}
       
       - name: Bindings - Test
         working-directory: bindings

--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -3,6 +3,11 @@ on:
   pull_request:
   workflow_dispatch:
     inputs:
+      publish:
+        description: 'Publish'
+        type: boolean
+        required: true
+        default: false
       publish_dry_run:
         description: 'Publish Dry Run'
         type: boolean
@@ -13,51 +18,51 @@ on:
         type: boolean
         required: true
         default: false
-      publish_linux_x64:
-        description: 'Publish Bindings for Linux x64'
-        type: boolean
-        required: true
-        default: false
-      publish_bindings:
-        description: 'Publish Bindings (from Linux x64)'
-        type: boolean
-        required: true
-        default: false
-      publish_api:
-        description: 'Publish API (from Linux x64)'
-        type: boolean
-        required: true
-        default: false
+      # publish_linux_x64:
+      #   description: 'Publish Bindings for Linux x64'
+      #   type: boolean
+      #   required: true
+      #   default: false
+      # publish_bindings:
+      #   description: 'Publish Bindings (from Linux x64)'
+      #   type: boolean
+      #   required: true
+      #   default: false
+      # publish_api:
+      #   description: 'Publish API (from Linux x64)'
+      #   type: boolean
+      #   required: true
+      #   default: false
       linux_arm64:
         description: 'Run on Linux arm64'
         type: boolean
         required: true
         default: false
-      publish_linux_arm64:
-        description: 'Publish Bindings for Linux arm64'
-        type: boolean
-        required: true
-        default: false
+      # publish_linux_arm64:
+      #   description: 'Publish Bindings for Linux arm64'
+      #   type: boolean
+      #   required: true
+      #   default: false
       macos_arm64:
         description: 'Run on Mac OS X arm64'
         type: boolean
         required: true
         default: false
-      publish_darwin_arm64:
-        description: 'Publish Bindings for Darwin arm64'
-        type: boolean
-        required: true
-        default: false
+      # publish_darwin_arm64:
+      #   description: 'Publish Bindings for Darwin arm64'
+      #   type: boolean
+      #   required: true
+      #   default: false
       windows_x64:
         description: 'Run on Windows x64'
         type: boolean
         required: true
         default: false
-      publish_win32_x64:
-        description: 'Publish Bindings for Win32 x64'
-        type: boolean
-        required: true
-        default: false
+      # publish_win32_x64:
+      #   description: 'Publish Bindings for Win32 x64'
+      #   type: boolean
+      #   required: true
+      #   default: false
   repository_dispatch:
 
 concurrency:
@@ -97,25 +102,25 @@ jobs:
         run: pnpm test
       
       - name: Git Status
-        if: ${{ inputs.publish_linux_x64 || inputs.publish_bindings || inputs.publish_api }}
+        if: ${{ inputs.publish }}
         run: git status
       
       - name: Publish - Bindings - Linux x64
-        if: ${{ inputs.publish_linux_x64 }}
+        if: ${{ inputs.publish }}
         working-directory: bindings/pkgs/@duckdb/node-bindings-linux-x64
         run: pnpm publish ${{ inputs.publish_dry_run && '--dry-run' || '' }} --publish-branch ${{ github.ref_name }} --access public
         env:
           NPM_AUTH_TOKEN: ${{ secrets.DUCKDB_NPM_TOKEN }}
       
       - name: Publish - Bindings
-        if: ${{ inputs.publish_bindings }}
+        if: ${{ inputs.publish }}
         working-directory: bindings/pkgs/@duckdb/node-bindings
         run: pnpm publish ${{ inputs.publish_dry_run && '--dry-run' || '' }} --publish-branch ${{ github.ref_name }} --access public
         env:
           NPM_AUTH_TOKEN: ${{ secrets.DUCKDB_NPM_TOKEN }}
 
       - name: Publish - API
-        if: ${{ inputs.publish_api }}
+        if: ${{ inputs.publish }}
         working-directory: api/pkgs/@duckdb/node-api
         run: pnpm publish ${{ inputs.publish_dry_run && '--dry-run' || '' }} --publish-branch ${{ github.ref_name }} --access public
         env:
@@ -147,11 +152,11 @@ jobs:
         run: pnpm run build
       
       - name: Git Status
-        if: ${{ inputs.publish_linux_arm64 }}
+        if: ${{ inputs.publish }}
         run: git status
       
       - name: Publish - Bindings - Linux arm64
-        if: ${{ inputs.publish_linux_arm64 }}
+        if: ${{ inputs.publish }}
         working-directory: bindings/pkgs/@duckdb/node-bindings-linux-arm64
         run: pnpm publish ${{ inputs.publish_dry_run && '--dry-run' || '' }} --publish-branch ${{ github.ref_name }} --access public
         env:
@@ -188,11 +193,11 @@ jobs:
         run: pnpm test
       
       - name: Git Status
-        if: ${{ inputs.publish_darwin_arm64 }}
+        if: ${{ inputs.publish }}
         run: git status
       
       - name: Publish - Bindings - Darwin arm64
-        if: ${{ inputs.publish_darwin_arm64 }}
+        if: ${{ inputs.publish }}
         working-directory: bindings/pkgs/@duckdb/node-bindings-darwin-arm64
         run: pnpm publish ${{ inputs.publish_dry_run && '--dry-run' || '' }} --publish-branch ${{ github.ref_name }} --access public
         env:
@@ -229,11 +234,11 @@ jobs:
         run: pnpm test
       
       - name: Git Status
-        if: ${{ inputs.publish_win32_x64 }}
+        if: ${{ inputs.publish }}
         run: git status
       
       - name: Publish - Bindings - Win32 x64
-        if: ${{ inputs.publish_win32_x64 }}
+        if: ${{ inputs.publish }}
         working-directory: bindings/pkgs/@duckdb/node-bindings-win32-x64
         run: pnpm publish ${{ inputs.publish_dry_run && '--dry-run' || '' }} --publish-branch ${{ github.ref_name }} --access public
         env:

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 - [@duckdb/node-api](api/pkgs/@duckdb/node-api/README.md)
 - [@duckdb/node-bindings](bindings/pkgs/@duckdb/node-bindings/README.md)
 - [@duckdb/node-bindings-darwin-arm64](bindings/pkgs/@duckdb/node-bindings-darwin-arm64/README.md)
+- [@duckdb/node-bindings-linux-arm64](bindings/pkgs/@duckdb/node-bindings-linux-x64/README.md)
 - [@duckdb/node-bindings-linux-x64](bindings/pkgs/@duckdb/node-bindings-linux-x64/README.md)
 - [@duckdb/node-bindings-win32-x64](bindings/pkgs/@duckdb/node-bindings-win32-x64/README.md)
 
@@ -17,6 +18,7 @@
 - [@duckdb/node-api](https://www.npmjs.com/package/@duckdb/node-api)
 - [@duckdb/node-bindings](https://www.npmjs.com/package/@duckdb/node-bindings)
 - [@duckdb/node-bindings-darwin-arm64](https://www.npmjs.com/package/@duckdb/node-bindings-darwin-arm64)
+- [@duckdb/node-bindings-linux-arm64](https://www.npmjs.com/package/@duckdb/node-bindings-linux-x64)
 - [@duckdb/node-bindings-linux-x64](https://www.npmjs.com/package/@duckdb/node-bindings-linux-x64)
 - [@duckdb/node-bindings-win32-x64](https://www.npmjs.com/package/@duckdb/node-bindings-win32-x64)
 
@@ -46,12 +48,14 @@ Change version in:
 - `api/pkgs/@duckdb/node-api/package.json`
 - `bindings/pkgs/@duckdb/node-bindings/package.json`
 - `bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json`
+- `bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json`
 - `bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json`
 - `bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json`
 
 ### Upgrade DuckDB Version
 
 Change version in:
+- `bindings/scripts/fetch_libduckdb_linux_aarch64.py`
 - `bindings/scripts/fetch_libduckdb_linux_amd64.py`
 - `bindings/scripts/fetch_libduckdb_osx_universal.py`
 - `bindings/scripts/fetch_libduckdb_windows_amd64.py`

--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -28,6 +28,7 @@ Some features are not yet complete:
 ### Supported Platforms
 
 - Linux x64
+- Linux arm64
 - Mac OS X (Darwin) arm64 (Apple Silicon)
 - Windows (Win32) x64
 

--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -27,8 +27,8 @@ Some features are not yet complete:
 
 ### Supported Platforms
 
+- Linux arm64 (experimental)
 - Linux x64
-- Linux arm64
 - Mac OS X (Darwin) arm64 (Apple Silicon)
 - Windows (Win32) x64
 

--- a/bindings/binding.gyp
+++ b/bindings/binding.gyp
@@ -9,7 +9,7 @@
             'script_path': '<(module_root_dir)/scripts/fetch_libduckdb_linux_amd64.py',
           },
         }],
-        ['OS=="linux" and target_arch=="amd64"', {
+        ['OS=="linux" and target_arch=="arm64"', {
           'variables': {
             'script_path': '<(module_root_dir)/scripts/fetch_libduckdb_linux_aarch64.py',
           },

--- a/bindings/binding.gyp
+++ b/bindings/binding.gyp
@@ -9,6 +9,11 @@
             'script_path': '<(module_root_dir)/scripts/fetch_libduckdb_linux_amd64.py',
           },
         }],
+        ['OS=="linux" and target_arch=="amd64"', {
+          'variables': {
+            'script_path': '<(module_root_dir)/scripts/fetch_libduckdb_linux_aarch64.py',
+          },
+        }],
         ['OS=="mac"', {
           'variables': {
             'script_path': '<(module_root_dir)/scripts/fetch_libduckdb_osx_universal.py',
@@ -51,6 +56,21 @@
             {
               'files': ['<(module_root_dir)/libduckdb/libduckdb.so'],
               'destination': '<(module_root_dir)/pkgs/@duckdb/node-bindings-linux-x64',
+            },
+          ],
+        }],
+        ['OS=="linux" and target_arch=="arm64"', {
+          'link_settings': {
+            'libraries': [
+              '-lduckdb',
+              '-L<(module_root_dir)/libduckdb',
+              '-Wl,-rpath,\'$$ORIGIN\'',
+            ],
+          },
+          'copies': [
+            {
+              'files': ['<(module_root_dir)/libduckdb/libduckdb.so'],
+              'destination': '<(module_root_dir)/pkgs/@duckdb/node-bindings-linux-arm64',
             },
           ],
         }],
@@ -98,6 +118,14 @@
             {
               'files': ['<(module_root_dir)/build/Release/duckdb.node'],
               'destination': '<(module_root_dir)/pkgs/@duckdb/node-bindings-linux-x64',
+            },
+          ],
+        }],
+        ['OS=="linux" and target_arch=="arm64"', {
+          'copies': [
+            {
+              'files': ['<(module_root_dir)/build/Release/duckdb.node'],
+              'destination': '<(module_root_dir)/pkgs/@duckdb/node-bindings-linux-arm64',
             },
           ],
         }],

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "npm run build:package && npm run build:test",
-    "build:package": "node-gyp configure --arch=$TARGET_ARCH && node-gyp build --arch=$TARGET_ARCH",
+    "build:package": "cross-replace node-gyp configure --arch=$TARGET_ARCH && node-gyp build --arch=$TARGET_ARCH",
     "build:test": "tsc -b test",
     "clean": "npm run clean:gyp && npm run clean:libduckdb && npm run clean:package",
     "clean:gyp": "node-gyp clean",
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@duckdb/node-bindings": "workspace:*",
+    "cross-replace": "^0.2.0",
     "node-addon-api": "^8.3.0",
     "node-gyp": "^10.3.1",
     "rimraf": "^5.0.10",

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "npm run build:package && npm run build:test",
-    "build:package": "node-gyp configure && node-gyp build",
+    "build:package": "node-gyp configure --arch=$TARGET_ARCH && node-gyp build --arch=$TARGET_ARCH",
     "build:test": "tsc -b test",
     "clean": "npm run clean:gyp && npm run clean:libduckdb && npm run clean:package",
     "clean:gyp": "node-gyp clean",

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "scripts": {
     "build": "npm run build:package && npm run build:test",
-    "build:package": "cross-replace node-gyp configure --arch=$TARGET_ARCH && node-gyp build --arch=$TARGET_ARCH",
+    "build:package": "cross-replace node-gyp configure --verbose --arch=$TARGET_ARCH && node-gyp build --verbose --arch=$TARGET_ARCH",
     "build:test": "tsc -b test",
     "clean": "npm run clean:gyp && npm run clean:libduckdb && npm run clean:package",
     "clean:gyp": "node-gyp clean",

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/.npmrc
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/.npmrc
@@ -1,0 +1,1 @@
+//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/README.md
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/README.md
@@ -1,0 +1,5 @@
+# DuckDB Node Bindings: Linux arm64
+
+Binaries supporting [Node](https://nodejs.org/) bindings to the [DuckDB C API](https://duckdb.org/docs/api/c/overview) for Linux arm64.
+
+See [@duckdb/node-bindings](https://www.npmjs.com/package/@duckdb/node-bindings) for a low-level API that uses these binaries, or [@duckdb/node-api](https://www.npmjs.com/package/@duckdb/node-api) for a high-level API built on those bindings.

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/README.md
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/README.md
@@ -1,5 +1,5 @@
-# DuckDB Node Bindings: Linux arm64
+# DuckDB Node Bindings: Linux arm64 (experimental)
 
-Binaries supporting [Node](https://nodejs.org/) bindings to the [DuckDB C API](https://duckdb.org/docs/api/c/overview) for Linux arm64.
+Binaries supporting [Node](https://nodejs.org/) bindings to the [DuckDB C API](https://duckdb.org/docs/api/c/overview) for Linux arm64. These are experimental; they are not fully tested.
 
 See [@duckdb/node-bindings](https://www.npmjs.com/package/@duckdb/node-bindings) for a low-level API that uses these binaries, or [@duckdb/node-api](https://www.npmjs.com/package/@duckdb/node-api) for a high-level API built on those bindings.

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@duckdb/node-bindings-linux-arm64",
+  "version": "1.1.3-alpha.6",
+  "os": [
+    "linux"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/duckdb/duckdb-node-neo.git"
+  }
+}

--- a/bindings/pkgs/@duckdb/node-bindings/README.md
+++ b/bindings/pkgs/@duckdb/node-bindings/README.md
@@ -6,7 +6,7 @@ See [@duckdb/node-api](https://www.npmjs.com/package/@duckdb/node-api) for a hig
 
 ### Supported Platforms
 
+- Linux arm64 (experimental)
 - Linux x64
-- Linux arm64
 - Mac OS X (Darwin) arm64 (Apple Silicon)
 - Windows (Win32) x64

--- a/bindings/pkgs/@duckdb/node-bindings/README.md
+++ b/bindings/pkgs/@duckdb/node-bindings/README.md
@@ -7,5 +7,6 @@ See [@duckdb/node-api](https://www.npmjs.com/package/@duckdb/node-api) for a hig
 ### Supported Platforms
 
 - Linux x64
+- Linux arm64
 - Mac OS X (Darwin) arm64 (Apple Silicon)
 - Windows (Win32) x64

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -5,6 +5,7 @@
   "types": "./duckdb.d.ts",
   "optionalDependencies": {
     "@duckdb/node-bindings-darwin-arm64": "workspace:*",
+    "@duckdb/node-bindings-linux-arm64": "workspace:*",
     "@duckdb/node-bindings-linux-x64": "workspace:*",
     "@duckdb/node-bindings-win32-x64": "workspace:*"
   },

--- a/bindings/scripts/fetch_libduckdb_linux_aarch64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_aarch64.py
@@ -1,0 +1,11 @@
+import os
+from fetch_libduckdb import fetch_libduckdb
+
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.1.3/libduckdb-linux-aarch64.zip"
+output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
+files = [
+  "duckdb.h",
+  "libduckdb.so",
+]
+
+fetch_libduckdb(zip_url, output_dir, files)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -38,6 +38,9 @@ importers:
       '@duckdb/node-bindings':
         specifier: workspace:*
         version: link:pkgs/@duckdb/node-bindings
+      cross-replace:
+        specifier: ^0.2.0
+        version: 0.2.0
       node-addon-api:
         specifier: ^8.3.0
         version: 8.3.0
@@ -434,6 +437,10 @@ packages:
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  cross-replace@0.2.0:
+    resolution: {integrity: sha512-LF8ZXUDGw5yy8YHPzw4RbOtJJG6NVxpxvEAJZwJgMyLV/wBJonG39vWBDS168nS4ImYP59mPkXj/5ezMOAuzwQ==}
+    hasBin: true
 
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
@@ -1178,6 +1185,10 @@ snapshots:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  cross-replace@0.2.0:
+    dependencies:
+      cross-spawn: 7.0.6
 
   cross-spawn@7.0.6:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@duckdb/node-bindings-darwin-arm64':
         specifier: workspace:*
         version: link:../node-bindings-darwin-arm64
+      '@duckdb/node-bindings-linux-arm64':
+        specifier: workspace:*
+        version: link:../node-bindings-linux-arm64
       '@duckdb/node-bindings-linux-x64':
         specifier: workspace:*
         version: link:../node-bindings-linux-x64
@@ -67,6 +70,8 @@ importers:
         version: link:../node-bindings-win32-x64
 
   bindings/pkgs/@duckdb/node-bindings-darwin-arm64: {}
+
+  bindings/pkgs/@duckdb/node-bindings-linux-arm64: {}
 
   bindings/pkgs/@duckdb/node-bindings-linux-x64: {}
 


### PR DESCRIPTION
- Add support for Linux arm64.
- The linux arm64 binaries are built using cross-compilation on a linux x64 runner. The tests are not run (since the can't on that architecture). If/when standard linux arm64 runners become available, we could switch to those.
- I had to remove some of the fine-grained control over publishing individual packages, since workflow_dispatch has a limit of 10 input parameters. Perhaps they could be brought back, if needed, by splitting the workflow. But I've never used them independently.