### PR TITLE
Simple write benchmarks

### DIFF
--- a/api/test/bench/write.bench.ts
+++ b/api/test/bench/write.bench.ts
@@ -1,0 +1,65 @@
+import { bench, describe } from "vitest";
+import {
+  DuckDBConnection,
+  DuckDBInstance,
+  DuckDBTimestampValue,
+} from "../../src";
+
+let instance: DuckDBInstance;
+let connection: DuckDBConnection;
+
+async function setup() {
+  instance = await DuckDBInstance.create();
+  connection = await instance.connect();
+
+  await connection.run(`
+    CREATE OR REPLACE TABLE test (
+      timestamp TIMESTAMPTZ NOT NULL,
+      value FLOAT NOT NULL,
+    );
+  `);
+}
+
+for (const batchSize of [1, 1000]) {
+  describe(`batch write of size ${batchSize}`, () => {
+    bench(
+      `${batchSize} insert bind`,
+      async () => {
+        const query = await connection.prepare(
+          "INSERT INTO test (timestamp, value) VALUES ($1, $2);"
+        );
+
+        for (let index = 0; index < batchSize; index++) {
+          query.bindTimestamp(
+            1,
+            new DuckDBTimestampValue(BigInt(Date.now()) * 1000n)
+          );
+          query.bindFloat(2, Math.random() * 1_000_000);
+
+          await query.run();
+        }
+      },
+      {
+        setup,
+      }
+    );
+    bench(
+      `${batchSize} row append`,
+      async () => {
+        const appender = await connection.createAppender("main", "test");
+
+        for (let index = 0; index < batchSize; index++) {
+          appender.appendTimestamp(
+            new DuckDBTimestampValue(BigInt(Date.now()) * 1000n)
+          );
+          appender.appendFloat(Math.random() * 1_000_000);
+          appender.endRow();
+        }
+        appender.close();
+      },
+      {
+        setup,
+      }
+    );
+  });
+}


### PR DESCRIPTION
This PR adds some simple write benchmarks, comparing insert vs appender performance at batches of 1 and 1000.

(These numbers are taken on my M1 Macbook Pro)
```
 ✓ test/bench/write.bench.ts (4) 3999ms
   ✓ batch write of size 1 (2) 1283ms
     name                  hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · 1 insert bind   4,440.54  0.1670  9.4687  0.2252  0.2373  0.3399  0.4004  1.2738  ±4.50%     2221
   · 1 row append   34,196.13  0.0257  1.6729  0.0292  0.0294  0.0408  0.0477  0.0725  ±0.98%    17099   fastest
   ✓ batch write of size 1000 (2) 2715ms
     name                    hz     min     max    mean     p75     p99    p995    p999      rme  samples
   · 1000 insert bind    7.4680  122.09  174.06  133.90  129.36  174.06  174.06  174.06  ±10.23%       10
   · 1000 row append   2,383.52  0.3978  0.7065  0.4195  0.4204  0.5430  0.5809  0.6203   ±0.35%     1192   fastest
```

