### PR TITLE
disconnect

### DIFF
--- a/api/src/DuckDBConnection.ts
+++ b/api/src/DuckDBConnection.ts
@@ -18,6 +18,13 @@ export class DuckDBConnection {
   ): Promise<DuckDBConnection> {
     return instance.connect();
   }
+  /** Same as disconnect. */
+  public close() {
+    return this.disconnect();
+  }
+  public disconnect() {
+    return duckdb.disconnect(this.connection);
+  }
   public interrupt() {
     duckdb.interrupt(this.connection);
   }

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -343,6 +343,21 @@ describe('api', () => {
       assertValues<number, DuckDBIntegerVector>(chunk, 0, DuckDBIntegerVector, [42]);
     }
   });
+  test('disconnecting connections', async () => {
+    const instance = await DuckDBInstance.create();
+    const connection = await instance.connect();
+    const prepared1 = await connection.prepare('select 1');
+    assert.isDefined(prepared1);
+    connection.disconnect();
+    try {
+      await connection.prepare('select 2');
+      assert.fail('should throw');
+    } catch (err) {
+      assert.deepEqual(err, new Error('Failed to prepare: connection disconnected'));
+    }
+    // ensure double-disconnect doesn't break anything
+    connection.disconnect();
+  });
   test('should support running prepared statements', async () => {
     await withConnection(async (connection) => {
       const prepared = await connection.prepare('select $num as a, $str as b, $bool as c, $null as d');

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -246,7 +246,7 @@ export function interrupt(connection: Connection): void;
 export function query_progress(connection: Connection): QueryProgress;
 
 // DUCKDB_API void duckdb_disconnect(duckdb_connection *connection);
-// not exposed: disconnected in finalizer
+export function disconnect(connection: Connection): void;
 
 // DUCKDB_API const char *duckdb_library_version();
 export function library_version(): string;

--- a/bindings/test/connection.test.ts
+++ b/bindings/test/connection.test.ts
@@ -1,0 +1,35 @@
+import duckdb from '@duckdb/node-bindings';
+import { expect, suite, test } from 'vitest';
+import { withConnection } from './utils/withConnection';
+
+suite('connection', () => {
+  test('disconnect', async () => {
+    await withConnection(async (connection) => {
+      const prepared1 = await duckdb.prepare(connection, 'select 1');
+      expect(prepared1).toBeDefined();
+      const { extracted_statements } = await duckdb.extract_statements(connection, 'select 10; select 20');
+      duckdb.disconnect(connection);
+      await expect(async () => await duckdb.prepare(connection, 'select 2'))
+        .rejects.toStrictEqual(new Error('Failed to prepare: connection disconnected'));
+      await expect(async () => await duckdb.query(connection, 'select 3'))
+        .rejects.toStrictEqual(new Error('Failed to query: connection disconnected'));
+      await expect(async () => await duckdb.extract_statements(connection, 'select 4; select 5'))
+        .rejects.toStrictEqual(new Error('Failed to extract statements: connection disconnected'));
+      await expect(async () => await duckdb.prepare_extracted_statement(connection, extracted_statements, 0))
+        .rejects.toStrictEqual(new Error('Failed to prepare extracted statement: connection disconnected'));
+      await expect(async () => await duckdb.appender_create(connection, 'main', 'my_target'))
+        .rejects.toStrictEqual(new Error('Failed to create appender: connection disconnected'));
+    });
+  });
+  test('double disconnect', async () => {
+    await withConnection(async (connection) => {
+      const prepared1 = await duckdb.prepare(connection, 'select 1');
+      expect(prepared1).toBeDefined();
+      duckdb.disconnect(connection);
+      // ensure a second disconnect is a no-op
+      duckdb.disconnect(connection);
+      await expect(async () => await duckdb.prepare(connection, 'select 3'))
+        .rejects.toStrictEqual(new Error('Failed to prepare: connection disconnected'));
+    });
+  });
+});


### PR DESCRIPTION
Implement `connection.disconnect()` (and the synonym `connection.close()`).

The challenge was dealing with the automatic disconnect during finalization and also double-disconnect. To make this work I had to add another layer of indirection around the connection object, so it can be nulled out. Luckily this wasn't too bad.

Added some error handling with helpful exception messages for trying to do things (query, prepare, etc.) on a disconnected connection. Some C API functions don't initialize their out parameters in some error conditions, so I added some defense-in-depth against that. Added several unit tests, at both the bindings and api layers.