### PR TITLE
Parameterised query benchmark

### DIFF
--- a/api/test/bench/prepare.bench.ts
+++ b/api/test/bench/prepare.bench.ts
@@ -1,0 +1,118 @@
+import { bench, describe } from "vitest";
+import {
+  DuckDBConnection,
+  DuckDBInstance,
+  DuckDBIntervalValue,
+  DuckDBPreparedStatement,
+} from "../../src";
+
+let instance: DuckDBInstance;
+let connection: DuckDBConnection;
+let prepared: DuckDBPreparedStatement;
+
+const TOTAL_SIZE = 1_000_000n;
+const SELECTION_SIZE = 1_000n;
+
+async function setup() {
+  instance = await DuckDBInstance.create();
+  connection = await instance.connect();
+
+  const tableSetupQuery = await connection.prepare(`
+CREATE OR REPLACE TABLE test AS
+SELECT 
+    TIMESTAMP '2025-01-01' + seq::BIGINT * INTERVAL 1 MILLISECOND AS timestamp,
+    RANDOM() * 1_000_000 AS value
+FROM 
+    range($1) AS seq(seq)
+  `);
+
+  tableSetupQuery.bindBigInt(1, TOTAL_SIZE);
+
+  await tableSetupQuery.run();
+}
+
+/**
+ * Randomly generate a BigInt amount of milliseconds to use as the query start point, allowing for
+ * SELECTION_SIZE worth of data
+ */
+function startMS() {
+  return BigInt(
+    Math.floor(Math.random() * Number(TOTAL_SIZE - SELECTION_SIZE))
+  );
+}
+
+describe(`Parameterised queries`, () => {
+  const factory = (start: string, end: string) => `SELECT *
+            FROM test
+            WHERE timestamp BETWEEN TIMESTAMP '2025-01-01' + ${start}
+                                AND TIMESTAMP '2025-01-01' + ${end};`;
+
+  bench(
+    `Multiple queries`,
+    async () => {
+      const s = startMS();
+      const e = s + SELECTION_SIZE;
+      const startInterval = `INTERVAL ${s} MILLISECONDS`;
+      const endInterval = `INTERVAL ${e} MILLISECONDS`;
+
+      const query = factory(startInterval, endInterval);
+
+      await connection.runAndReadAll(query);
+    },
+    {
+      setup,
+    }
+  );
+
+  bench(
+    `Prepared with re-use`,
+    async () => {
+      const startInterval = startMS();
+      const endInterval = startInterval + SELECTION_SIZE;
+
+      prepared.bindInterval(
+        1,
+        new DuckDBIntervalValue(0, 0, startInterval * 1000n)
+      );
+      prepared.bindInterval(
+        2,
+        new DuckDBIntervalValue(0, 0, endInterval * 1000n)
+      );
+
+      await prepared.runAndReadAll();
+    },
+    {
+      setup: async () => {
+        await setup();
+
+        const query = factory("$1", "$2");
+        prepared = await connection.prepare(query);
+      },
+    }
+  );
+
+  bench(
+    `Prepared each time`,
+    async () => {
+      const startInterval = startMS();
+      const endInterval = startInterval + SELECTION_SIZE;
+
+      const query = factory("$1", "$2");
+      prepared = await connection.prepare(query);
+
+      prepared.bindInterval(
+        1,
+        new DuckDBIntervalValue(0, 0, startInterval * 1000n)
+      );
+      prepared.bindInterval(
+        2,
+        new DuckDBIntervalValue(0, 0, endInterval * 1000n)
+      );
+
+      await prepared.runAndReadAll();
+    },
+    {
+      setup,
+    }
+  );
+});


### PR DESCRIPTION
This PR adds a benchmark to compare the performance of parameterising a query.

The statistically significant takeaway by my reading is:

- It's faster to `prepare` once then re-bind parameters multiple times if possible.
- If the query can't be parameterised, calling `prepare` and binding every time has an overhead that can be avoided with a simpler `run` call.

````
 ✓ test/bench/prepare.bench.ts (3) 2041ms
   ✓ Parameterised queries (3) 2040ms
     name                        hz     min     max    mean     p75     p99    p995    p999     rme  samples
   · Multiple queries      2,634.62  0.2616  5.2889  0.3796  0.3935  0.5699  0.6606  4.9380  ±2.84%     1318
   · Prepared with re-use  2,908.72  0.2303  5.0928  0.3438  0.3634  0.5307  0.5631  4.3680  ±2.58%     1455   fastest
   · Prepared each time    2,371.56  0.3070  6.8511  0.4217  0.4347  0.7030  0.9216  5.2908  ±3.33%     1186   slowest
```