### PR TITLE
bump pkgs to 1.1.3-alpha.8

### DIFF
--- a/api/pkgs/@duckdb/node-api/package.json
+++ b/api/pkgs/@duckdb/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-api",
-  "version": "1.1.3-alpha.7",
+  "version": "1.1.3-alpha.8",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",
   "dependencies": {

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-arm64",
-  "version": "1.1.3-alpha.7",
+  "version": "1.1.3-alpha.8",
   "os": [
     "darwin"
   ],

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-x64",
-  "version": "1.1.3-alpha.7",
+  "version": "1.1.3-alpha.8",
   "os": [
     "darwin"
   ],

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-arm64",
-  "version": "1.1.3-alpha.7",
+  "version": "1.1.3-alpha.8",
   "os": [
     "linux"
   ],

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-x64",
-  "version": "1.1.3-alpha.7",
+  "version": "1.1.3-alpha.8",
   "os": [
     "linux"
   ],

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-x64",
-  "version": "1.1.3-alpha.7",
+  "version": "1.1.3-alpha.8",
   "os": [
     "win32"
   ],

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings",
-  "version": "1.1.3-alpha.7",
+  "version": "1.1.3-alpha.8",
   "main": "./duckdb.js",
   "types": "./duckdb.d.ts",
   "optionalDependencies": {


### PR DESCRIPTION
This version contains:
- Support for [result streaming](https://github.com/duckdb/duckdb-node-neo/pull/77).
- Support [explicit disconnect](https://github.com/duckdb/duckdb-node-neo/pull/78).