### PR TITLE
support writing to data chunks

### DIFF
--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -18,8 +18,8 @@ available separately as [@duckdb/duckdb-bindings](https://www.npmjs.com/package/
 ### Roadmap
 
 Some features are not yet complete:
-- Appending and binding advanced data types. (Additional DuckDB C API support needed.)
-- Writing to data chunk vectors. (Needs special handling in Node.)
+- Binding advanced data types. (Additional DuckDB C API support needed.)
+- Appending advanced data types row-by-row. Appending data chunks recommended instead.
 - User-defined types & functions. (Support for this was added to the DuckDB C API in v1.1.0.)
 - Profiling info (Added in v1.1.0)
 - Table description (Added in v1.1.0)
@@ -410,6 +410,31 @@ appender.appendVarchar('goose');
 appender.endRow();
 
 appender.close(); // also flushes
+```
+
+### Append Data Chunk
+
+```ts
+await connection.run(
+  `create or replace table target_table(i integer, v varchar)`
+);
+
+const appender = await connection.createAppender('main', 'target_table');
+
+const chunk = DuckDBDataChunk.create([INTEGER, VARCHAR]);
+chunk.setColumns([
+  [42, 123, 17],
+  ['duck', 'mallad', 'goose'],
+]);
+// OR:
+// chunk.setRows([
+//   [42, 'duck'],
+//   [123, 'mallard'],
+//   [17, 'goose'],
+// ]);
+
+appender.appendDataChunk(chunk);
+appender.flush();
 ```
 
 ### Extract Statements

--- a/api/src/DuckDBDataChunk.ts
+++ b/api/src/DuckDBDataChunk.ts
@@ -9,8 +9,12 @@ export class DuckDBDataChunk {
   constructor(chunk: duckdb.DataChunk) {
     this.chunk = chunk;
   }
-  public static create(types: readonly DuckDBType[]): DuckDBDataChunk {
-    return new DuckDBDataChunk(duckdb.create_data_chunk(types.map(t => t.toLogicalType().logical_type)));
+  public static create(types: readonly DuckDBType[], rowCount?: number): DuckDBDataChunk {
+    const chunk = new DuckDBDataChunk(duckdb.create_data_chunk(types.map(t => t.toLogicalType().logical_type)));
+    if (rowCount != undefined) {
+      chunk.rowCount = rowCount;
+    }
+    return chunk;
   }
   public reset() {
     duckdb.data_chunk_reset(this.chunk);
@@ -51,6 +55,9 @@ export class DuckDBDataChunk {
     return columns;
   }
   public setColumns(columns: readonly (readonly DuckDBValue[])[]) {
+    if (columns.length > 0) {
+      this.rowCount = columns[0].length;
+    }
     for (let columnIndex = 0; columnIndex < columns.length; columnIndex++) {
       this.setColumnValues(columnIndex, columns[columnIndex]);
     }

--- a/api/src/DuckDBDataChunk.ts
+++ b/api/src/DuckDBDataChunk.ts
@@ -9,7 +9,7 @@ export class DuckDBDataChunk {
   constructor(chunk: duckdb.DataChunk) {
     this.chunk = chunk;
   }
-  public static create(types: DuckDBType[]): DuckDBDataChunk {
+  public static create(types: readonly DuckDBType[]): DuckDBDataChunk {
     return new DuckDBDataChunk(duckdb.create_data_chunk(types.map(t => t.toLogicalType().logical_type)));
   }
   public reset() {
@@ -32,7 +32,7 @@ export class DuckDBDataChunk {
   public getColumnValues(columnIndex: number): DuckDBValue[] {
     return this.getColumnVector(columnIndex).toArray();
   }
-  public setColumnValues(columnIndex: number, values: DuckDBValue[]) {
+  public setColumnValues(columnIndex: number, values: readonly DuckDBValue[]) {
     const vector = this.getColumnVector(columnIndex);
     if (vector.itemCount !== values.length) {
       throw new Error(`number of values must equal chunk row count`);
@@ -50,7 +50,7 @@ export class DuckDBDataChunk {
     }
     return columns;
   }
-  public setColumns(columns: DuckDBValue[][]) {
+  public setColumns(columns: readonly (readonly DuckDBValue[])[]) {
     for (let columnIndex = 0; columnIndex < columns.length; columnIndex++) {
       this.setColumnValues(columnIndex, columns[columnIndex]);
     }
@@ -72,7 +72,7 @@ export class DuckDBDataChunk {
     }
     return rows;
   }
-  public setRows(rows: DuckDBValue[][]) {
+  public setRows(rows: readonly (readonly DuckDBValue[])[]) {
     this.rowCount = rows.length;
     const columnCount = this.columnCount;
     for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {

--- a/api/src/DuckDBDataChunk.ts
+++ b/api/src/DuckDBDataChunk.ts
@@ -1,4 +1,5 @@
 import duckdb from '@duckdb/node-bindings';
+import { DuckDBType } from './DuckDBType';
 import { DuckDBVector } from './DuckDBVector';
 import { DuckDBValue } from './values';
 
@@ -8,8 +9,8 @@ export class DuckDBDataChunk {
   constructor(chunk: duckdb.DataChunk) {
     this.chunk = chunk;
   }
-  public static create(logical_types: duckdb.LogicalType[]): DuckDBDataChunk {
-    return new DuckDBDataChunk(duckdb.create_data_chunk(logical_types));
+  public static create(types: DuckDBType[]): DuckDBDataChunk {
+    return new DuckDBDataChunk(duckdb.create_data_chunk(types.map(t => t.toLogicalType().logical_type)));
   }
   public reset() {
     duckdb.data_chunk_reset(this.chunk);

--- a/api/src/DuckDBType.ts
+++ b/api/src/DuckDBType.ts
@@ -704,6 +704,7 @@ export const UUID = DuckDBUUIDType.instance;
 
 export class DuckDBUnionType extends BaseDuckDBType<DuckDBTypeId.UNION> {
   public readonly memberTags: readonly string[];
+  public readonly tagMemberIndexes: Readonly<Record<string, number>>;
   public readonly memberTypes: readonly DuckDBType[];
   public constructor(
     memberTags: readonly string[],
@@ -716,7 +717,15 @@ export class DuckDBUnionType extends BaseDuckDBType<DuckDBTypeId.UNION> {
         tags length (${memberTags.length}) does not match valueTypes length (${memberTypes.length})`);
     }
     this.memberTags = memberTags;
+    const tagMemberIndexes: Record<string, number> = {};
+    for (let i = 0; i < memberTags.length; i++) {
+      tagMemberIndexes[memberTags[i]] = i;
+    }
+    this.tagMemberIndexes = tagMemberIndexes;
     this.memberTypes = memberTypes;
+  }
+  public memberIndexForTag(tag: string): number {
+    return this.tagMemberIndexes[tag];
   }
   public get memberCount() {
     return this.memberTags.length;

--- a/api/src/DuckDBType.ts
+++ b/api/src/DuckDBType.ts
@@ -485,6 +485,7 @@ export const TIMESTAMP_NS = DuckDBTimestampNanosecondsType.instance;
 
 export class DuckDBEnumType extends BaseDuckDBType<DuckDBTypeId.ENUM> {
   public readonly values: readonly string[];
+  public readonly valueIndexes: Readonly<Record<string, number>>;
   public readonly internalTypeId: DuckDBTypeId;
   public constructor(
     values: readonly string[],
@@ -493,7 +494,15 @@ export class DuckDBEnumType extends BaseDuckDBType<DuckDBTypeId.ENUM> {
   ) {
     super(DuckDBTypeId.ENUM, alias);
     this.values = values;
+    const valueIndexes: Record<string, number> = {};
+    for (let i = 0; i < values.length; i++) {
+      valueIndexes[values[i]] = i;
+    }
+    this.valueIndexes = valueIndexes;
     this.internalTypeId = internalTypeId;
+  }
+  public indexForValue(value: string): number {
+    return this.valueIndexes[value];
   }
   public toString(): string {
     return `ENUM(${this.values.map(quotedString).join(', ')})`;

--- a/api/src/DuckDBType.ts
+++ b/api/src/DuckDBType.ts
@@ -2,6 +2,17 @@ import duckdb from '@duckdb/node-bindings';
 import { DuckDBLogicalType } from './DuckDBLogicalType';
 import { DuckDBTypeId } from './DuckDBTypeId';
 import { quotedIdentifier, quotedString } from './sql';
+import {
+  DuckDBDateValue,
+  DuckDBTimestampMillisecondsValue,
+  DuckDBTimestampNanosecondsValue,
+  DuckDBTimestampSecondsValue,
+  DuckDBTimestampTZValue,
+  DuckDBTimestampValue,
+  DuckDBTimeTZValue,
+  DuckDBTimeValue,
+  DuckDBUUIDValue,
+} from './values';
 
 export abstract class BaseDuckDBType<T extends DuckDBTypeId> {
   public readonly typeId: T;
@@ -14,7 +25,9 @@ export abstract class BaseDuckDBType<T extends DuckDBTypeId> {
     return DuckDBTypeId[this.typeId];
   }
   public toLogicalType(): DuckDBLogicalType {
-    const logicalType = DuckDBLogicalType.create(duckdb.create_logical_type(this.typeId as number as duckdb.Type));
+    const logicalType = DuckDBLogicalType.create(
+      duckdb.create_logical_type(this.typeId as number as duckdb.Type)
+    );
     if (this.alias) {
       logicalType.alias = this.alias;
     }
@@ -31,6 +44,7 @@ export class DuckDBBooleanType extends BaseDuckDBType<DuckDBTypeId.BOOLEAN> {
     return alias ? new DuckDBBooleanType(alias) : DuckDBBooleanType.instance;
   }
 }
+export const BOOLEAN = DuckDBBooleanType.instance;
 
 export class DuckDBTinyIntType extends BaseDuckDBType<DuckDBTypeId.TINYINT> {
   public constructor(alias?: string) {
@@ -42,7 +56,14 @@ export class DuckDBTinyIntType extends BaseDuckDBType<DuckDBTypeId.TINYINT> {
   }
   public static readonly Max = 2 ** 7 - 1;
   public static readonly Min = -(2 ** 7);
+  public get max() {
+    return DuckDBTinyIntType.Max;
+  }
+  public get min() {
+    return DuckDBTinyIntType.Min;
+  }
 }
+export const TINYINT = DuckDBTinyIntType.instance;
 
 export class DuckDBSmallIntType extends BaseDuckDBType<DuckDBTypeId.SMALLINT> {
   public constructor(alias?: string) {
@@ -54,7 +75,14 @@ export class DuckDBSmallIntType extends BaseDuckDBType<DuckDBTypeId.SMALLINT> {
   }
   public static readonly Max = 2 ** 15 - 1;
   public static readonly Min = -(2 ** 15);
+  public get max() {
+    return DuckDBSmallIntType.Max;
+  }
+  public get min() {
+    return DuckDBSmallIntType.Min;
+  }
 }
+export const SMALLINT = DuckDBSmallIntType.instance;
 
 export class DuckDBIntegerType extends BaseDuckDBType<DuckDBTypeId.INTEGER> {
   public constructor(alias?: string) {
@@ -66,7 +94,14 @@ export class DuckDBIntegerType extends BaseDuckDBType<DuckDBTypeId.INTEGER> {
   }
   public static readonly Max = 2 ** 31 - 1;
   public static readonly Min = -(2 ** 31);
+  public get max() {
+    return DuckDBIntegerType.Max;
+  }
+  public get min() {
+    return DuckDBIntegerType.Min;
+  }
 }
+export const INTEGER = DuckDBIntegerType.instance;
 
 export class DuckDBBigIntType extends BaseDuckDBType<DuckDBTypeId.BIGINT> {
   public constructor(alias?: string) {
@@ -78,7 +113,14 @@ export class DuckDBBigIntType extends BaseDuckDBType<DuckDBTypeId.BIGINT> {
   }
   public static readonly Max: bigint = 2n ** 63n - 1n;
   public static readonly Min: bigint = -(2n ** 63n);
+  public get max() {
+    return DuckDBBigIntType.Max;
+  }
+  public get min() {
+    return DuckDBBigIntType.Min;
+  }
 }
+export const BIGINT = DuckDBBigIntType.instance;
 
 export class DuckDBUTinyIntType extends BaseDuckDBType<DuckDBTypeId.UTINYINT> {
   public constructor(alias?: string) {
@@ -90,7 +132,14 @@ export class DuckDBUTinyIntType extends BaseDuckDBType<DuckDBTypeId.UTINYINT> {
   }
   public static readonly Max = 2 ** 8 - 1;
   public static readonly Min = 0;
+  public get max() {
+    return DuckDBUTinyIntType.Max;
+  }
+  public get min() {
+    return DuckDBUTinyIntType.Min;
+  }
 }
+export const UTINYINT = DuckDBUTinyIntType.instance;
 
 export class DuckDBUSmallIntType extends BaseDuckDBType<DuckDBTypeId.USMALLINT> {
   public constructor(alias?: string) {
@@ -98,11 +147,20 @@ export class DuckDBUSmallIntType extends BaseDuckDBType<DuckDBTypeId.USMALLINT> 
   }
   public static readonly instance = new DuckDBUSmallIntType();
   public static create(alias?: string): DuckDBUSmallIntType {
-    return alias ? new DuckDBUSmallIntType(alias) : DuckDBUSmallIntType.instance;
+    return alias
+      ? new DuckDBUSmallIntType(alias)
+      : DuckDBUSmallIntType.instance;
   }
   public static readonly Max = 2 ** 16 - 1;
   public static readonly Min = 0;
+  public get max() {
+    return DuckDBUSmallIntType.Max;
+  }
+  public get min() {
+    return DuckDBUSmallIntType.Min;
+  }
 }
+export const USMALLINT = DuckDBUSmallIntType.instance;
 
 export class DuckDBUIntegerType extends BaseDuckDBType<DuckDBTypeId.UINTEGER> {
   public constructor(alias?: string) {
@@ -114,7 +172,14 @@ export class DuckDBUIntegerType extends BaseDuckDBType<DuckDBTypeId.UINTEGER> {
   }
   public static readonly Max = 2 ** 32 - 1;
   public static readonly Min = 0;
+  public get max() {
+    return DuckDBUIntegerType.Max;
+  }
+  public get min() {
+    return DuckDBUIntegerType.Min;
+  }
 }
+export const UINTEGER = DuckDBUIntegerType.instance;
 
 export class DuckDBUBigIntType extends BaseDuckDBType<DuckDBTypeId.UBIGINT> {
   public constructor(alias?: string) {
@@ -126,7 +191,14 @@ export class DuckDBUBigIntType extends BaseDuckDBType<DuckDBTypeId.UBIGINT> {
   }
   public static readonly Max: bigint = 2n ** 64n - 1n;
   public static readonly Min: bigint = 0n;
+  public get max() {
+    return DuckDBUBigIntType.Max;
+  }
+  public get min() {
+    return DuckDBUBigIntType.Min;
+  }
 }
+export const UBIGINT = DuckDBUBigIntType.instance;
 
 export class DuckDBFloatType extends BaseDuckDBType<DuckDBTypeId.FLOAT> {
   public constructor(alias?: string) {
@@ -136,9 +208,16 @@ export class DuckDBFloatType extends BaseDuckDBType<DuckDBTypeId.FLOAT> {
   public static create(alias?: string): DuckDBFloatType {
     return alias ? new DuckDBFloatType(alias) : DuckDBFloatType.instance;
   }
-  public static readonly Min = Math.fround(-3.4028235e+38);
-  public static readonly Max = Math.fround( 3.4028235e+38);
+  public static readonly Max = Math.fround(3.4028235e38);
+  public static readonly Min = Math.fround(-3.4028235e38);
+  public get max() {
+    return DuckDBFloatType.Max;
+  }
+  public get min() {
+    return DuckDBFloatType.Min;
+  }
 }
+export const FLOAT = DuckDBFloatType.instance;
 
 export class DuckDBDoubleType extends BaseDuckDBType<DuckDBTypeId.DOUBLE> {
   public constructor(alias?: string) {
@@ -148,9 +227,16 @@ export class DuckDBDoubleType extends BaseDuckDBType<DuckDBTypeId.DOUBLE> {
   public static create(alias?: string): DuckDBDoubleType {
     return alias ? new DuckDBDoubleType(alias) : DuckDBDoubleType.instance;
   }
-  public static readonly Min = -Number.MAX_VALUE;
   public static readonly Max = Number.MAX_VALUE;
+  public static readonly Min = -Number.MAX_VALUE;
+  public get max() {
+    return DuckDBDoubleType.Max;
+  }
+  public get min() {
+    return DuckDBDoubleType.Min;
+  }
 }
+export const DOUBLE = DuckDBDoubleType.instance;
 
 export class DuckDBTimestampType extends BaseDuckDBType<DuckDBTypeId.TIMESTAMP> {
   public constructor(alias?: string) {
@@ -158,9 +244,27 @@ export class DuckDBTimestampType extends BaseDuckDBType<DuckDBTypeId.TIMESTAMP> 
   }
   public static readonly instance = new DuckDBTimestampType();
   public static create(alias?: string): DuckDBTimestampType {
-    return alias ? new DuckDBTimestampType(alias) : DuckDBTimestampType.instance;
+    return alias
+      ? new DuckDBTimestampType(alias)
+      : DuckDBTimestampType.instance;
+  }
+  public get epoch() {
+    return DuckDBTimestampValue.Epoch;
+  }
+  public get max() {
+    return DuckDBTimestampValue.Max;
+  }
+  public get min() {
+    return DuckDBTimestampValue.Min;
+  }
+  public get posInf() {
+    return DuckDBTimestampValue.PosInf;
+  }
+  public get negInf() {
+    return DuckDBTimestampValue.NegInf;
   }
 }
+export const TIMESTAMP = DuckDBTimestampType.instance;
 
 export type DuckDBTimestampMicrosecondsType = DuckDBTimestampType;
 export const DuckDBTimestampMicrosecondsType = DuckDBTimestampType;
@@ -173,7 +277,23 @@ export class DuckDBDateType extends BaseDuckDBType<DuckDBTypeId.DATE> {
   public static create(alias?: string): DuckDBDateType {
     return alias ? new DuckDBDateType(alias) : DuckDBDateType.instance;
   }
+  public get epoch() {
+    return DuckDBDateValue.Epoch;
+  }
+  public get max() {
+    return DuckDBDateValue.Max;
+  }
+  public get min() {
+    return DuckDBDateValue.Min;
+  }
+  public get posInf() {
+    return DuckDBDateValue.PosInf;
+  }
+  public get negInf() {
+    return DuckDBDateValue.NegInf;
+  }
 }
+export const DATE = DuckDBDateType.instance;
 
 export class DuckDBTimeType extends BaseDuckDBType<DuckDBTypeId.TIME> {
   public constructor(alias?: string) {
@@ -183,7 +303,14 @@ export class DuckDBTimeType extends BaseDuckDBType<DuckDBTypeId.TIME> {
   public static create(alias?: string): DuckDBTimeType {
     return alias ? new DuckDBTimeType(alias) : DuckDBTimeType.instance;
   }
+  public get max() {
+    return DuckDBTimeValue.Max;
+  }
+  public get min() {
+    return DuckDBTimeValue.Min;
+  }
 }
+export const TIME = DuckDBTimeType.instance;
 
 export class DuckDBIntervalType extends BaseDuckDBType<DuckDBTypeId.INTERVAL> {
   public constructor(alias?: string) {
@@ -194,6 +321,7 @@ export class DuckDBIntervalType extends BaseDuckDBType<DuckDBTypeId.INTERVAL> {
     return alias ? new DuckDBIntervalType(alias) : DuckDBIntervalType.instance;
   }
 }
+export const INTERVAL = DuckDBIntervalType.instance;
 
 export class DuckDBHugeIntType extends BaseDuckDBType<DuckDBTypeId.HUGEINT> {
   public constructor(alias?: string) {
@@ -205,7 +333,14 @@ export class DuckDBHugeIntType extends BaseDuckDBType<DuckDBTypeId.HUGEINT> {
   }
   public static readonly Max: bigint = 2n ** 127n - 1n;
   public static readonly Min: bigint = -(2n ** 127n);
+  public get max() {
+    return DuckDBHugeIntType.Max;
+  }
+  public get min() {
+    return DuckDBHugeIntType.Min;
+  }
 }
+export const HUGEINT = DuckDBHugeIntType.instance;
 
 export class DuckDBUHugeIntType extends BaseDuckDBType<DuckDBTypeId.UHUGEINT> {
   public constructor(alias?: string) {
@@ -217,7 +352,14 @@ export class DuckDBUHugeIntType extends BaseDuckDBType<DuckDBTypeId.UHUGEINT> {
   }
   public static readonly Max: bigint = 2n ** 128n - 1n;
   public static readonly Min: bigint = 0n;
+  public get max() {
+    return DuckDBUHugeIntType.Max;
+  }
+  public get min() {
+    return DuckDBUHugeIntType.Min;
+  }
 }
+export const UHUGEINT = DuckDBUHugeIntType.instance;
 
 export class DuckDBVarCharType extends BaseDuckDBType<DuckDBTypeId.VARCHAR> {
   public constructor(alias?: string) {
@@ -228,6 +370,7 @@ export class DuckDBVarCharType extends BaseDuckDBType<DuckDBTypeId.VARCHAR> {
     return alias ? new DuckDBVarCharType(alias) : DuckDBVarCharType.instance;
   }
 }
+export const VARCHAR = DuckDBVarCharType.instance;
 
 export class DuckDBBlobType extends BaseDuckDBType<DuckDBTypeId.BLOB> {
   public constructor(alias?: string) {
@@ -238,6 +381,7 @@ export class DuckDBBlobType extends BaseDuckDBType<DuckDBTypeId.BLOB> {
     return alias ? new DuckDBBlobType(alias) : DuckDBBlobType.instance;
   }
 }
+export const BLOB = DuckDBBlobType.instance;
 
 export class DuckDBDecimalType extends BaseDuckDBType<DuckDBTypeId.DECIMAL> {
   public readonly width: number;
@@ -259,6 +403,19 @@ export class DuckDBDecimalType extends BaseDuckDBType<DuckDBTypeId.DECIMAL> {
   }
   public static readonly default = new DuckDBDecimalType(18, 3);
 }
+export function DECIMAL(
+  width?: number,
+  scale?: number,
+  alias?: string
+): DuckDBDecimalType {
+  if (width === undefined) {
+    return DuckDBDecimalType.default;
+  }
+  if (scale === undefined) {
+    return new DuckDBDecimalType(width, 0);
+  }
+  return new DuckDBDecimalType(width, scale, alias);
+}
 
 export class DuckDBTimestampSecondsType extends BaseDuckDBType<DuckDBTypeId.TIMESTAMP_S> {
   public constructor(alias?: string) {
@@ -266,9 +423,21 @@ export class DuckDBTimestampSecondsType extends BaseDuckDBType<DuckDBTypeId.TIME
   }
   public static readonly instance = new DuckDBTimestampSecondsType();
   public static create(alias?: string): DuckDBTimestampSecondsType {
-    return alias ? new DuckDBTimestampSecondsType(alias) : DuckDBTimestampSecondsType.instance;
+    return alias
+      ? new DuckDBTimestampSecondsType(alias)
+      : DuckDBTimestampSecondsType.instance;
+  }
+  public get epoch() {
+    return DuckDBTimestampSecondsValue.Epoch;
+  }
+  public get max() {
+    return DuckDBTimestampSecondsValue.Max;
+  }
+  public get min() {
+    return DuckDBTimestampSecondsValue.Min;
   }
 }
+export const TIMESTAMP_S = DuckDBTimestampSecondsType.instance;
 
 export class DuckDBTimestampMillisecondsType extends BaseDuckDBType<DuckDBTypeId.TIMESTAMP_MS> {
   public constructor(alias?: string) {
@@ -276,9 +445,21 @@ export class DuckDBTimestampMillisecondsType extends BaseDuckDBType<DuckDBTypeId
   }
   public static readonly instance = new DuckDBTimestampMillisecondsType();
   public static create(alias?: string): DuckDBTimestampMillisecondsType {
-    return alias ? new DuckDBTimestampMillisecondsType(alias) : DuckDBTimestampMillisecondsType.instance;
+    return alias
+      ? new DuckDBTimestampMillisecondsType(alias)
+      : DuckDBTimestampMillisecondsType.instance;
+  }
+  public get epoch() {
+    return DuckDBTimestampMillisecondsValue.Epoch;
+  }
+  public get max() {
+    return DuckDBTimestampMillisecondsValue.Max;
+  }
+  public get min() {
+    return DuckDBTimestampMillisecondsValue.Min;
   }
 }
+export const TIMESTAMP_MS = DuckDBTimestampMillisecondsType.instance;
 
 export class DuckDBTimestampNanosecondsType extends BaseDuckDBType<DuckDBTypeId.TIMESTAMP_NS> {
   public constructor(alias?: string) {
@@ -286,14 +467,30 @@ export class DuckDBTimestampNanosecondsType extends BaseDuckDBType<DuckDBTypeId.
   }
   public static readonly instance = new DuckDBTimestampNanosecondsType();
   public static create(alias?: string): DuckDBTimestampNanosecondsType {
-    return alias ? new DuckDBTimestampNanosecondsType(alias) : DuckDBTimestampNanosecondsType.instance;
+    return alias
+      ? new DuckDBTimestampNanosecondsType(alias)
+      : DuckDBTimestampNanosecondsType.instance;
+  }
+  public get epoch() {
+    return DuckDBTimestampNanosecondsValue.Epoch;
+  }
+  public get max() {
+    return DuckDBTimestampNanosecondsValue.Max;
+  }
+  public get min() {
+    return DuckDBTimestampNanosecondsValue.Min;
   }
 }
+export const TIMESTAMP_NS = DuckDBTimestampNanosecondsType.instance;
 
 export class DuckDBEnumType extends BaseDuckDBType<DuckDBTypeId.ENUM> {
   public readonly values: readonly string[];
   public readonly internalTypeId: DuckDBTypeId;
-  public constructor(values: readonly string[], internalTypeId: DuckDBTypeId, alias?: string) {
+  public constructor(
+    values: readonly string[],
+    internalTypeId: DuckDBTypeId,
+    alias?: string
+  ) {
     super(DuckDBTypeId.ENUM, alias);
     this.values = values;
     this.internalTypeId = internalTypeId;
@@ -309,6 +506,40 @@ export class DuckDBEnumType extends BaseDuckDBType<DuckDBTypeId.ENUM> {
     return logicalType;
   }
 }
+export function ENUM8(
+  values: readonly string[],
+  alias?: string
+): DuckDBEnumType {
+  return new DuckDBEnumType(values, DuckDBTypeId.UTINYINT, alias);
+}
+export function ENUM16(
+  values: readonly string[],
+  alias?: string
+): DuckDBEnumType {
+  return new DuckDBEnumType(values, DuckDBTypeId.USMALLINT, alias);
+}
+export function ENUM32(
+  values: readonly string[],
+  alias?: string
+): DuckDBEnumType {
+  return new DuckDBEnumType(values, DuckDBTypeId.UINTEGER, alias);
+}
+export function ENUM(
+  values: readonly string[],
+  alias?: string
+): DuckDBEnumType {
+  if (values.length < 256) {
+    return ENUM8(values, alias);
+  } else if (values.length < 65536) {
+    return ENUM16(values, alias);
+  } else if (values.length < 4294967296) {
+    return ENUM32(values, alias);
+  } else {
+    throw new Error(
+      `ENUM types cannot have more than 4294967295 values; received ${values.length}`
+    );
+  }
+}
 
 export class DuckDBListType extends BaseDuckDBType<DuckDBTypeId.LIST> {
   public readonly valueType: DuckDBType;
@@ -320,18 +551,27 @@ export class DuckDBListType extends BaseDuckDBType<DuckDBTypeId.LIST> {
     return `${this.valueType}[]`;
   }
   public override toLogicalType(): DuckDBLogicalType {
-    const logicalType = DuckDBLogicalType.createList(this.valueType.toLogicalType());
+    const logicalType = DuckDBLogicalType.createList(
+      this.valueType.toLogicalType()
+    );
     if (this.alias) {
       logicalType.alias = this.alias;
     }
     return logicalType;
   }
 }
+export function LIST(valueType: DuckDBType, alias?: string): DuckDBListType {
+  return new DuckDBListType(valueType, alias);
+}
 
 export class DuckDBStructType extends BaseDuckDBType<DuckDBTypeId.STRUCT> {
   public readonly entryNames: readonly string[];
   public readonly entryTypes: readonly DuckDBType[];
-  public constructor(entryNames: readonly string[], entryTypes: readonly DuckDBType[], alias?: string) {
+  public constructor(
+    entryNames: readonly string[],
+    entryTypes: readonly DuckDBType[],
+    alias?: string
+  ) {
     super(DuckDBTypeId.STRUCT, alias);
     if (entryNames.length !== entryTypes.length) {
       throw new Error(`Could not create DuckDBStructType: \
@@ -346,23 +586,40 @@ export class DuckDBStructType extends BaseDuckDBType<DuckDBTypeId.STRUCT> {
   public toString(): string {
     const parts: string[] = [];
     for (let i = 0; i < this.entryNames.length; i++) {
-      parts.push(`${quotedIdentifier(this.entryNames[i])} ${this.entryTypes[i]}`);
+      parts.push(
+        `${quotedIdentifier(this.entryNames[i])} ${this.entryTypes[i]}`
+      );
     }
     return `STRUCT(${parts.join(', ')})`;
   }
   public override toLogicalType(): DuckDBLogicalType {
-    const logicalType = DuckDBLogicalType.createStruct(this.entryNames, this.entryTypes.map(t => t.toLogicalType()));
+    const logicalType = DuckDBLogicalType.createStruct(
+      this.entryNames,
+      this.entryTypes.map((t) => t.toLogicalType())
+    );
     if (this.alias) {
       logicalType.alias = this.alias;
     }
     return logicalType;
   }
 }
+export function STRUCT(
+  entries: Record<string, DuckDBType>,
+  alias?: string
+): DuckDBStructType {
+  const entryNames = Object.keys(entries);
+  const entryTypes = Object.values(entries);
+  return new DuckDBStructType(entryNames, entryTypes, alias);
+}
 
 export class DuckDBMapType extends BaseDuckDBType<DuckDBTypeId.MAP> {
   public readonly keyType: DuckDBType;
   public readonly valueType: DuckDBType;
-  public constructor(keyType: DuckDBType, valueType: DuckDBType, alias?: string) {
+  public constructor(
+    keyType: DuckDBType,
+    valueType: DuckDBType,
+    alias?: string
+  ) {
     super(DuckDBTypeId.MAP, alias);
     this.keyType = keyType;
     this.valueType = valueType;
@@ -371,12 +628,22 @@ export class DuckDBMapType extends BaseDuckDBType<DuckDBTypeId.MAP> {
     return `MAP(${this.keyType}, ${this.valueType})`;
   }
   public override toLogicalType(): DuckDBLogicalType {
-    const logicalType = DuckDBLogicalType.createMap(this.keyType.toLogicalType(), this.valueType.toLogicalType());
+    const logicalType = DuckDBLogicalType.createMap(
+      this.keyType.toLogicalType(),
+      this.valueType.toLogicalType()
+    );
     if (this.alias) {
       logicalType.alias = this.alias;
     }
     return logicalType;
   }
+}
+export function MAP(
+  keyType: DuckDBType,
+  valueType: DuckDBType,
+  alias?: string
+): DuckDBMapType {
+  return new DuckDBMapType(keyType, valueType, alias);
 }
 
 export class DuckDBArrayType extends BaseDuckDBType<DuckDBTypeId.ARRAY> {
@@ -391,12 +658,22 @@ export class DuckDBArrayType extends BaseDuckDBType<DuckDBTypeId.ARRAY> {
     return `${this.valueType}[${this.length}]`;
   }
   public override toLogicalType(): DuckDBLogicalType {
-    const logicalType = DuckDBLogicalType.createArray(this.valueType.toLogicalType(), this.length);
+    const logicalType = DuckDBLogicalType.createArray(
+      this.valueType.toLogicalType(),
+      this.length
+    );
     if (this.alias) {
       logicalType.alias = this.alias;
     }
     return logicalType;
   }
+}
+export function ARRAY(
+  valueType: DuckDBType,
+  length: number,
+  alias?: string
+): DuckDBArrayType {
+  return new DuckDBArrayType(valueType, length, alias);
 }
 
 export class DuckDBUUIDType extends BaseDuckDBType<DuckDBTypeId.UUID> {
@@ -407,12 +684,23 @@ export class DuckDBUUIDType extends BaseDuckDBType<DuckDBTypeId.UUID> {
   public static create(alias?: string): DuckDBUUIDType {
     return alias ? new DuckDBUUIDType(alias) : DuckDBUUIDType.instance;
   }
+  public get max() {
+    return DuckDBUUIDValue.Max;
+  }
+  public get min() {
+    return DuckDBUUIDValue.Min;
+  }
 }
+export const UUID = DuckDBUUIDType.instance;
 
 export class DuckDBUnionType extends BaseDuckDBType<DuckDBTypeId.UNION> {
   public readonly memberTags: readonly string[];
   public readonly memberTypes: readonly DuckDBType[];
-  public constructor(memberTags: readonly string[], memberTypes: readonly DuckDBType[], alias?: string) {
+  public constructor(
+    memberTags: readonly string[],
+    memberTypes: readonly DuckDBType[],
+    alias?: string
+  ) {
     super(DuckDBTypeId.UNION, alias);
     if (memberTags.length !== memberTypes.length) {
       throw new Error(`Could not create DuckDBUnionType: \
@@ -427,17 +715,30 @@ export class DuckDBUnionType extends BaseDuckDBType<DuckDBTypeId.UNION> {
   public toString(): string {
     const parts: string[] = [];
     for (let i = 0; i < this.memberTags.length; i++) {
-      parts.push(`${quotedIdentifier(this.memberTags[i])} ${this.memberTypes[i]}`);
+      parts.push(
+        `${quotedIdentifier(this.memberTags[i])} ${this.memberTypes[i]}`
+      );
     }
     return `UNION(${parts.join(', ')})`;
   }
   public override toLogicalType(): DuckDBLogicalType {
-    const logicalType = DuckDBLogicalType.createUnion(this.memberTags, this.memberTypes.map(t => t.toLogicalType()));
+    const logicalType = DuckDBLogicalType.createUnion(
+      this.memberTags,
+      this.memberTypes.map((t) => t.toLogicalType())
+    );
     if (this.alias) {
       logicalType.alias = this.alias;
     }
     return logicalType;
   }
+}
+export function UNION(
+  members: Record<string, DuckDBType>,
+  alias?: string
+): DuckDBUnionType {
+  const memberTags = Object.keys(members);
+  const memberTypes = Object.values(members);
+  return new DuckDBUnionType(memberTags, memberTypes, alias);
 }
 
 export class DuckDBBitType extends BaseDuckDBType<DuckDBTypeId.BIT> {
@@ -449,32 +750,58 @@ export class DuckDBBitType extends BaseDuckDBType<DuckDBTypeId.BIT> {
     return alias ? new DuckDBBitType(alias) : DuckDBBitType.instance;
   }
 }
+export const BIT = DuckDBBitType.instance;
 
 export class DuckDBTimeTZType extends BaseDuckDBType<DuckDBTypeId.TIME_TZ> {
   public constructor(alias?: string) {
     super(DuckDBTypeId.TIME_TZ, alias);
   }
   public toString(): string {
-    return "TIME WITH TIME ZONE";
+    return 'TIME WITH TIME ZONE';
   }
   public static readonly instance = new DuckDBTimeTZType();
   public static create(alias?: string): DuckDBTimeTZType {
     return alias ? new DuckDBTimeTZType(alias) : DuckDBTimeTZType.instance;
   }
+  public get max() {
+    return DuckDBTimeTZValue.Max;
+  }
+  public get min() {
+    return DuckDBTimeTZValue.Min;
+  }
 }
+export const TIMETZ = DuckDBTimeTZType.instance;
 
 export class DuckDBTimestampTZType extends BaseDuckDBType<DuckDBTypeId.TIMESTAMP_TZ> {
   public constructor(alias?: string) {
     super(DuckDBTypeId.TIMESTAMP_TZ, alias);
   }
   public toString(): string {
-    return "TIMESTAMP WITH TIME ZONE";
+    return 'TIMESTAMP WITH TIME ZONE';
   }
   public static readonly instance = new DuckDBTimestampTZType();
   public static create(alias?: string): DuckDBTimestampTZType {
-    return alias ? new DuckDBTimestampTZType(alias) : DuckDBTimestampTZType.instance;
+    return alias
+      ? new DuckDBTimestampTZType(alias)
+      : DuckDBTimestampTZType.instance;
+  }
+  public get epoch() {
+    return DuckDBTimestampTZValue.Epoch;
+  }
+  public get max() {
+    return DuckDBTimestampTZValue.Max;
+  }
+  public get min() {
+    return DuckDBTimestampTZValue.Min;
+  }
+  public get posInf() {
+    return DuckDBTimestampTZValue.PosInf;
+  }
+  public get negInf() {
+    return DuckDBTimestampTZValue.NegInf;
   }
 }
+export const TIMESTAMPTZ = DuckDBTimestampTZType.instance;
 
 export class DuckDBAnyType extends BaseDuckDBType<DuckDBTypeId.ANY> {
   public constructor(alias?: string) {
@@ -485,6 +812,7 @@ export class DuckDBAnyType extends BaseDuckDBType<DuckDBTypeId.ANY> {
     return alias ? new DuckDBAnyType(alias) : DuckDBAnyType.instance;
   }
 }
+export const ANY = DuckDBAnyType.instance;
 
 export class DuckDBVarIntType extends BaseDuckDBType<DuckDBTypeId.VARINT> {
   public constructor(alias?: string) {
@@ -494,9 +822,18 @@ export class DuckDBVarIntType extends BaseDuckDBType<DuckDBTypeId.VARINT> {
   public static create(alias?: string): DuckDBVarIntType {
     return alias ? new DuckDBVarIntType(alias) : DuckDBVarIntType.instance;
   }
-  public static readonly Max: bigint =  179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368n;
-  public static readonly Min: bigint = -179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368n;
+  public static readonly Max: bigint =
+    179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368n;
+  public static readonly Min: bigint =
+    -179769313486231570814527423731704356798070567525844996598917476803157260780028538760589558632766878171540458953514382464234321326889464182768467546703537516986049910576551282076245490090389328944075868508455133942304583236903222948165808559332123348274797826204144723168738177180919299881250404026184124858368n;
+  public get max() {
+    return DuckDBVarIntType.Max;
+  }
+  public get min() {
+    return DuckDBVarIntType.Min;
+  }
 }
+export const VARINT = DuckDBVarIntType.instance;
 
 export class DuckDBSQLNullType extends BaseDuckDBType<DuckDBTypeId.SQLNULL> {
   public constructor(alias?: string) {
@@ -507,6 +844,7 @@ export class DuckDBSQLNullType extends BaseDuckDBType<DuckDBTypeId.SQLNULL> {
     return alias ? new DuckDBSQLNullType(alias) : DuckDBSQLNullType.instance;
   }
 }
+export const SQLNULL = DuckDBSQLNullType.instance;
 
 export type DuckDBType =
   | DuckDBBooleanType
@@ -544,5 +882,4 @@ export type DuckDBType =
   | DuckDBTimestampTZType
   | DuckDBAnyType
   | DuckDBVarIntType
-  | DuckDBSQLNullType
-  ;
+  | DuckDBSQLNullType;

--- a/api/src/DuckDBVector.ts
+++ b/api/src/DuckDBVector.ts
@@ -465,8 +465,13 @@ export class DuckDBBooleanVector extends DuckDBVector<boolean> {
   public override getItem(itemIndex: number): boolean | null {
     return this.validity.itemValid(itemIndex) ? getBoolean(this.dataView, itemIndex * duckdb.sizeof_bool) : null;
   }
-  public override setItem(_itemIndex: number, _value: boolean | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: boolean | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -503,8 +508,13 @@ export class DuckDBTinyIntVector extends DuckDBVector<number> {
   public override getItem(itemIndex: number): number | null {
     return this.validity.itemValid(itemIndex) ? this.items[itemIndex] : null;
   }
-  public override setItem(_itemIndex: number, _value: number | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: number | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -537,8 +547,13 @@ export class DuckDBSmallIntVector extends DuckDBVector<number> {
   public override getItem(itemIndex: number): number | null {
     return this.validity.itemValid(itemIndex) ? this.items[itemIndex] : null;
   }
-  public override setItem(_itemIndex: number, _value: number | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: number | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -614,8 +629,13 @@ export class DuckDBBigIntVector extends DuckDBVector<bigint> {
   public override getItem(itemIndex: number): bigint | null {
     return this.validity.itemValid(itemIndex) ? this.items[itemIndex] : null;
   }
-  public override setItem(_itemIndex: number, _value: bigint | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: bigint | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -648,8 +668,13 @@ export class DuckDBUTinyIntVector extends DuckDBVector<number> {
   public override getItem(itemIndex: number): number | null {
     return this.validity.itemValid(itemIndex) ? this.items[itemIndex] : null;
   }
-  public override setItem(_itemIndex: number, _value: number | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: number | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -682,8 +707,13 @@ export class DuckDBUSmallIntVector extends DuckDBVector<number> {
   public override getItem(itemIndex: number): number | null {
     return this.validity.itemValid(itemIndex) ? this.items[itemIndex] : null;
   }
-  public override setItem(_itemIndex: number, _value: number | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: number | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -716,8 +746,13 @@ export class DuckDBUIntegerVector extends DuckDBVector<number> {
   public override getItem(itemIndex: number): number | null {
     return this.validity.itemValid(itemIndex) ? this.items[itemIndex] : null;
   }
-  public override setItem(_itemIndex: number, _value: number | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: number | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -750,8 +785,13 @@ export class DuckDBUBigIntVector extends DuckDBVector<bigint> {
   public override getItem(itemIndex: number): bigint | null {
     return this.validity.itemValid(itemIndex) ? this.items[itemIndex] : null;
   }
-  public override setItem(_itemIndex: number, _value: bigint | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: bigint | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -784,8 +824,13 @@ export class DuckDBFloatVector extends DuckDBVector<number> {
   public override getItem(itemIndex: number): number | null {
     return this.validity.itemValid(itemIndex) ? this.items[itemIndex] : null;
   }
-  public override setItem(_itemIndex: number, _value: number | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: number | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -818,8 +863,13 @@ export class DuckDBDoubleVector extends DuckDBVector<number> {
   public override getItem(itemIndex: number): number | null {
     return this.validity.itemValid(itemIndex) ? this.items[itemIndex] : null;
   }
-  public override setItem(_itemIndex: number, _value: number | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: number | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -852,8 +902,13 @@ export class DuckDBTimestampVector extends DuckDBVector<DuckDBTimestampValue> {
   public override getItem(itemIndex: number): DuckDBTimestampValue | null {
     return this.validity.itemValid(itemIndex) ? new DuckDBTimestampValue(this.items[itemIndex]) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBTimestampValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBTimestampValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -886,8 +941,13 @@ export class DuckDBDateVector extends DuckDBVector<DuckDBDateValue> {
   public override getItem(itemIndex: number): DuckDBDateValue | null {
     return this.validity.itemValid(itemIndex) ? new DuckDBDateValue(this.items[itemIndex]) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBDateValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBDateValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -920,8 +980,13 @@ export class DuckDBTimeVector extends DuckDBVector<DuckDBTimeValue> {
   public override getItem(itemIndex: number): DuckDBTimeValue | null {
     return this.validity.itemValid(itemIndex) ? new DuckDBTimeValue(this.items[itemIndex]) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBTimeValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBTimeValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -963,8 +1028,13 @@ export class DuckDBIntervalVector extends DuckDBVector<DuckDBIntervalValue> {
     const micros = getInt64(this.dataView, itemStart + 8);
     return new DuckDBIntervalValue(months, days, micros);
   }
-  public override setItem(_itemIndex: number, _value: DuckDBIntervalValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBIntervalValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1008,8 +1078,13 @@ export class DuckDBHugeIntVector extends DuckDBVector<bigint> {
       ? duckdb.hugeint_to_double(getInt128(this.dataView, itemIndex * 16))
       : null;
   }
-  public override setItem(_itemIndex: number, _value: bigint | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: bigint | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1053,8 +1128,13 @@ export class DuckDBUHugeIntVector extends DuckDBVector<bigint> {
       ? duckdb.uhugeint_to_double(getUInt128(this.dataView, itemIndex * 16))
       : null;
   }
-  public override setItem(_itemIndex: number, _value: bigint | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: bigint | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1205,8 +1285,13 @@ export class DuckDBDecimal2Vector extends DuckDBVector<DuckDBDecimalValue> {
   public getScaledValue(itemIndex: number): number | null {
     return this.validity.itemValid(itemIndex) ? getInt16(this.dataView, itemIndex * 2) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBDecimalValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBDecimalValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1251,8 +1336,13 @@ export class DuckDBDecimal4Vector extends DuckDBVector<DuckDBDecimalValue> {
   public getScaledValue(itemIndex: number): number | null {
     return this.validity.itemValid(itemIndex) ? getInt32(this.dataView, itemIndex * 4) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBDecimalValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBDecimalValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1297,8 +1387,13 @@ export class DuckDBDecimal8Vector extends DuckDBVector<DuckDBDecimalValue> {
   public getScaledValue(itemIndex: number): bigint | null {
     return this.validity.itemValid(itemIndex) ? getInt64(this.dataView, itemIndex * 8) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBDecimalValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBDecimalValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1343,8 +1438,13 @@ export class DuckDBDecimal16Vector extends DuckDBVector<DuckDBDecimalValue> {
   public getScaledValue(itemIndex: number): bigint | null {
     return this.validity.itemValid(itemIndex) ? getInt128(this.dataView, itemIndex * 16) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBDecimalValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBDecimalValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1382,8 +1482,13 @@ export class DuckDBTimestampSecondsVector extends DuckDBVector<DuckDBTimestampSe
   public override getItem(itemIndex: number): DuckDBTimestampSecondsValue | null {
     return this.validity.itemValid(itemIndex) ? new DuckDBTimestampSecondsValue(this.items[itemIndex]) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBTimestampSecondsValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBTimestampSecondsValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1416,8 +1521,13 @@ export class DuckDBTimestampMillisecondsVector extends DuckDBVector<DuckDBTimest
   public override getItem(itemIndex: number): DuckDBTimestampMillisecondsValue | null {
     return this.validity.itemValid(itemIndex) ? new DuckDBTimestampMillisecondsValue(this.items[itemIndex]) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBTimestampMillisecondsValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBTimestampMillisecondsValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1450,8 +1560,13 @@ export class DuckDBTimestampNanosecondsVector extends DuckDBVector<DuckDBTimesta
   public override getItem(itemIndex: number): DuckDBTimestampNanosecondsValue | null {
     return this.validity.itemValid(itemIndex) ? new DuckDBTimestampNanosecondsValue(this.items[itemIndex]) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBTimestampNanosecondsValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBTimestampNanosecondsValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1486,8 +1601,13 @@ export class DuckDBEnum1Vector extends DuckDBVector<string> {
   public override getItem(itemIndex: number): string | null {
     return this.validity.itemValid(itemIndex) ? this.enumType.values[this.items[itemIndex]] : null;
   }
-  public override setItem(_itemIndex: number, _value: string | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: string | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1522,8 +1642,13 @@ export class DuckDBEnum2Vector extends DuckDBVector<string> {
   public override getItem(itemIndex: number): string | null {
     return this.validity.itemValid(itemIndex) ? this.enumType.values[this.items[itemIndex]] : null;
   }
-  public override setItem(_itemIndex: number, _value: string | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: string | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1558,8 +1683,13 @@ export class DuckDBEnum4Vector extends DuckDBVector<string> {
   public override getItem(itemIndex: number): string | null {
     return this.validity.itemValid(itemIndex) ? this.enumType.values[this.items[itemIndex]] : null;
   }
-  public override setItem(_itemIndex: number, _value: string | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: string | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -1706,22 +1836,42 @@ export class DuckDBStructVector extends DuckDBVector<DuckDBStructValue> {
   private readonly _itemCount: number;
   private readonly entryVectors: readonly DuckDBVector[];
   private readonly validity: DuckDBValidity;
-  constructor(structType: DuckDBStructType, itemCount: number, entryVectors: readonly DuckDBVector[], validity: DuckDBValidity) {
+  private readonly vector: duckdb.Vector;
+  constructor(
+    structType: DuckDBStructType,
+    itemCount: number,
+    entryVectors: readonly DuckDBVector[],
+    validity: DuckDBValidity,
+    vector: duckdb.Vector,
+  ) {
     super();
     this.structType = structType;
     this._itemCount = itemCount;
     this.entryVectors = entryVectors;
     this.validity = validity;
+    this.vector = vector;
   }
-  static fromRawVector(structType: DuckDBStructType, vector: duckdb.Vector, itemCount: number): DuckDBStructVector {
+  static fromRawVector(
+    structType: DuckDBStructType,
+    vector: duckdb.Vector,
+    itemCount: number
+  ): DuckDBStructVector {
     const entryCount = structType.entryCount;
     const entryVectors: DuckDBVector[] = [];
     for (let i = 0; i < entryCount; i++) {
       const child_vector = duckdb.struct_vector_get_child(vector, i);
-      entryVectors.push(DuckDBVector.create(child_vector, itemCount, structType.entryTypes[i]));
+      entryVectors.push(
+        DuckDBVector.create(child_vector, itemCount, structType.entryTypes[i])
+      );
     }
     const validity = DuckDBValidity.fromVector(vector, itemCount);
-    return new DuckDBStructVector(structType, itemCount, entryVectors, validity);
+    return new DuckDBStructVector(
+      structType,
+      itemCount,
+      entryVectors,
+      validity,
+      vector,
+    );
   }
   public override get type(): DuckDBStructType {
     return this.structType;
@@ -1736,28 +1886,54 @@ export class DuckDBStructVector extends DuckDBVector<DuckDBStructValue> {
     const entries: { [name: string]: DuckDBValue } = {};
     const entryCount = this.structType.entryCount;
     for (let i = 0; i < entryCount; i++) {
-      entries[this.structType.entryNames[i]] = this.entryVectors[i].getItem(itemIndex);
+      entries[this.structType.entryNames[i]] =
+        this.entryVectors[i].getItem(itemIndex);
     }
     return new DuckDBStructValue(entries);
   }
-  public getItemValue(itemIndex: number, entryIndex: number): DuckDBValue | null {
+  public getItemValue(
+    itemIndex: number,
+    entryIndex: number
+  ): DuckDBValue | null {
     if (!this.validity.itemValid(itemIndex)) {
       return null;
     }
     return this.entryVectors[entryIndex].getItem(itemIndex);
   }
-  public override setItem(_itemIndex: number, _value: DuckDBStructValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBStructValue | null) {
+    if (value != null) {
+      const entryCount = this.structType.entryCount;
+      for (let i = 0; i < entryCount; i++) {
+        this.entryVectors[i].setItem(
+          itemIndex,
+          value.entries[this.structType.entryNames[i]]
+        );
+      }
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
+  }
+  public setItemValue(
+    itemIndex: number,
+    entryIndex: number,
+    value: DuckDBValue
+  ) {
+    return this.entryVectors[entryIndex].setItem(itemIndex, value);
   }
   public override flush() {
-    throw new Error('not yet implemented');
+    for (const entryVector of this.entryVectors) {
+      entryVector.flush();
+    }
+    this.validity.flush(this.vector);
   }
   public override slice(offset: number, length: number): DuckDBStructVector {
     return new DuckDBStructVector(
       this.structType,
       length,
-      this.entryVectors.map(entryVector => entryVector.slice(offset, length)),
+      this.entryVectors.map((entryVector) => entryVector.slice(offset, length)),
       this.validity.slice(offset, length),
+      this.vector,
     );
   }
 }
@@ -1818,17 +1994,20 @@ export class DuckDBMapVector extends DuckDBVector<DuckDBMapValue> {
 export class DuckDBArrayVector extends DuckDBVector<DuckDBArrayValue> {
   private readonly arrayType: DuckDBArrayType;
   private readonly validity: DuckDBValidity;
+  private readonly vector: duckdb.Vector;
   private readonly childData: DuckDBVector;
   private readonly _itemCount: number;
   constructor(
     arrayType: DuckDBArrayType,
     validity: DuckDBValidity,
+    vector: duckdb.Vector,
     childData: DuckDBVector,
     itemCount: number,
   ) {
     super();
     this.arrayType = arrayType;
     this.validity = validity;
+    this.vector = vector;
     this.childData = childData;
     this._itemCount = itemCount;
   }
@@ -1837,7 +2016,7 @@ export class DuckDBArrayVector extends DuckDBVector<DuckDBArrayValue> {
     const child_vector = duckdb.array_vector_get_child(vector);
     const childItemsPerArray = DuckDBArrayVector.itemSize(arrayType) * arrayType.length;
     const childData = DuckDBVector.create(child_vector, itemCount * childItemsPerArray, arrayType.valueType);
-    return new DuckDBArrayVector(arrayType, validity, childData, itemCount);
+    return new DuckDBArrayVector(arrayType, validity, vector, childData, itemCount);
   }
   private static itemSize(arrayType: DuckDBArrayType): number {
     if (arrayType.valueType instanceof DuckDBArrayType) {
@@ -1858,16 +2037,26 @@ export class DuckDBArrayVector extends DuckDBVector<DuckDBArrayValue> {
     }
     return new DuckDBArrayValue(this.childData.slice(itemIndex * this.arrayType.length, this.arrayType.length).toArray());
   }
-  public override setItem(_itemIndex: number, _value: DuckDBArrayValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBArrayValue | null) {
+    if (value != null) {
+      const startIndex = itemIndex * this.arrayType.length;
+      for (let i = 0; i < this.arrayType.length; i++) {
+        this.childData.setItem(startIndex + i, value.items[i]);
+      }
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
-    throw new Error('not yet implemented');
+    this.childData.flush();
+    this.validity.flush(this.vector);
   }
   public override slice(offset: number, length: number): DuckDBArrayVector {
     return new DuckDBArrayVector(
       this.arrayType,
       this.validity.slice(offset, length),
+      this.vector,
       this.childData.slice(offset * this.arrayType.length, length * this.arrayType.length),
       length,
     );
@@ -1899,8 +2088,13 @@ export class DuckDBUUIDVector extends DuckDBVector<DuckDBUUIDValue> {
   public override getItem(itemIndex: number): DuckDBUUIDValue | null { 
     return this.validity.itemValid(itemIndex) ? new DuckDBUUIDValue(getInt128(this.dataView, itemIndex * 16)) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBUUIDValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBUUIDValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -2033,8 +2227,13 @@ export class DuckDBTimeTZVector extends DuckDBVector<DuckDBTimeTZValue> {
   public override getItem(itemIndex: number): DuckDBTimeTZValue | null {
     return this.validity.itemValid(itemIndex) ? DuckDBTimeTZValue.fromBits(this.items[itemIndex]) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBTimeTZValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBTimeTZValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');
@@ -2067,8 +2266,13 @@ export class DuckDBTimestampTZVector extends DuckDBVector<DuckDBTimestampTZValue
   public override getItem(itemIndex: number): DuckDBTimestampTZValue | null {
     return this.validity.itemValid(itemIndex) ? new DuckDBTimestampTZValue(this.items[itemIndex]) : null;
   }
-  public override setItem(_itemIndex: number, _value: DuckDBTimestampTZValue | null) {
-    throw new Error('not yet implemented');
+  public override setItem(itemIndex: number, value: DuckDBTimestampTZValue | null) {
+    if (value != null) {
+      throw new Error('not yet implemented');
+      this.validity.setItemValid(itemIndex, true);
+    } else {
+      this.validity.setItemValid(itemIndex, false);
+    }
   }
   public override flush() {
     throw new Error('not yet implemented');

--- a/api/src/conversion/bytesFromString.ts
+++ b/api/src/conversion/bytesFromString.ts
@@ -1,0 +1,5 @@
+const textEncoder = new TextEncoder();
+
+export function bytesFromString(str: string): Uint8Array {
+  return textEncoder.encode(str);
+}

--- a/api/src/values/DuckDBBlobValue.ts
+++ b/api/src/values/DuckDBBlobValue.ts
@@ -1,6 +1,5 @@
+import { bytesFromString } from '../conversion/bytesFromString';
 import { stringFromBlob } from '../conversion/stringFromBlob';
-
-const textEncoder = new TextEncoder();
 
 export class DuckDBBlobValue {
   public readonly bytes: Uint8Array;
@@ -15,7 +14,7 @@ export class DuckDBBlobValue {
   }
 
   public static fromString(str: string): DuckDBBlobValue {
-    return new DuckDBBlobValue(Buffer.from(textEncoder.encode(str)));
+    return new DuckDBBlobValue(Buffer.from(bytesFromString(str)));
   }
 }
 

--- a/api/src/values/DuckDBBlobValue.ts
+++ b/api/src/values/DuckDBBlobValue.ts
@@ -19,6 +19,10 @@ export class DuckDBBlobValue {
   }
 }
 
-export function blobValue(bytes: Uint8Array): DuckDBBlobValue {
-  return new DuckDBBlobValue(bytes);
+export function blobValue(input: Uint8Array | string): DuckDBBlobValue {
+  if (typeof input === 'string') {
+    return DuckDBBlobValue.fromString(input);
+  }
+  return new DuckDBBlobValue(input);
 }
+

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -1304,13 +1304,17 @@ describe('api', () => {
   });
   test('create and append data chunk with all types', async () => {
     await withConnection(async (connection) => {
-      const columnCount = 11;
+      const columnCount = 12;
       const types = testAllTypesColumnTypes.slice(0, columnCount);
       const columns = testAllTypesColumns.slice(0, columnCount);
       const columnNamesAndTypes = testAllTypesColumnsNamesAndTypes.slice(
         0,
         columnCount
       );
+      // workaround until VARINT is fixed (in 1.2.0)
+      types[11] = BOOLEAN;
+      columns[11] = [false, true, null];
+      columnNamesAndTypes[11] = { name: 'varint_as_bool', type: BOOLEAN };
 
       const chunk = DuckDBDataChunk.create(types);
       chunk.rowCount = 3;
@@ -1342,7 +1346,7 @@ describe('api', () => {
         assertValues(resultChunk, 8, DuckDBUSmallIntVector, columns[8]);
         assertValues(resultChunk, 9, DuckDBUIntegerVector, columns[9]);
         assertValues(resultChunk, 10, DuckDBUBigIntVector, columns[10]);
-        // assertValues(resultChunk, 11, DuckDBVarIntVector, columns[11]); // See https://github.com/duckdb/duckdb/pull/15670
+        assertValues(resultChunk, 11, DuckDBBooleanVector, columns[11]); // workaround until VARINT is fixed (in 1.2.0)
 
         // assertValues(resultChunk, 20, DuckDBFloatVector, columns[20]);
         // assertValues(resultChunk, 21, DuckDBDoubleVector, columns[21]);

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -1304,7 +1304,7 @@ describe('api', () => {
   });
   test('create and append data chunk with all types', async () => {
     await withConnection(async (connection) => {
-      const columnCount = 5;
+      const columnCount = 11;
       const types = testAllTypesColumnTypes.slice(0, columnCount);
       const columns = testAllTypesColumns.slice(0, columnCount);
       const columnNamesAndTypes = testAllTypesColumnsNamesAndTypes.slice(
@@ -1336,7 +1336,19 @@ describe('api', () => {
         assertValues(resultChunk, 2, DuckDBSmallIntVector, columns[2]);
         assertValues(resultChunk, 3, DuckDBIntegerVector, columns[3]);
         assertValues(resultChunk, 4, DuckDBBigIntVector, columns[4]);
+        assertValues(resultChunk, 5, DuckDBHugeIntVector, columns[5]);
+        assertValues(resultChunk, 6, DuckDBUHugeIntVector, columns[6]);
+        assertValues(resultChunk, 7, DuckDBUTinyIntVector, columns[7]);
+        assertValues(resultChunk, 8, DuckDBUSmallIntVector, columns[8]);
+        assertValues(resultChunk, 9, DuckDBUIntegerVector, columns[9]);
+        assertValues(resultChunk, 10, DuckDBUBigIntVector, columns[10]);
+        // assertValues(resultChunk, 11, DuckDBVarIntVector, columns[11]); // See https://github.com/duckdb/duckdb/pull/15670
+
+        // assertValues(resultChunk, 20, DuckDBFloatVector, columns[20]);
+        // assertValues(resultChunk, 21, DuckDBDoubleVector, columns[21]);
       }
+
+      // }
     });
   });
 });

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -1304,13 +1304,10 @@ describe('api', () => {
   });
   test('create and append data chunk with all types', async () => {
     await withConnection(async (connection) => {
-      const columnCount = 44;
-      const types = testAllTypesColumnTypes.slice(0, columnCount);
-      const columns = testAllTypesColumns.slice(0, columnCount);
-      const columnNamesAndTypes = testAllTypesColumnsNamesAndTypes.slice(
-        0,
-        columnCount
-      );
+      const types = [...testAllTypesColumnTypes];
+      const columns = [...testAllTypesColumns];
+      const columnNamesAndTypes = [...testAllTypesColumnsNamesAndTypes];
+      
       // workaround until VARINT is fixed (in 1.2.0)
       types[11] = BOOLEAN;
       columns[11] = [false, true, null];
@@ -1322,7 +1319,7 @@ describe('api', () => {
 
       await connection.run(
         `create table target(${columnNamesAndTypes
-          .map(({ name, type }) => `${name} ${type}`)
+          .map(({ name, type }) => `"${name.replace(`"`, `""`)}" ${type}`)
           .join(', ')})`
       );
       const appender = await connection.createAppender('main', 'target');
@@ -1394,6 +1391,16 @@ describe('api', () => {
         assertValues(resultChunk, 41, DuckDBStructVector, columns[41]);
         assertValues(resultChunk, 42, DuckDBStructVector, columns[42]); // struct_of_arrays
         assertValues(resultChunk, 43, DuckDBListVector, columns[43]); // array_of_structs
+        assertValues(resultChunk, 44, DuckDBMapVector, columns[44]);
+        assertValues(resultChunk, 45, DuckDBUnionVector, columns[45]);
+        assertValues(resultChunk, 46, DuckDBArrayVector, columns[46]); // fixed_int_array
+        assertValues(resultChunk, 47, DuckDBArrayVector, columns[47]); // fixed_varchar_array
+        assertValues(resultChunk, 48, DuckDBArrayVector, columns[48]); // fixed_nested_int_array
+        assertValues(resultChunk, 49, DuckDBArrayVector, columns[49]); // fixed_nested_varchar_array
+        assertValues(resultChunk, 50, DuckDBArrayVector, columns[50]); // fixed_struct_array
+        assertValues(resultChunk, 51, DuckDBStructVector, columns[51]); // struct_of_fixed_array
+        assertValues(resultChunk, 52, DuckDBArrayVector, columns[52]); // fixed_array_of_int_list
+        assertValues(resultChunk, 53, DuckDBListVector, columns[53]); // list_of_fixed_int_array
       }
     });
   });

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -1304,7 +1304,7 @@ describe('api', () => {
   });
   test('create and append data chunk with all types', async () => {
     await withConnection(async (connection) => {
-      const columnCount = 12;
+      const columnCount = 44;
       const types = testAllTypesColumnTypes.slice(0, columnCount);
       const columns = testAllTypesColumns.slice(0, columnCount);
       const columnNamesAndTypes = testAllTypesColumnsNamesAndTypes.slice(
@@ -1347,12 +1347,54 @@ describe('api', () => {
         assertValues(resultChunk, 9, DuckDBUIntegerVector, columns[9]);
         assertValues(resultChunk, 10, DuckDBUBigIntVector, columns[10]);
         assertValues(resultChunk, 11, DuckDBBooleanVector, columns[11]); // workaround until VARINT is fixed (in 1.2.0)
-
-        // assertValues(resultChunk, 20, DuckDBFloatVector, columns[20]);
-        // assertValues(resultChunk, 21, DuckDBDoubleVector, columns[21]);
+        assertValues(resultChunk, 12, DuckDBDateVector, columns[12]);
+        assertValues(resultChunk, 13, DuckDBTimeVector, columns[13]);
+        assertValues(resultChunk, 14, DuckDBTimestampVector, columns[14]);
+        assertValues(
+          resultChunk,
+          15,
+          DuckDBTimestampSecondsVector,
+          columns[15]
+        );
+        assertValues(
+          resultChunk,
+          16,
+          DuckDBTimestampMillisecondsVector,
+          columns[16]
+        );
+        assertValues(
+          resultChunk,
+          17,
+          DuckDBTimestampNanosecondsVector,
+          columns[17]
+        );
+        assertValues(resultChunk, 18, DuckDBTimeTZVector, columns[18]);
+        assertValues(resultChunk, 19, DuckDBTimestampTZVector, columns[19]);
+        assertValues(resultChunk, 20, DuckDBFloatVector, columns[20]);
+        assertValues(resultChunk, 21, DuckDBDoubleVector, columns[21]);
+        assertValues(resultChunk, 22, DuckDBDecimal16Vector, columns[22]);
+        assertValues(resultChunk, 23, DuckDBDecimal32Vector, columns[23]);
+        assertValues(resultChunk, 24, DuckDBDecimal64Vector, columns[24]);
+        assertValues(resultChunk, 25, DuckDBDecimal128Vector, columns[25]);
+        assertValues(resultChunk, 26, DuckDBUUIDVector, columns[26]);
+        assertValues(resultChunk, 27, DuckDBIntervalVector, columns[27]);
+        assertValues(resultChunk, 28, DuckDBVarCharVector, columns[28]);
+        assertValues(resultChunk, 29, DuckDBBlobVector, columns[29]);
+        assertValues(resultChunk, 30, DuckDBBitVector, columns[30]);
+        assertValues(resultChunk, 31, DuckDBEnum8Vector, columns[31]);
+        assertValues(resultChunk, 32, DuckDBEnum16Vector, columns[32]);
+        assertValues(resultChunk, 33, DuckDBEnum32Vector, columns[33]);
+        assertValues(resultChunk, 34, DuckDBListVector, columns[34]); // int_array
+        assertValues(resultChunk, 35, DuckDBListVector, columns[35]); // double_array
+        assertValues(resultChunk, 36, DuckDBListVector, columns[36]); // date_array
+        assertValues(resultChunk, 37, DuckDBListVector, columns[37]); // timestamp_array
+        assertValues(resultChunk, 38, DuckDBListVector, columns[38]); // timestamptz_array
+        assertValues(resultChunk, 39, DuckDBListVector, columns[39]); // varchar_array
+        assertValues(resultChunk, 40, DuckDBListVector, columns[40]); // nested_int_array
+        assertValues(resultChunk, 41, DuckDBStructVector, columns[41]);
+        assertValues(resultChunk, 42, DuckDBStructVector, columns[42]); // struct_of_arrays
+        assertValues(resultChunk, 43, DuckDBListVector, columns[43]); // array_of_structs
       }
-
-      // }
     });
   });
 });

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -985,8 +985,7 @@ describe('api', () => {
     }
   });
   test('write integer vector', () => {
-    const chunk = DuckDBDataChunk.create([INTEGER]);
-    chunk.rowCount = 3;
+    const chunk = DuckDBDataChunk.create([INTEGER], 3);
     const vector = chunk.getColumnVector(0) as DuckDBIntegerVector;
     assert.equal(vector.itemCount, 3);
     vector.setItem(0, 42);
@@ -997,8 +996,7 @@ describe('api', () => {
     assert.equal(vector.getItem(2), 67890);
   });
   test('write integer vector with nulls', () => {
-    const chunk = DuckDBDataChunk.create([INTEGER]);
-    chunk.rowCount = 3;
+    const chunk = DuckDBDataChunk.create([INTEGER], 3);
     const vector = chunk.getColumnVector(0) as DuckDBIntegerVector;
     assert.equal(vector.itemCount, 3);
     vector.setItem(0, 42);
@@ -1012,8 +1010,7 @@ describe('api', () => {
     await withConnection(async (connection) => {
       const values = [42, 12345, null];
 
-      const chunk = DuckDBDataChunk.create([INTEGER]);
-      chunk.rowCount = values.length;
+      const chunk = DuckDBDataChunk.create([INTEGER], values.length);
       chunk.setColumnValues(0, values);
 
       await connection.run('create table target(col0 int)');
@@ -1036,8 +1033,7 @@ describe('api', () => {
       const baselineValues = [10, 11, 12];
       const targetValues = [42, 12345, null];
 
-      const chunk = DuckDBDataChunk.create([INTEGER]);
-      chunk.rowCount = targetValues.length;
+      const chunk = DuckDBDataChunk.create([INTEGER], targetValues.length);
       const vector = chunk.getColumnVector(0) as DuckDBIntegerVector;
 
       // First, set the values to something known as a baseline.
@@ -1087,8 +1083,7 @@ describe('api', () => {
     await withConnection(async (connection) => {
       const values = ['xyz', 'abcdefghijkl', 'ABCDEFGHIJKLM', null];
 
-      const chunk = DuckDBDataChunk.create([VARCHAR]);
-      chunk.rowCount = values.length;
+      const chunk = DuckDBDataChunk.create([VARCHAR], values.length);
       chunk.setColumnValues(0, values);
 
       await connection.run('create table target(col0 varchar)');
@@ -1124,8 +1119,7 @@ describe('api', () => {
         ),
         null,
       ];
-      const chunk = DuckDBDataChunk.create([BLOB]);
-      chunk.rowCount = values.length;
+      const chunk = DuckDBDataChunk.create([BLOB], values.length);
       chunk.setColumnValues(0, values);
 
       await connection.run('create table target(col0 blob)');
@@ -1152,8 +1146,7 @@ describe('api', () => {
         null,
       ];
 
-      const chunk = DuckDBDataChunk.create([LIST(INTEGER)]);
-      chunk.rowCount = values.length;
+      const chunk = DuckDBDataChunk.create([LIST(INTEGER)], values.length);
       chunk.setColumnValues(0, values);
 
       await connection.run('create table target(col0 integer[])');
@@ -1180,8 +1173,7 @@ describe('api', () => {
         null,
       ];
 
-      const chunk = DuckDBDataChunk.create([ARRAY(INTEGER, 3)]);
-      chunk.rowCount = values.length;
+      const chunk = DuckDBDataChunk.create([ARRAY(INTEGER, 3)], values.length);
       chunk.setColumnValues(0, values);
 
       await connection.run('create table target(col0 integer[3])');
@@ -1208,8 +1200,7 @@ describe('api', () => {
         null,
       ];
 
-      const chunk = DuckDBDataChunk.create([ARRAY(VARCHAR, 3)]);
-      chunk.rowCount = values.length;
+      const chunk = DuckDBDataChunk.create([ARRAY(VARCHAR, 3)], values.length);
       chunk.setColumnValues(0, values);
 
       await connection.run('create table target(col0 varchar[3])');
@@ -1238,8 +1229,7 @@ describe('api', () => {
 
       const chunk = DuckDBDataChunk.create([
         STRUCT({ 'num': INTEGER, 'str': VARCHAR }),
-      ]);
-      chunk.rowCount = values.length;
+      ], values.length);
       chunk.setColumnValues(0, values);
 
       await connection.run(
@@ -1307,14 +1297,13 @@ describe('api', () => {
       const types = [...testAllTypesColumnTypes];
       const columns = [...testAllTypesColumns];
       const columnNamesAndTypes = [...testAllTypesColumnsNamesAndTypes];
-      
+
       // workaround until VARINT is fixed (in 1.2.0)
       types[11] = BOOLEAN;
       columns[11] = [false, true, null];
       columnNamesAndTypes[11] = { name: 'varint_as_bool', type: BOOLEAN };
 
       const chunk = DuckDBDataChunk.create(types);
-      chunk.rowCount = 3;
       chunk.setColumns(columns);
 
       await connection.run(

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -1,111 +1,104 @@
 import { assert, describe, test } from 'vitest';
 import {
+  ANY,
+  ARRAY,
+  BIGINT,
+  BIT,
+  BLOB,
+  BOOLEAN,
+  DATE,
+  DECIMAL,
+  DOUBLE,
   DateParts,
-  DuckDBAnyType,
-  DuckDBArrayType,
   DuckDBArrayVector,
-  DuckDBBigIntType,
   DuckDBBigIntVector,
-  DuckDBBitType,
   DuckDBBitVector,
-  DuckDBBlobType,
-  DuckDBBlobValue,
   DuckDBBlobVector,
-  DuckDBBooleanType,
   DuckDBBooleanVector,
   DuckDBConnection,
   DuckDBDataChunk,
-  DuckDBDateType,
   DuckDBDateValue,
   DuckDBDateVector,
+  DuckDBDecimal128Vector,
   DuckDBDecimal16Vector,
-  DuckDBDecimal2Vector,
-  DuckDBDecimal4Vector,
-  DuckDBDecimal8Vector,
-  DuckDBDecimalType,
+  DuckDBDecimal32Vector,
+  DuckDBDecimal64Vector,
   DuckDBDecimalValue,
-  DuckDBDoubleType,
   DuckDBDoubleVector,
-  DuckDBEnum1Vector,
-  DuckDBEnum2Vector,
-  DuckDBEnum4Vector,
-  DuckDBEnumType,
-  DuckDBFloatType,
+  DuckDBEnum16Vector,
+  DuckDBEnum32Vector,
+  DuckDBEnum8Vector,
   DuckDBFloatVector,
-  DuckDBHugeIntType,
   DuckDBHugeIntVector,
   DuckDBInstance,
-  DuckDBIntegerType,
   DuckDBIntegerVector,
-  DuckDBIntervalType,
   DuckDBIntervalVector,
-  DuckDBListType,
   DuckDBListVector,
-  DuckDBMapType,
   DuckDBMapVector,
   DuckDBPendingResultState,
   DuckDBResult,
-  DuckDBSQLNullType,
-  DuckDBSmallIntType,
   DuckDBSmallIntVector,
-  DuckDBStructType,
   DuckDBStructVector,
-  DuckDBTimeTZType,
   DuckDBTimeTZValue,
   DuckDBTimeTZVector,
-  DuckDBTimeType,
   DuckDBTimeValue,
   DuckDBTimeVector,
-  DuckDBTimestampMillisecondsType,
-  DuckDBTimestampMillisecondsValue,
   DuckDBTimestampMillisecondsVector,
-  DuckDBTimestampNanosecondsType,
-  DuckDBTimestampNanosecondsValue,
   DuckDBTimestampNanosecondsVector,
-  DuckDBTimestampSecondsType,
-  DuckDBTimestampSecondsValue,
   DuckDBTimestampSecondsVector,
-  DuckDBTimestampTZType,
   DuckDBTimestampTZValue,
   DuckDBTimestampTZVector,
-  DuckDBTimestampType,
   DuckDBTimestampValue,
   DuckDBTimestampVector,
-  DuckDBTinyIntType,
   DuckDBTinyIntVector,
   DuckDBType,
-  DuckDBTypeId,
-  DuckDBUBigIntType,
   DuckDBUBigIntVector,
-  DuckDBUHugeIntType,
   DuckDBUHugeIntVector,
-  DuckDBUIntegerType,
   DuckDBUIntegerVector,
-  DuckDBUSmallIntType,
   DuckDBUSmallIntVector,
-  DuckDBUTinyIntType,
   DuckDBUTinyIntVector,
-  DuckDBUUIDType,
-  DuckDBUUIDValue,
   DuckDBUUIDVector,
-  DuckDBUnionType,
   DuckDBUnionVector,
   DuckDBValue,
-  DuckDBVarCharType,
   DuckDBVarCharVector,
-  DuckDBVarIntType,
   DuckDBVarIntVector,
   DuckDBVector,
+  ENUM,
+  FLOAT,
+  HUGEINT,
+  INTEGER,
+  INTERVAL,
+  LIST,
+  MAP,
   ResultReturnType,
+  SMALLINT,
+  SQLNULL,
+  STRUCT,
   StatementType,
+  TIME,
+  TIMESTAMP,
+  TIMESTAMPTZ,
+  TIMESTAMP_MS,
+  TIMESTAMP_NS,
+  TIMESTAMP_S,
+  TIMETZ,
+  TINYINT,
   TimeParts,
   TimeTZParts,
   TimestampParts,
+  UBIGINT,
+  UHUGEINT,
+  UINTEGER,
+  UNION,
+  USMALLINT,
+  UTINYINT,
+  UUID,
+  VARCHAR,
+  VARINT,
   arrayValue,
   bitValue,
   blobValue,
   configurationOptionDescriptions,
-  dateValue,
   decimalValue,
   intervalValue,
   listValue,
@@ -113,16 +106,15 @@ import {
   structValue,
   timeTZValue,
   timeValue,
-  timestampTZValue,
-  timestampValue,
   unionValue,
-  version
+  version,
 } from '../src';
-
-const BI_10_8 = 100000000n;
-const BI_10_10 = 10000000000n;
-const BI_18_9s = BI_10_8 * BI_10_10 - 1n;
-const BI_38_9s = BI_10_8 * BI_10_10 * BI_10_10 * BI_10_10 - 1n;
+import {
+  ColumnNameAndType,
+  testAllTypesColumnTypes,
+  testAllTypesColumns,
+  testAllTypesColumnsNamesAndTypes,
+} from './util/testAllTypes';
 
 async function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => {
@@ -130,35 +122,53 @@ async function sleep(ms: number): Promise<void> {
   });
 }
 
-async function withConnection(fn: (connection: DuckDBConnection) => Promise<void>) {
+async function withConnection(
+  fn: (connection: DuckDBConnection) => Promise<void>
+) {
   const instance = await DuckDBInstance.create();
   const connection = await instance.connect();
   await fn(connection);
 }
 
-interface ExpectedColumn {
-  readonly name: string;
-  readonly type: DuckDBType;
-}
-
-function assertColumns(result: DuckDBResult, expectedColumns: readonly ExpectedColumn[]) {
-  assert.strictEqual(result.columnCount, expectedColumns.length, 'column count');
+function assertColumns(
+  result: DuckDBResult,
+  expectedColumns: readonly ColumnNameAndType[]
+) {
+  assert.strictEqual(
+    result.columnCount,
+    expectedColumns.length,
+    'column count'
+  );
   for (let i = 0; i < expectedColumns.length; i++) {
     const { name, type } = expectedColumns[i];
     assert.strictEqual(result.columnName(i), name, 'column name');
-    assert.strictEqual(result.columnTypeId(i), type.typeId, `column type id (column: ${name})`);
-    assert.deepStrictEqual(result.columnType(i), type, `column type (column: ${name})`);
+    assert.strictEqual(
+      result.columnTypeId(i),
+      type.typeId,
+      `column type id (column: ${name})`
+    );
+    assert.deepStrictEqual(
+      result.columnType(i),
+      type,
+      `column type (column: ${name})`
+    );
   }
 }
 
-function isVectorType<TValue extends DuckDBValue, TVector extends DuckDBVector<TValue>>(
+function isVectorType<
+  TValue extends DuckDBValue,
+  TVector extends DuckDBVector<TValue>
+>(
   vector: DuckDBVector<any> | null,
-  vectorType: new (...args: any[]) => TVector,
+  vectorType: new (...args: any[]) => TVector
 ): vector is TVector {
   return vector instanceof vectorType;
 }
 
-function getColumnVector<TValue extends DuckDBValue, TVector extends DuckDBVector<TValue>>(
+function getColumnVector<
+  TValue extends DuckDBValue,
+  TVector extends DuckDBVector<TValue>
+>(
   chunk: DuckDBDataChunk,
   columnIndex: number,
   vectorType: new (...args: any[]) => TVector
@@ -173,33 +183,44 @@ function getColumnVector<TValue extends DuckDBValue, TVector extends DuckDBVecto
 function assertVectorValues<TValue extends DuckDBValue>(
   vector: DuckDBVector<TValue> | null | undefined,
   values: readonly TValue[],
-  vectorName: string,
+  vectorName: string
 ) {
   if (!vector) {
     assert.fail(`${vectorName} unexpectedly null or undefined`);
   }
-  assert.strictEqual(vector.itemCount, values.length,
-      `expected vector ${vectorName} item count to be ${values.length} but found ${vector.itemCount}`);
+  assert.strictEqual(
+    vector.itemCount,
+    values.length,
+    `expected vector ${vectorName} item count to be ${values.length} but found ${vector.itemCount}`
+  );
   for (let i = 0; i < values.length; i++) {
     const actual: TValue | null = vector.getItem(i);
     const expected = values[i];
-    assert.deepStrictEqual(actual, expected,
-      `expected vector ${vectorName}[${i}] to be ${expected} but found ${actual}`);
+    assert.deepStrictEqual(
+      actual,
+      expected,
+      `expected vector ${vectorName}[${i}] to be ${expected} but found ${actual}`
+    );
   }
 }
 
-function assertValues<TValue extends DuckDBValue, TVector extends DuckDBVector<TValue>>(
+function assertValues<
+  TValue extends DuckDBValue,
+  TVector extends DuckDBVector<TValue>
+>(
   chunk: DuckDBDataChunk,
   columnIndex: number,
   vectorType: new (...args: any[]) => TVector,
-  values: readonly (TValue | null)[],
+  values: readonly (TValue | null)[]
 ) {
   const vector = getColumnVector(chunk, columnIndex, vectorType);
   assertVectorValues(vector, values, `${columnIndex}`);
 }
 
 function bigints(start: bigint, end: bigint) {
-  return Array.from({ length: Number(end - start) + 1 }).map((_, i) => start + BigInt(i));
+  return Array.from({ length: Number(end - start) + 1 }).map(
+    (_, i) => start + BigInt(i)
+  );
 }
 
 describe('api', () => {
@@ -218,9 +239,15 @@ describe('api', () => {
     assert.equal(ResultReturnType.QUERY_RESULT, 3);
 
     assert.equal(ResultReturnType[ResultReturnType.INVALID], 'INVALID');
-    assert.equal(ResultReturnType[ResultReturnType.CHANGED_ROWS], 'CHANGED_ROWS');
+    assert.equal(
+      ResultReturnType[ResultReturnType.CHANGED_ROWS],
+      'CHANGED_ROWS'
+    );
     assert.equal(ResultReturnType[ResultReturnType.NOTHING], 'NOTHING');
-    assert.equal(ResultReturnType[ResultReturnType.QUERY_RESULT], 'QUERY_RESULT');
+    assert.equal(
+      ResultReturnType[ResultReturnType.QUERY_RESULT],
+      'QUERY_RESULT'
+    );
   });
   test('StatementType enum', () => {
     assert.equal(StatementType.INVALID, 0);
@@ -282,66 +309,65 @@ describe('api', () => {
     assert.equal(StatementType[StatementType.MULTI], 'MULTI');
   });
   test('DuckDBType toString', () => {
-    assert.equal(DuckDBBooleanType.instance.toString(), 'BOOLEAN');
-    assert.equal(DuckDBTinyIntType.instance.toString(), 'TINYINT');
-    assert.equal(DuckDBSmallIntType.instance.toString(), 'SMALLINT');
-    assert.equal(DuckDBIntegerType.instance.toString(), 'INTEGER');
-    assert.equal(DuckDBBigIntType.instance.toString(), 'BIGINT');
-    assert.equal(DuckDBUTinyIntType.instance.toString(), 'UTINYINT');
-    assert.equal(DuckDBUSmallIntType.instance.toString(), 'USMALLINT');
-    assert.equal(DuckDBUIntegerType.instance.toString(), 'UINTEGER');
-    assert.equal(DuckDBUBigIntType.instance.toString(), 'UBIGINT');
-    assert.equal(DuckDBFloatType.instance.toString(), 'FLOAT');
-    assert.equal(DuckDBDoubleType.instance.toString(), 'DOUBLE');
-    assert.equal(DuckDBTimestampType.instance.toString(), 'TIMESTAMP');
-    assert.equal(DuckDBDateType.instance.toString(), 'DATE');
-    assert.equal(DuckDBTimeType.instance.toString(), 'TIME');
-    assert.equal(DuckDBIntervalType.instance.toString(), 'INTERVAL');
-    assert.equal(DuckDBHugeIntType.instance.toString(), 'HUGEINT');
-    assert.equal(DuckDBUHugeIntType.instance.toString(), 'UHUGEINT');
-    assert.equal(DuckDBVarCharType.instance.toString(), 'VARCHAR');
-    assert.equal(DuckDBBlobType.instance.toString(), 'BLOB');
-    assert.equal((new DuckDBDecimalType(17, 5)).toString(), 'DECIMAL(17,5)');
-    assert.equal(DuckDBTimestampSecondsType.instance.toString(), 'TIMESTAMP_S');
-    assert.equal(DuckDBTimestampMillisecondsType.instance.toString(), 'TIMESTAMP_MS');
-    assert.equal(DuckDBTimestampNanosecondsType.instance.toString(), 'TIMESTAMP_NS');
+    assert.equal(BOOLEAN.toString(), 'BOOLEAN');
+    assert.equal(TINYINT.toString(), 'TINYINT');
+    assert.equal(SMALLINT.toString(), 'SMALLINT');
+    assert.equal(INTEGER.toString(), 'INTEGER');
+    assert.equal(BIGINT.toString(), 'BIGINT');
+    assert.equal(UTINYINT.toString(), 'UTINYINT');
+    assert.equal(USMALLINT.toString(), 'USMALLINT');
+    assert.equal(UINTEGER.toString(), 'UINTEGER');
+    assert.equal(UBIGINT.toString(), 'UBIGINT');
+    assert.equal(FLOAT.toString(), 'FLOAT');
+    assert.equal(DOUBLE.toString(), 'DOUBLE');
+    assert.equal(TIMESTAMP.toString(), 'TIMESTAMP');
+    assert.equal(DATE.toString(), 'DATE');
+    assert.equal(TIME.toString(), 'TIME');
+    assert.equal(INTERVAL.toString(), 'INTERVAL');
+    assert.equal(HUGEINT.toString(), 'HUGEINT');
+    assert.equal(UHUGEINT.toString(), 'UHUGEINT');
+    assert.equal(VARCHAR.toString(), 'VARCHAR');
+    assert.equal(BLOB.toString(), 'BLOB');
+    assert.equal(DECIMAL(17, 5).toString(), 'DECIMAL(17,5)');
+    assert.equal(TIMESTAMP_S.toString(), 'TIMESTAMP_S');
+    assert.equal(TIMESTAMP_MS.toString(), 'TIMESTAMP_MS');
+    assert.equal(TIMESTAMP_NS.toString(), 'TIMESTAMP_NS');
     assert.equal(
-      (new DuckDBEnumType(['fly', 'swim', 'walk'], DuckDBTypeId.UTINYINT)).toString(),
+      ENUM(['fly', 'swim', 'walk']).toString(),
       `ENUM('fly', 'swim', 'walk')`
     );
-    assert.equal((new DuckDBListType(DuckDBIntegerType.instance)).toString(), 'INTEGER[]');
-    assert.equal((new DuckDBStructType(
-      ['id', 'ts'],
-      [DuckDBVarCharType.instance, DuckDBTimestampType.instance],
-    )).toString(), 'STRUCT("id" VARCHAR, "ts" TIMESTAMP)');
+    assert.equal(LIST(INTEGER).toString(), 'INTEGER[]');
     assert.equal(
-      (new DuckDBMapType(DuckDBIntegerType.instance, DuckDBVarCharType.instance)).toString(),
-      'MAP(INTEGER, VARCHAR)'
+      STRUCT({ 'id': VARCHAR, 'ts': TIMESTAMP }).toString(),
+      'STRUCT("id" VARCHAR, "ts" TIMESTAMP)'
     );
-    assert.equal((new DuckDBArrayType(DuckDBIntegerType.instance, 3)).toString(), 'INTEGER[3]');
-    assert.equal(DuckDBUUIDType.instance.toString(), 'UUID');
-    assert.equal((new DuckDBUnionType(
-      ['str', 'num'],
-      [DuckDBVarCharType.instance, DuckDBIntegerType.instance],
-    )).toString(), 'UNION("str" VARCHAR, "num" INTEGER)');
-    assert.equal(DuckDBBitType.instance.toString(), 'BIT');
-    assert.equal(DuckDBTimeTZType.instance.toString(), 'TIME WITH TIME ZONE');
-    assert.equal(DuckDBTimestampTZType.instance.toString(), 'TIMESTAMP WITH TIME ZONE');
-    assert.equal(DuckDBAnyType.instance.toString(), 'ANY');
-    assert.equal(DuckDBVarIntType.instance.toString(), 'VARINT');
-    assert.equal(DuckDBSQLNullType.instance.toString(), 'SQLNULL');
+    assert.equal(MAP(INTEGER, VARCHAR).toString(), 'MAP(INTEGER, VARCHAR)');
+    assert.equal(ARRAY(INTEGER, 3).toString(), 'INTEGER[3]');
+    assert.equal(UUID.toString(), 'UUID');
+    assert.equal(
+      UNION({ 'str': VARCHAR, 'num': INTEGER }).toString(),
+      'UNION("str" VARCHAR, "num" INTEGER)'
+    );
+    assert.equal(BIT.toString(), 'BIT');
+    assert.equal(TIMETZ.toString(), 'TIME WITH TIME ZONE');
+    assert.equal(TIMESTAMPTZ.toString(), 'TIMESTAMP WITH TIME ZONE');
+    assert.equal(ANY.toString(), 'ANY');
+    assert.equal(VARINT.toString(), 'VARINT');
+    assert.equal(SQLNULL.toString(), 'SQLNULL');
   });
   test('should support creating, connecting, running a basic query, and reading results', async () => {
     const instance = await DuckDBInstance.create();
     const connection = await instance.connect();
     const result = await connection.run('select 42 as num');
-    assertColumns(result, [{ name: 'num', type: DuckDBIntegerType.instance }]);
+    assertColumns(result, [{ name: 'num', type: INTEGER }]);
     const chunk = await result.fetchChunk();
     assert.isDefined(chunk);
     if (chunk) {
       assert.strictEqual(chunk.columnCount, 1);
       assert.strictEqual(chunk.rowCount, 1);
-      assertValues<number, DuckDBIntegerVector>(chunk, 0, DuckDBIntegerVector, [42]);
+      assertValues<number, DuckDBIntegerVector>(chunk, 0, DuckDBIntegerVector, [
+        42,
+      ]);
     }
   });
   test('disconnecting connections', async () => {
@@ -354,14 +380,19 @@ describe('api', () => {
       await connection.prepare('select 2');
       assert.fail('should throw');
     } catch (err) {
-      assert.deepEqual(err, new Error('Failed to prepare: connection disconnected'));
+      assert.deepEqual(
+        err,
+        new Error('Failed to prepare: connection disconnected')
+      );
     }
     // ensure double-disconnect doesn't break anything
     connection.disconnect();
   });
   test('should support running prepared statements', async () => {
     await withConnection(async (connection) => {
-      const prepared = await connection.prepare('select $num as a, $str as b, $bool as c, $null as d');
+      const prepared = await connection.prepare(
+        'select $num as a, $str as b, $bool as c, $null as d'
+      );
       assert.strictEqual(prepared.parameterCount, 4);
       assert.strictEqual(prepared.parameterName(1), 'num');
       assert.strictEqual(prepared.parameterName(2), 'str');
@@ -373,46 +404,71 @@ describe('api', () => {
       prepared.bindNull(4);
       const result = await prepared.run();
       assertColumns(result, [
-        { name: 'a', type: DuckDBIntegerType.instance },
-        { name: 'b', type: DuckDBVarCharType.instance },
-        { name: 'c', type: DuckDBBooleanType.instance },
-        { name: 'd', type: DuckDBIntegerType.instance },
+        { name: 'a', type: INTEGER },
+        { name: 'b', type: VARCHAR },
+        { name: 'c', type: BOOLEAN },
+        { name: 'd', type: INTEGER },
       ]);
       const chunk = await result.fetchChunk();
       assert.isDefined(chunk);
       if (chunk) {
         assert.strictEqual(chunk.columnCount, 4);
         assert.strictEqual(chunk.rowCount, 1);
-        assertValues<number, DuckDBIntegerVector>(chunk, 0, DuckDBIntegerVector, [10]);
-        assertValues<string, DuckDBVarCharVector>(chunk, 1, DuckDBVarCharVector, ['abc']);
-        assertValues<boolean, DuckDBBooleanVector>(chunk, 2, DuckDBBooleanVector, [true]);
-        assertValues<number, DuckDBIntegerVector>(chunk, 3, DuckDBIntegerVector, [null]);
+        assertValues<number, DuckDBIntegerVector>(
+          chunk,
+          0,
+          DuckDBIntegerVector,
+          [10]
+        );
+        assertValues<string, DuckDBVarCharVector>(
+          chunk,
+          1,
+          DuckDBVarCharVector,
+          ['abc']
+        );
+        assertValues<boolean, DuckDBBooleanVector>(
+          chunk,
+          2,
+          DuckDBBooleanVector,
+          [true]
+        );
+        assertValues<number, DuckDBIntegerVector>(
+          chunk,
+          3,
+          DuckDBIntegerVector,
+          [null]
+        );
       }
     });
   });
   test('should support starting prepared statements and running them incrementally', async () => {
     await withConnection(async (connection) => {
-      const prepared = await connection.prepare('select int from test_all_types()');
+      const prepared = await connection.prepare(
+        'select int from test_all_types()'
+      );
       const pending = prepared.start();
       let taskCount = 0;
       while (pending.runTask() !== DuckDBPendingResultState.RESULT_READY) {
         taskCount++;
-        if (taskCount > 100) { // arbitrary upper bound on the number of tasks expected for this simple query
+        // arbitrary upper bound on the number of tasks expected for this simple query
+        if (taskCount > 100) {
           assert.fail('Unexpectedly large number of tasks');
         }
         await sleep(1);
       }
       // console.debug('task count: ', taskCount);
       const result = await pending.getResult();
-      assertColumns(result, [
-        { name: 'int', type: DuckDBIntegerType.instance },
-      ]);
+      assertColumns(result, [{ name: 'int', type: INTEGER }]);
       const chunk = await result.fetchChunk();
       assert.isDefined(chunk);
       if (chunk) {
         assert.strictEqual(chunk.columnCount, 1);
         assert.strictEqual(chunk.rowCount, 3);
-        assertValues(chunk, 0, DuckDBIntegerVector, [DuckDBIntegerType.Min, DuckDBIntegerType.Max, null]);
+        assertValues(chunk, 0, DuckDBIntegerVector, [
+          INTEGER.min,
+          INTEGER.max,
+          null,
+        ]);
       }
     });
   });
@@ -421,9 +477,7 @@ describe('api', () => {
       const prepared = await connection.prepare('from range(10000)');
       const pending = prepared.start();
       const result = await pending.getResult();
-      assertColumns(result, [
-        { name: 'range', type: DuckDBBigIntType.instance },
-      ]);
+      assertColumns(result, [{ name: 'range', type: BIGINT }]);
       const chunks: DuckDBDataChunk[] = [];
       let currentChunk: DuckDBDataChunk | null = null;
       currentChunk = await result.fetchChunk();
@@ -434,92 +488,38 @@ describe('api', () => {
       currentChunk = null;
       assert.strictEqual(chunks.length, 5); // ceil(10000 / 2048) = 5
       assertValues(chunks[0], 0, DuckDBBigIntVector, bigints(0n, 2048n - 1n));
-      assertValues(chunks[1], 0, DuckDBBigIntVector, bigints(2048n, 2048n * 2n - 1n));
-      assertValues(chunks[2], 0, DuckDBBigIntVector, bigints(2048n * 2n, 2048n * 3n - 1n));
-      assertValues(chunks[3], 0, DuckDBBigIntVector, bigints(2048n * 3n, 2048n * 4n - 1n));
-      assertValues(chunks[4], 0, DuckDBBigIntVector, bigints(2048n * 4n, 9999n));
+      assertValues(
+        chunks[1],
+        0,
+        DuckDBBigIntVector,
+        bigints(2048n, 2048n * 2n - 1n)
+      );
+      assertValues(
+        chunks[2],
+        0,
+        DuckDBBigIntVector,
+        bigints(2048n * 2n, 2048n * 3n - 1n)
+      );
+      assertValues(
+        chunks[3],
+        0,
+        DuckDBBigIntVector,
+        bigints(2048n * 3n, 2048n * 4n - 1n)
+      );
+      assertValues(
+        chunks[4],
+        0,
+        DuckDBBigIntVector,
+        bigints(2048n * 4n, 9999n)
+      );
     });
   });
   test('should support all data types', async () => {
     await withConnection(async (connection) => {
-      const result = await connection.run('from test_all_types(use_large_enum=true)');
-      const smallEnumValues = ['DUCK_DUCK_ENUM', 'GOOSE'];
-      const mediumEnumValues = Array.from({ length: 300 }).map((_, i) => `enum_${i}`);
-      const largeEnumValues = Array.from({ length: 70000 }).map((_, i) => `enum_${i}`);
-      assertColumns(result, [
-        { name: 'bool', type: DuckDBBooleanType.instance },
-        { name: 'tinyint', type: DuckDBTinyIntType.instance },
-        { name: 'smallint', type: DuckDBSmallIntType.instance },
-        { name: 'int', type: DuckDBIntegerType.instance },
-        { name: 'bigint', type: DuckDBBigIntType.instance },
-        { name: 'hugeint', type: DuckDBHugeIntType.instance },
-        { name: 'uhugeint', type: DuckDBUHugeIntType.instance },
-        { name: 'utinyint', type: DuckDBUTinyIntType.instance },
-        { name: 'usmallint', type: DuckDBUSmallIntType.instance },
-        { name: 'uint', type: DuckDBUIntegerType.instance },
-        { name: 'ubigint', type: DuckDBUBigIntType.instance },
-        { name: 'varint', type: DuckDBVarIntType.instance },
-        { name: 'date', type: DuckDBDateType.instance },
-        { name: 'time', type: DuckDBTimeType.instance },
-        { name: 'timestamp', type: DuckDBTimestampType.instance },
-        { name: 'timestamp_s', type: DuckDBTimestampSecondsType.instance },
-        { name: 'timestamp_ms', type: DuckDBTimestampMillisecondsType.instance },
-        { name: 'timestamp_ns', type: DuckDBTimestampNanosecondsType.instance },
-        { name: 'time_tz', type: DuckDBTimeTZType.instance },
-        { name: 'timestamp_tz', type: DuckDBTimestampTZType.instance },
-        { name: 'float', type: DuckDBFloatType.instance },
-        { name: 'double', type: DuckDBDoubleType.instance },
-        { name: 'dec_4_1', type: new DuckDBDecimalType(4, 1) },
-        { name: 'dec_9_4', type: new DuckDBDecimalType(9, 4) },
-        { name: 'dec_18_6', type: new DuckDBDecimalType(18, 6) },
-        { name: 'dec38_10', type: new DuckDBDecimalType(38, 10) },
-        { name: 'uuid', type: DuckDBUUIDType.instance },
-        { name: 'interval', type: DuckDBIntervalType.instance },
-        { name: 'varchar', type: DuckDBVarCharType.instance },
-        { name: 'blob', type: DuckDBBlobType.instance },
-        { name: 'bit', type: DuckDBBitType.instance },
-        { name: 'small_enum', type: new DuckDBEnumType(smallEnumValues, DuckDBTypeId.UTINYINT) },
-        { name: 'medium_enum', type: new DuckDBEnumType(mediumEnumValues, DuckDBTypeId.USMALLINT) },
-        { name: 'large_enum', type: new DuckDBEnumType(largeEnumValues, DuckDBTypeId.UINTEGER) },
-        { name: 'int_array', type: new DuckDBListType(DuckDBIntegerType.instance) },
-        { name: 'double_array', type: new DuckDBListType(DuckDBDoubleType.instance) },
-        { name: 'date_array', type: new DuckDBListType(DuckDBDateType.instance) },
-        { name: 'timestamp_array', type: new DuckDBListType(DuckDBTimestampType.instance) },
-        { name: 'timestamptz_array', type: new DuckDBListType(DuckDBTimestampTZType.instance) },
-        { name: 'varchar_array', type: new DuckDBListType(DuckDBVarCharType.instance) },
-        { name: 'nested_int_array', type: new DuckDBListType(new DuckDBListType(DuckDBIntegerType.instance)) },
-        { name: 'struct', type: new DuckDBStructType(
-          ['a', 'b'],
-          [DuckDBIntegerType.instance, DuckDBVarCharType.instance],
-        ) },
-        { name: 'struct_of_arrays', type: new DuckDBStructType(
-          ['a', 'b'],
-          [new DuckDBListType(DuckDBIntegerType.instance), new DuckDBListType(DuckDBVarCharType.instance)],
-        ) },
-        { name: 'array_of_structs', type: new DuckDBListType(new DuckDBStructType(
-          ['a', 'b'],
-          [DuckDBIntegerType.instance, DuckDBVarCharType.instance],
-        ))},
-        { name: 'map', type: new DuckDBMapType(DuckDBVarCharType.instance, DuckDBVarCharType.instance) },
-        { name: 'union', type: new DuckDBUnionType(
-          ['name', 'age'],
-          [DuckDBVarCharType.instance, DuckDBSmallIntType.instance],
-        )},
-        { name: 'fixed_int_array', type: new DuckDBArrayType(DuckDBIntegerType.instance, 3) },
-        { name: 'fixed_varchar_array', type: new DuckDBArrayType(DuckDBVarCharType.instance, 3) },
-        { name: 'fixed_nested_int_array', type: new DuckDBArrayType(new DuckDBArrayType(DuckDBIntegerType.instance, 3), 3) },
-        { name: 'fixed_nested_varchar_array', type: new DuckDBArrayType(new DuckDBArrayType(DuckDBVarCharType.instance, 3), 3) },
-        { name: 'fixed_struct_array', type: new DuckDBArrayType(new DuckDBStructType(
-          ['a', 'b'],
-          [DuckDBIntegerType.instance, DuckDBVarCharType.instance],
-        ), 3) },
-        { name: 'struct_of_fixed_array', type: new DuckDBStructType(
-          ['a', 'b'],
-          [new DuckDBArrayType(DuckDBIntegerType.instance, 3), new DuckDBArrayType(DuckDBVarCharType.instance, 3)],
-        ) },
-        { name: 'fixed_array_of_int_list', type: new DuckDBArrayType(new DuckDBListType(DuckDBIntegerType.instance), 3) },
-        { name: 'list_of_fixed_int_array', type: new DuckDBListType(new DuckDBArrayType(DuckDBIntegerType.instance, 3)) },
-      ]);
+      const result = await connection.run(
+        'from test_all_types(use_large_enum=true)'
+      );
+      assertColumns(result, testAllTypesColumnsNamesAndTypes);
 
       const chunk = await result.fetchChunk();
       assert.isDefined(chunk);
@@ -527,277 +527,102 @@ describe('api', () => {
         assert.strictEqual(chunk.columnCount, 54);
         assert.strictEqual(chunk.rowCount, 3);
 
-        assertValues(chunk, 0, DuckDBBooleanVector, [false, true, null]);
-        assertValues(chunk, 1, DuckDBTinyIntVector, [DuckDBTinyIntType.Min, DuckDBTinyIntType.Max, null]);
-        assertValues(chunk, 2, DuckDBSmallIntVector, [DuckDBSmallIntType.Min, DuckDBSmallIntType.Max, null]);
-        assertValues(chunk, 3, DuckDBIntegerVector, [DuckDBIntegerType.Min, DuckDBIntegerType.Max, null]);
-        assertValues(chunk, 4, DuckDBBigIntVector, [DuckDBBigIntType.Min, DuckDBBigIntType.Max, null]);
-        assertValues(chunk, 5, DuckDBHugeIntVector, [DuckDBHugeIntType.Min, DuckDBHugeIntType.Max, null]);
-        assertValues(chunk, 6, DuckDBUHugeIntVector, [DuckDBUHugeIntType.Min, DuckDBUHugeIntType.Max, null]);
-        assertValues(chunk, 7, DuckDBUTinyIntVector, [DuckDBUTinyIntType.Min, DuckDBUTinyIntType.Max, null]);
-        assertValues(chunk, 8, DuckDBUSmallIntVector, [DuckDBUSmallIntType.Min, DuckDBUSmallIntType.Max, null]);
-        assertValues(chunk, 9, DuckDBUIntegerVector, [DuckDBUIntegerType.Min, DuckDBUIntegerType.Max, null]);
-        assertValues(chunk, 10, DuckDBUBigIntVector, [DuckDBUBigIntType.Min, DuckDBUBigIntType.Max, null]);
-        assertValues(chunk, 11, DuckDBVarIntVector, [DuckDBVarIntType.Min, DuckDBVarIntType.Max, null]);
-        assertValues(chunk, 12, DuckDBDateVector, [DuckDBDateValue.Min, DuckDBDateValue.Max, null]);
-        assertValues(chunk, 13, DuckDBTimeVector, [DuckDBTimeValue.Min, DuckDBTimeValue.Max, null]);
-        assertValues(chunk, 14, DuckDBTimestampVector,
-          [DuckDBTimestampValue.Min, DuckDBTimestampValue.Max, null]);
-        assertValues(chunk, 15, DuckDBTimestampSecondsVector,
-          [DuckDBTimestampSecondsValue.Min, DuckDBTimestampSecondsValue.Max, null]);
-        assertValues(chunk, 16, DuckDBTimestampMillisecondsVector,
-          [DuckDBTimestampMillisecondsValue.Min, DuckDBTimestampMillisecondsValue.Max, null]);
-        assertValues(chunk, 17, DuckDBTimestampNanosecondsVector,
-          [DuckDBTimestampNanosecondsValue.Min, DuckDBTimestampNanosecondsValue.Max, null]);
-        assertValues(chunk, 18, DuckDBTimeTZVector, [DuckDBTimeTZValue.Min, DuckDBTimeTZValue.Max, null]);
-        assertValues(chunk, 19, DuckDBTimestampTZVector,
-          [DuckDBTimestampTZValue.Min, DuckDBTimestampTZValue.Max, null]);
-        assertValues(chunk, 20, DuckDBFloatVector, [DuckDBFloatType.Min, DuckDBFloatType.Max, null]);
-        assertValues(chunk, 21, DuckDBDoubleVector, [DuckDBDoubleType.Min, DuckDBDoubleType.Max, null]);
-        assertValues(chunk, 22, DuckDBDecimal2Vector, [
-          decimalValue(-9999n, 4, 1),
-          decimalValue( 9999n, 4, 1),
-          null,
-        ]);
-        assertValues(chunk, 23, DuckDBDecimal4Vector, [
-          decimalValue(-999999999n, 9, 4),
-          decimalValue( 999999999n, 9, 4),
-          null,
-        ]);
-        assertValues(chunk, 24, DuckDBDecimal8Vector, [
-          decimalValue(-BI_18_9s, 18, 6),
-          decimalValue( BI_18_9s, 18, 6),
-          null,
-        ]);
-        assertValues(chunk, 25, DuckDBDecimal16Vector, [
-          decimalValue(-BI_38_9s, 38, 10),
-          decimalValue( BI_38_9s, 38, 10),
-          null,
-        ]);
-        assertValues(chunk, 26, DuckDBUUIDVector, [DuckDBUUIDValue.Min, DuckDBUUIDValue.Max, null]);
-        assertValues(chunk, 27, DuckDBIntervalVector, [
-          intervalValue(0, 0, 0n),
-          intervalValue(999, 999, 999999999n),
-          null,
-        ]);
-        assertValues<string, DuckDBVarCharVector>(chunk, 28, DuckDBVarCharVector, ['🦆🦆🦆🦆🦆🦆', 'goo\0se', null]);
-        assertValues(chunk, 29, DuckDBBlobVector, [
-          DuckDBBlobValue.fromString('thisisalongblob\x00withnullbytes'),
-          DuckDBBlobValue.fromString('\x00\x00\x00a'),
-          null,
-        ]);
-        assertValues(chunk, 30, DuckDBBitVector, [
-          bitValue('0010001001011100010101011010111'),
-          bitValue('10101'),
-          null,
-        ]);
-        assertValues(chunk, 31, DuckDBEnum1Vector, [
-          smallEnumValues[0],
-          smallEnumValues[smallEnumValues.length - 1],
-          null,
-        ]);
-        assertValues(chunk, 32, DuckDBEnum2Vector, [
-          mediumEnumValues[0],
-          mediumEnumValues[mediumEnumValues.length - 1],
-          null,
-        ]);
-        assertValues(chunk, 33, DuckDBEnum4Vector, [
-          largeEnumValues[0],
-          largeEnumValues[largeEnumValues.length - 1],
-          null,
-        ]);
+        assertValues(chunk, 0, DuckDBBooleanVector, testAllTypesColumns[0]);
+        assertValues(chunk, 1, DuckDBTinyIntVector, testAllTypesColumns[1]);
+        assertValues(chunk, 2, DuckDBSmallIntVector, testAllTypesColumns[2]);
+        assertValues(chunk, 3, DuckDBIntegerVector, testAllTypesColumns[3]);
+        assertValues(chunk, 4, DuckDBBigIntVector, testAllTypesColumns[4]);
+        assertValues(chunk, 5, DuckDBHugeIntVector, testAllTypesColumns[5]);
+        assertValues(chunk, 6, DuckDBUHugeIntVector, testAllTypesColumns[6]);
+        assertValues(chunk, 7, DuckDBUTinyIntVector, testAllTypesColumns[7]);
+        assertValues(chunk, 8, DuckDBUSmallIntVector, testAllTypesColumns[8]);
+        assertValues(chunk, 9, DuckDBUIntegerVector, testAllTypesColumns[9]);
+        assertValues(chunk, 10, DuckDBUBigIntVector, testAllTypesColumns[10]);
+        assertValues(chunk, 11, DuckDBVarIntVector, testAllTypesColumns[11]);
+        assertValues(chunk, 12, DuckDBDateVector, testAllTypesColumns[12]);
+        assertValues(chunk, 13, DuckDBTimeVector, testAllTypesColumns[13]);
+        assertValues(chunk, 14, DuckDBTimestampVector, testAllTypesColumns[14]);
+        assertValues(
+          chunk,
+          15,
+          DuckDBTimestampSecondsVector,
+          testAllTypesColumns[15]
+        );
+        assertValues(
+          chunk,
+          16,
+          DuckDBTimestampMillisecondsVector,
+          testAllTypesColumns[16]
+        );
+        assertValues(
+          chunk,
+          17,
+          DuckDBTimestampNanosecondsVector,
+          testAllTypesColumns[17]
+        );
+        assertValues(chunk, 18, DuckDBTimeTZVector, testAllTypesColumns[18]);
+        assertValues(
+          chunk,
+          19,
+          DuckDBTimestampTZVector,
+          testAllTypesColumns[19]
+        );
+        assertValues(chunk, 20, DuckDBFloatVector, testAllTypesColumns[20]);
+        assertValues(chunk, 21, DuckDBDoubleVector, testAllTypesColumns[21]);
+        assertValues(chunk, 22, DuckDBDecimal16Vector, testAllTypesColumns[22]);
+        assertValues(chunk, 23, DuckDBDecimal32Vector, testAllTypesColumns[23]);
+        assertValues(chunk, 24, DuckDBDecimal64Vector, testAllTypesColumns[24]);
+        assertValues(
+          chunk,
+          25,
+          DuckDBDecimal128Vector,
+          testAllTypesColumns[25]
+        );
+        assertValues(chunk, 26, DuckDBUUIDVector, testAllTypesColumns[26]);
+        assertValues(chunk, 27, DuckDBIntervalVector, testAllTypesColumns[27]);
+        assertValues(chunk, 28, DuckDBVarCharVector, testAllTypesColumns[28]);
+        assertValues(chunk, 29, DuckDBBlobVector, testAllTypesColumns[29]);
+        assertValues(chunk, 30, DuckDBBitVector, testAllTypesColumns[30]);
+        assertValues(chunk, 31, DuckDBEnum8Vector, testAllTypesColumns[31]);
+        assertValues(chunk, 32, DuckDBEnum16Vector, testAllTypesColumns[32]);
+        assertValues(chunk, 33, DuckDBEnum32Vector, testAllTypesColumns[33]);
         // int_array
-        assertValues(chunk, 34, DuckDBListVector, [
-          listValue([]),
-          listValue([42, 999, null, null, -42]),
-          null,
-        ]);
+        assertValues(chunk, 34, DuckDBListVector, testAllTypesColumns[34]);
         // double_array
-        assertValues(chunk, 35, DuckDBListVector, [
-          listValue([]),
-          listValue([42.0, NaN, Infinity, -Infinity, null, -42.0]),
-          null,
-        ]);
+        assertValues(chunk, 35, DuckDBListVector, testAllTypesColumns[35]);
         // date_array
-        assertValues(chunk, 36, DuckDBListVector, [
-          listValue([]),
-          listValue([dateValue(0), DuckDBDateValue.PosInf, DuckDBDateValue.NegInf, null, dateValue(19124)]),
-          null,
-        ]);
+        assertValues(chunk, 36, DuckDBListVector, testAllTypesColumns[36]);
         // timestamp_array
-        assertValues(chunk, 37, DuckDBListVector, [
-          listValue([]),
-          listValue([
-            DuckDBTimestampValue.Epoch,
-            DuckDBTimestampValue.PosInf,
-            DuckDBTimestampValue.NegInf,
-            null,
-            // 1652372625 is 2022-05-12 16:23:45
-            timestampValue(1652372625n * 1000n * 1000n),
-          ]),
-          null,
-        ]);
+        assertValues(chunk, 37, DuckDBListVector, testAllTypesColumns[37]);
         // timestamptz_array
-        assertValues(chunk, 38, DuckDBListVector, [
-          listValue([]),
-          listValue([
-            DuckDBTimestampTZValue.Epoch,
-            DuckDBTimestampTZValue.PosInf,
-            DuckDBTimestampTZValue.NegInf,
-            null,
-            // 1652397825 = 1652372625 + 25200, 25200 = 7 * 60 * 60 = 7 hours in seconds
-            // This 7 hour difference is hard coded into test_all_types (value is 2022-05-12 16:23:45-07)
-            timestampTZValue(1652397825n * 1000n * 1000n),
-          ]),
-          null,
-        ]);
+        assertValues(chunk, 38, DuckDBListVector, testAllTypesColumns[38]);
         // varchar_array
-        assertValues(chunk, 39, DuckDBListVector, [
-          listValue([]),
-          // Note that the string 'goose' in varchar_array does NOT have an embedded null character.
-          listValue(['🦆🦆🦆🦆🦆🦆', 'goose', null, '']),
-          null,
-        ]);
+        assertValues(chunk, 39, DuckDBListVector, testAllTypesColumns[39]);
         // nested_int_array
-        assertValues(chunk, 40, DuckDBListVector, [
-          listValue([]),
-          listValue([
-            listValue([]),
-            listValue([42, 999, null, null, -42]),
-            null,
-            listValue([]),
-            listValue([42, 999, null, null, -42]),
-          ]),
-          null,
-        ]);
-        assertValues(chunk, 41, DuckDBStructVector, [
-          structValue({ 'a': null, 'b': null }),
-          structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
-          null,
-        ]);
+        assertValues(chunk, 40, DuckDBListVector, testAllTypesColumns[40]);
+        assertValues(chunk, 41, DuckDBStructVector, testAllTypesColumns[41]);
         // struct_of_arrays
-        assertValues(chunk, 42, DuckDBStructVector, [
-          structValue({ 'a': null, 'b': null }),
-          structValue({
-            'a': listValue([42, 999, null, null, -42]),
-            'b': listValue(['🦆🦆🦆🦆🦆🦆', 'goose', null, '']),
-          }),
-          null,
-        ]);
+        assertValues(chunk, 42, DuckDBStructVector, testAllTypesColumns[42]);
         // array_of_structs
-        assertValues(chunk, 43, DuckDBListVector, [
-          listValue([]),
-          listValue([
-            structValue({ 'a': null, 'b': null }),
-            structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
-            null,
-          ]),
-          null,
-        ]);
-        assertValues(chunk, 44, DuckDBMapVector, [
-          mapValue([]),
-          mapValue([{ key: 'key1', value: '🦆🦆🦆🦆🦆🦆' }, { key: 'key2', value: 'goose' }]),
-          null,
-        ]);
-        assertValues<DuckDBValue, DuckDBUnionVector>(chunk, 45, DuckDBUnionVector, [
-          unionValue('name', 'Frank'),
-          unionValue('age', 5),
-          null,
-        ]);
+        assertValues(chunk, 43, DuckDBListVector, testAllTypesColumns[43]);
+        assertValues(chunk, 44, DuckDBMapVector, testAllTypesColumns[44]);
+        assertValues(chunk, 45, DuckDBUnionVector, testAllTypesColumns[45]);
         // fixed_int_array
-        assertValues(chunk, 46, DuckDBArrayVector, [
-          arrayValue([null, 2, 3]),
-          arrayValue([4, 5, 6]),
-          null,
-        ]);
+        assertValues(chunk, 46, DuckDBArrayVector, testAllTypesColumns[46]);
         // fixed_varchar_array
-        assertValues(chunk, 47, DuckDBArrayVector, [
-          arrayValue(['a', null, 'c']),
-          arrayValue(['d', 'e', 'f']),
-          null,
-        ]);
+        assertValues(chunk, 47, DuckDBArrayVector, testAllTypesColumns[47]);
         // fixed_nested_int_array
-        assertValues(chunk, 48, DuckDBArrayVector, [
-          arrayValue([
-            arrayValue([null, 2, 3]),
-            null,
-            arrayValue([null, 2, 3]),
-          ]),
-          arrayValue([
-            arrayValue([4, 5, 6]),
-            arrayValue([null, 2, 3]),
-            arrayValue([4, 5, 6]),
-          ]),
-          null,
-        ]);
+        assertValues(chunk, 48, DuckDBArrayVector, testAllTypesColumns[48]);
         // fixed_nested_varchar_array
-        assertValues(chunk, 49, DuckDBArrayVector, [
-          arrayValue([
-            arrayValue(['a', null, 'c']),
-            null,
-            arrayValue(['a', null, 'c']),
-          ]),
-          arrayValue([
-            arrayValue(['d', 'e', 'f']),
-            arrayValue(['a', null, 'c']),
-            arrayValue(['d', 'e', 'f']),
-          ]),
-          null,
-        ]);
+        assertValues(chunk, 49, DuckDBArrayVector, testAllTypesColumns[49]);
         // fixed_struct_array
-        assertValues(chunk, 50, DuckDBArrayVector, [
-          arrayValue([
-            structValue({ 'a': null, 'b': null }),
-            structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
-            structValue({ 'a': null, 'b': null }),
-          ]),
-          arrayValue([
-            structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
-            structValue({ 'a': null, 'b': null }),
-            structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
-          ]),
-          null,
-        ]);
+        assertValues(chunk, 50, DuckDBArrayVector, testAllTypesColumns[50]);
         // struct_of_fixed_array
-        assertValues(chunk, 51, DuckDBStructVector, [
-          structValue({
-            'a': arrayValue([null, 2, 3]),
-            'b': arrayValue(['a', null, 'c']),
-          }),
-          structValue({
-            'a': arrayValue([4, 5, 6]),
-            'b': arrayValue(['d', 'e', 'f']),
-          }),
-          null,
-        ]);
+        assertValues(chunk, 51, DuckDBStructVector, testAllTypesColumns[51]);
         // fixed_array_of_int_list
-        assertValues(chunk, 52, DuckDBArrayVector, [
-          arrayValue([
-            listValue([]),
-            listValue([42, 999, null, null, -42]),
-            listValue([]),
-          ]),
-          arrayValue([
-            listValue([42, 999, null, null, -42]),
-            listValue([]),
-            listValue([42, 999, null, null, -42]),
-          ]),
-          null,
-        ]);
+        assertValues(chunk, 52, DuckDBArrayVector, testAllTypesColumns[52]);
         // list_of_fixed_int_array
-        assertValues(chunk, 53, DuckDBListVector, [
-          listValue([
-            arrayValue([null, 2, 3]),
-            arrayValue([4, 5, 6]),
-            arrayValue([null, 2, 3]),
-          ]),
-          listValue([
-            arrayValue([4, 5, 6]),
-            arrayValue([null, 2, 3]),
-            arrayValue([4, 5, 6]),
-          ]),
-          null,
-        ]);
+        assertValues(chunk, 53, DuckDBListVector, testAllTypesColumns[53]);
       }
     });
   });
@@ -810,81 +635,145 @@ describe('api', () => {
     // bit
     assert.equal(bitValue('').toString(), '');
     assert.equal(bitValue('10101').toString(), '10101');
-    assert.equal(bitValue('0010001001011100010101011010111').toString(), '0010001001011100010101011010111');
+    assert.equal(
+      bitValue('0010001001011100010101011010111').toString(),
+      '0010001001011100010101011010111'
+    );
 
     // blob
-    assert.equal(DuckDBBlobValue.fromString('').toString(), '');
-    assert.equal(DuckDBBlobValue.fromString('thisisalongblob\x00withnullbytes').toString(), 'thisisalongblob\\x00withnullbytes');
-    assert.equal(DuckDBBlobValue.fromString('\x00\x00\x00a').toString(), '\\x00\\x00\\x00a');
+    assert.equal(blobValue('').toString(), '');
+    assert.equal(
+      blobValue('thisisalongblob\x00withnullbytes').toString(),
+      'thisisalongblob\\x00withnullbytes'
+    );
+    assert.equal(blobValue('\x00\x00\x00a').toString(), '\\x00\\x00\\x00a');
 
     // date
-    assert.equal(DuckDBDateValue.Epoch.toString(), '1970-01-01');
-    assert.equal(DuckDBDateValue.Max.toString(), '5881580-07-10');
-    assert.equal(DuckDBDateValue.Min.toString(), '5877642-06-25 (BC)');
+    assert.equal(DATE.epoch.toString(), '1970-01-01');
+    assert.equal(DATE.max.toString(), '5881580-07-10');
+    assert.equal(DATE.min.toString(), '5877642-06-25 (BC)');
 
     // decimal
     assert.equal(decimalValue(0n, 4, 1).toString(), '0.0');
-    assert.equal(decimalValue( 9876n, 4, 1).toString(),  '987.6');
+    assert.equal(decimalValue(9876n, 4, 1).toString(), '987.6');
     assert.equal(decimalValue(-9876n, 4, 1).toString(), '-987.6');
 
     assert.equal(decimalValue(0n, 9, 4).toString(), '0.0000');
-    assert.equal(decimalValue( 987654321n, 9, 4).toString(),  '98765.4321');
+    assert.equal(decimalValue(987654321n, 9, 4).toString(), '98765.4321');
     assert.equal(decimalValue(-987654321n, 9, 4).toString(), '-98765.4321');
 
     assert.equal(decimalValue(0n, 18, 6).toString(), '0.000000');
-    assert.equal(decimalValue( 987654321098765432n, 18, 6).toString(),  '987654321098.765432');
-    assert.equal(decimalValue(-987654321098765432n, 18, 6).toString(), '-987654321098.765432');
+    assert.equal(
+      decimalValue(987654321098765432n, 18, 6).toString(),
+      '987654321098.765432'
+    );
+    assert.equal(
+      decimalValue(-987654321098765432n, 18, 6).toString(),
+      '-987654321098.765432'
+    );
 
     assert.equal(decimalValue(0n, 38, 10).toString(), '0.0000000000');
-    assert.equal(decimalValue( 98765432109876543210987654321098765432n, 38, 10).toString(),  '9876543210987654321098765432.1098765432');
-    assert.equal(decimalValue(-98765432109876543210987654321098765432n, 38, 10).toString(), '-9876543210987654321098765432.1098765432');
+    assert.equal(
+      decimalValue(98765432109876543210987654321098765432n, 38, 10).toString(),
+      '9876543210987654321098765432.1098765432'
+    );
+    assert.equal(
+      decimalValue(-98765432109876543210987654321098765432n, 38, 10).toString(),
+      '-9876543210987654321098765432.1098765432'
+    );
 
     // interval
     assert.equal(intervalValue(0, 0, 0n).toString(), '00:00:00');
 
-    assert.equal(intervalValue( 1, 0, 0n).toString(),  '1 month');
+    assert.equal(intervalValue(1, 0, 0n).toString(), '1 month');
     assert.equal(intervalValue(-1, 0, 0n).toString(), '-1 month');
-    assert.equal(intervalValue( 2, 0, 0n).toString(),  '2 months');
+    assert.equal(intervalValue(2, 0, 0n).toString(), '2 months');
     assert.equal(intervalValue(-2, 0, 0n).toString(), '-2 months');
-    assert.equal(intervalValue( 12, 0, 0n).toString(), '1 year');
+    assert.equal(intervalValue(12, 0, 0n).toString(), '1 year');
     assert.equal(intervalValue(-12, 0, 0n).toString(), '-1 year');
-    assert.equal(intervalValue( 24, 0, 0n).toString(),  '2 years');
+    assert.equal(intervalValue(24, 0, 0n).toString(), '2 years');
     assert.equal(intervalValue(-24, 0, 0n).toString(), '-2 years');
-    assert.equal(intervalValue( 25, 0, 0n).toString(),  '2 years 1 month');
+    assert.equal(intervalValue(25, 0, 0n).toString(), '2 years 1 month');
     assert.equal(intervalValue(-25, 0, 0n).toString(), '-2 years -1 month');
 
-    assert.equal(intervalValue(0, 1, 0n).toString(),   '1 day');
+    assert.equal(intervalValue(0, 1, 0n).toString(), '1 day');
     assert.equal(intervalValue(0, -1, 0n).toString(), '-1 day');
-    assert.equal(intervalValue(0, 2, 0n).toString(),   '2 days');
+    assert.equal(intervalValue(0, 2, 0n).toString(), '2 days');
     assert.equal(intervalValue(0, -2, 0n).toString(), '-2 days');
     assert.equal(intervalValue(0, 30, 0n).toString(), '30 days');
     assert.equal(intervalValue(0, 365, 0n).toString(), '365 days');
 
-    assert.equal(intervalValue(0, 0,  1n).toString(),  '00:00:00.000001');
+    assert.equal(intervalValue(0, 0, 1n).toString(), '00:00:00.000001');
     assert.equal(intervalValue(0, 0, -1n).toString(), '-00:00:00.000001');
-    assert.equal(intervalValue(0, 0,  987654n).toString(),  '00:00:00.987654');
+    assert.equal(intervalValue(0, 0, 987654n).toString(), '00:00:00.987654');
     assert.equal(intervalValue(0, 0, -987654n).toString(), '-00:00:00.987654');
-    assert.equal(intervalValue(0, 0,  1000000n).toString(),  '00:00:01');
+    assert.equal(intervalValue(0, 0, 1000000n).toString(), '00:00:01');
     assert.equal(intervalValue(0, 0, -1000000n).toString(), '-00:00:01');
-    assert.equal(intervalValue(0, 0,  59n * 1000000n).toString(),  '00:00:59');
+    assert.equal(intervalValue(0, 0, 59n * 1000000n).toString(), '00:00:59');
     assert.equal(intervalValue(0, 0, -59n * 1000000n).toString(), '-00:00:59');
-    assert.equal(intervalValue(0, 0,  60n * 1000000n).toString(),  '00:01:00');
+    assert.equal(intervalValue(0, 0, 60n * 1000000n).toString(), '00:01:00');
     assert.equal(intervalValue(0, 0, -60n * 1000000n).toString(), '-00:01:00');
-    assert.equal(intervalValue(0, 0,  59n * 60n * 1000000n).toString(),  '00:59:00');
-    assert.equal(intervalValue(0, 0, -59n * 60n * 1000000n).toString(), '-00:59:00');
-    assert.equal(intervalValue(0, 0,  60n * 60n * 1000000n).toString(),  '01:00:00');
-    assert.equal(intervalValue(0, 0, -60n * 60n * 1000000n).toString(), '-01:00:00');
-    assert.equal(intervalValue(0, 0,  24n * 60n * 60n * 1000000n).toString(),  '24:00:00');
-    assert.equal(intervalValue(0, 0, -24n * 60n * 60n * 1000000n).toString(), '-24:00:00');
-    assert.equal(intervalValue(0, 0,  2147483647n * 60n * 60n * 1000000n).toString(),  '2147483647:00:00');
-    assert.equal(intervalValue(0, 0, -2147483647n * 60n * 60n * 1000000n).toString(), '-2147483647:00:00');
-    assert.equal(intervalValue(0, 0,   2147483647n * 60n * 60n * 1000000n + 1n ).toString(),  '2147483647:00:00.000001');
-    assert.equal(intervalValue(0, 0, -(2147483647n * 60n * 60n * 1000000n + 1n)).toString(), '-2147483647:00:00.000001');
+    assert.equal(
+      intervalValue(0, 0, 59n * 60n * 1000000n).toString(),
+      '00:59:00'
+    );
+    assert.equal(
+      intervalValue(0, 0, -59n * 60n * 1000000n).toString(),
+      '-00:59:00'
+    );
+    assert.equal(
+      intervalValue(0, 0, 60n * 60n * 1000000n).toString(),
+      '01:00:00'
+    );
+    assert.equal(
+      intervalValue(0, 0, -60n * 60n * 1000000n).toString(),
+      '-01:00:00'
+    );
+    assert.equal(
+      intervalValue(0, 0, 24n * 60n * 60n * 1000000n).toString(),
+      '24:00:00'
+    );
+    assert.equal(
+      intervalValue(0, 0, -24n * 60n * 60n * 1000000n).toString(),
+      '-24:00:00'
+    );
+    assert.equal(
+      intervalValue(0, 0, 2147483647n * 60n * 60n * 1000000n).toString(),
+      '2147483647:00:00'
+    );
+    assert.equal(
+      intervalValue(0, 0, -2147483647n * 60n * 60n * 1000000n).toString(),
+      '-2147483647:00:00'
+    );
+    assert.equal(
+      intervalValue(0, 0, 2147483647n * 60n * 60n * 1000000n + 1n).toString(),
+      '2147483647:00:00.000001'
+    );
+    assert.equal(
+      intervalValue(
+        0,
+        0,
+        -(2147483647n * 60n * 60n * 1000000n + 1n)
+      ).toString(),
+      '-2147483647:00:00.000001'
+    );
 
-    assert.equal(intervalValue(2 * 12 + 3, 5, (7n * 60n * 60n + 11n * 60n + 13n) * 1000000n + 17n).toString(),
-      '2 years 3 months 5 days 07:11:13.000017');
-    assert.equal(intervalValue(-(2 * 12 + 3), -5, -((7n * 60n * 60n + 11n * 60n + 13n) * 1000000n + 17n)).toString(),
-      '-2 years -3 months -5 days -07:11:13.000017');
+    assert.equal(
+      intervalValue(
+        2 * 12 + 3,
+        5,
+        (7n * 60n * 60n + 11n * 60n + 13n) * 1000000n + 17n
+      ).toString(),
+      '2 years 3 months 5 days 07:11:13.000017'
+    );
+    assert.equal(
+      intervalValue(
+        -(2 * 12 + 3),
+        -5,
+        -((7n * 60n * 60n + 11n * 60n + 13n) * 1000000n + 17n)
+      ).toString(),
+      '-2 years -3 months -5 days -07:11:13.000017'
+    );
 
     // list
     assert.equal(listValue([]).toString(), '[]');
@@ -893,102 +782,143 @@ describe('api', () => {
 
     // map
     assert.equal(mapValue([]).toString(), '{}');
-    assert.equal(mapValue([{ key: 1, value: 'a' }, { key: 2, value: 'b' }]).toString(), `{1: 'a', 2: 'b'}`);
+    assert.equal(
+      mapValue([
+        { key: 1, value: 'a' },
+        { key: 2, value: 'b' },
+      ]).toString(),
+      `{1: 'a', 2: 'b'}`
+    );
 
     // struct
     assert.equal(structValue({}).toString(), '{}');
-    assert.equal(structValue({a: 1, b: 2}).toString(), `{'a': 1, 'b': 2}`);
+    assert.equal(structValue({ a: 1, b: 2 }).toString(), `{'a': 1, 'b': 2}`);
 
     // timestamp milliseconds
-    assert.equal(DuckDBTimestampMillisecondsValue.Epoch.toString(), '1970-01-01 00:00:00');
-    assert.equal(DuckDBTimestampMillisecondsValue.Max.toString(), '294247-01-10 04:00:54.775');
-    assert.equal(DuckDBTimestampMillisecondsValue.Min.toString(), '290309-12-22 (BC) 00:00:00');
+    assert.equal(TIMESTAMP_MS.epoch.toString(), '1970-01-01 00:00:00');
+    assert.equal(TIMESTAMP_MS.max.toString(), '294247-01-10 04:00:54.775');
+    assert.equal(TIMESTAMP_MS.min.toString(), '290309-12-22 (BC) 00:00:00');
 
     // timestamp nanoseconds
-    assert.equal(DuckDBTimestampNanosecondsValue.Epoch.toString(), '1970-01-01 00:00:00');
-    assert.equal(DuckDBTimestampNanosecondsValue.Max.toString(), '2262-04-11 23:47:16.854775806');
-    assert.equal(DuckDBTimestampNanosecondsValue.Min.toString(), '1677-09-22 00:00:00');
+    assert.equal(TIMESTAMP_NS.epoch.toString(), '1970-01-01 00:00:00');
+    assert.equal(TIMESTAMP_NS.max.toString(), '2262-04-11 23:47:16.854775806');
+    assert.equal(TIMESTAMP_NS.min.toString(), '1677-09-22 00:00:00');
 
     // timestamp seconds
-    assert.equal(DuckDBTimestampSecondsValue.Epoch.toString(), '1970-01-01 00:00:00');
-    assert.equal(DuckDBTimestampSecondsValue.Max.toString(), '294247-01-10 04:00:54');
-    assert.equal(DuckDBTimestampSecondsValue.Min.toString(), '290309-12-22 (BC) 00:00:00');
+    assert.equal(TIMESTAMP_S.epoch.toString(), '1970-01-01 00:00:00');
+    assert.equal(TIMESTAMP_S.max.toString(), '294247-01-10 04:00:54');
+    assert.equal(TIMESTAMP_S.min.toString(), '290309-12-22 (BC) 00:00:00');
 
     // timestamp tz
-    assert.equal(DuckDBTimestampTZValue.Epoch.toString(), '1970-01-01 00:00:00');
-    // assert.equal(DuckDBTimestampTZValue.Max.toString(), '294247-01-09 20:00:54.775806-08'); // in PST
-    assert.equal(DuckDBTimestampTZValue.Max.toString(), '294247-01-10 04:00:54.775806'); // TODO TZ
-    // assert.equal(DuckDBTimestampTZValue.Min.toString(), '290309-12-21 (BC) 16:00:00-08'); // in PST
-    assert.equal(DuckDBTimestampTZValue.Min.toString(), '290309-12-22 (BC) 00:00:00'); // TODO TZ
-    assert.equal(DuckDBTimestampTZValue.PosInf.toString(), 'infinity');
-    assert.equal(DuckDBTimestampTZValue.NegInf.toString(), '-infinity');
+    assert.equal(TIMESTAMPTZ.epoch.toString(), '1970-01-01 00:00:00');
+    // assert.equal(TIMESTAMPTZ.max.toString(), '294247-01-09 20:00:54.775806-08'); // in PST
+    assert.equal(TIMESTAMPTZ.max.toString(), '294247-01-10 04:00:54.775806'); // TODO TZ
+    // assert.equal(TIMESTAMPTZ.min.toString(), '290309-12-21 (BC) 16:00:00-08'); // in PST
+    assert.equal(TIMESTAMPTZ.min.toString(), '290309-12-22 (BC) 00:00:00'); // TODO TZ
+    assert.equal(TIMESTAMPTZ.posInf.toString(), 'infinity');
+    assert.equal(TIMESTAMPTZ.negInf.toString(), '-infinity');
 
     // timestamp
-    assert.equal(DuckDBTimestampValue.Epoch.toString(), '1970-01-01 00:00:00');
-    assert.equal(DuckDBTimestampValue.Max.toString(), '294247-01-10 04:00:54.775806');
-    assert.equal(DuckDBTimestampValue.Min.toString(), '290309-12-22 (BC) 00:00:00');
-    assert.equal(DuckDBTimestampValue.PosInf.toString(), 'infinity');
-    assert.equal(DuckDBTimestampValue.NegInf.toString(), '-infinity');
+    assert.equal(TIMESTAMP.epoch.toString(), '1970-01-01 00:00:00');
+    assert.equal(TIMESTAMP.max.toString(), '294247-01-10 04:00:54.775806');
+    assert.equal(TIMESTAMP.min.toString(), '290309-12-22 (BC) 00:00:00');
+    assert.equal(TIMESTAMP.posInf.toString(), 'infinity');
+    assert.equal(TIMESTAMP.negInf.toString(), '-infinity');
 
     // time tz
     assert.equal(timeTZValue(0n, 0).toString(), '00:00:00');
-    // assert.equal(DuckDBTimeTZValue.Max.toString(), '24:00:00-15:59:59'); 
-    assert.equal(DuckDBTimeTZValue.Max.toString(), '24:00:00'); // TODO TZ
-    // assert.equal(DuckDBTimeTZValue.Max.toString(), '00:00:00+15:59:59'); 
-    assert.equal(DuckDBTimeTZValue.Min.toString(), '00:00:00'); // TODO TZ
+    // assert.equal(TIMETZ.max.toString(), '24:00:00-15:59:59');
+    assert.equal(TIMETZ.max.toString(), '24:00:00'); // TODO TZ
+    // assert.equal(TIMETZ.min.toString(), '00:00:00+15:59:59');
+    assert.equal(TIMETZ.min.toString(), '00:00:00'); // TODO TZ
 
     // time
-    assert.equal(DuckDBTimeValue.Max.toString(), '24:00:00');
-    assert.equal(DuckDBTimeValue.Min.toString(), '00:00:00');
-    assert.equal(timeValue((12n * 60n * 60n + 34n * 60n + 56n) * 1000000n + 987654n).toString(), '12:34:56.987654');
+    assert.equal(TIME.max.toString(), '24:00:00');
+    assert.equal(TIME.min.toString(), '00:00:00');
+    assert.equal(
+      timeValue(
+        (12n * 60n * 60n + 34n * 60n + 56n) * 1000000n + 987654n
+      ).toString(),
+      '12:34:56.987654'
+    );
 
     // union
     assert.equal(unionValue('a', 42).toString(), '42');
     assert.equal(unionValue('b', 'duck').toString(), 'duck');
 
     // uuid
-    assert.equal(DuckDBUUIDValue.Min.toString(), '00000000-0000-0000-0000-000000000000');
-    assert.equal(DuckDBUUIDValue.Max.toString(), 'ffffffff-ffff-ffff-ffff-ffffffffffff');
+    assert.equal(UUID.min.toString(), '00000000-0000-0000-0000-000000000000');
+    assert.equal(UUID.max.toString(), 'ffffffff-ffff-ffff-ffff-ffffffffffff');
   });
   test('date isFinite', () => {
-    assert.isTrue(DuckDBDateValue.Epoch.isFinite);
-    assert.isTrue(DuckDBDateValue.Max.isFinite);
-    assert.isTrue(DuckDBDateValue.Min.isFinite);
-    assert.isFalse(DuckDBDateValue.PosInf.isFinite);
-    assert.isFalse(DuckDBDateValue.NegInf.isFinite);
+    assert.isTrue(DATE.epoch.isFinite);
+    assert.isTrue(DATE.max.isFinite);
+    assert.isTrue(DATE.min.isFinite);
+    assert.isFalse(DATE.posInf.isFinite);
+    assert.isFalse(DATE.negInf.isFinite);
   });
   test('value conversion', () => {
     const dateParts: DateParts = { year: 2024, month: 6, day: 3 };
     const timeParts: TimeParts = { hour: 12, min: 34, sec: 56, micros: 789123 };
-    const timeTZParts: TimeTZParts = { time: timeParts, offset: DuckDBTimeTZValue.MinOffset };
+    const timeTZParts: TimeTZParts = {
+      time: timeParts,
+      offset: DuckDBTimeTZValue.MinOffset,
+    };
     const timestampParts: TimestampParts = { date: dateParts, time: timeParts };
 
     assert.deepEqual(DuckDBDateValue.fromParts(dateParts).toParts(), dateParts);
     assert.deepEqual(DuckDBTimeValue.fromParts(timeParts).toParts(), timeParts);
-    assert.deepEqual(DuckDBTimeTZValue.fromParts(timeTZParts).toParts(), timeTZParts);
-    assert.deepEqual(DuckDBTimestampValue.fromParts(timestampParts).toParts(), timestampParts);
-    assert.deepEqual(DuckDBTimestampTZValue.fromParts(timestampParts).toParts(), timestampParts);
+    assert.deepEqual(
+      DuckDBTimeTZValue.fromParts(timeTZParts).toParts(),
+      timeTZParts
+    );
+    assert.deepEqual(
+      DuckDBTimestampValue.fromParts(timestampParts).toParts(),
+      timestampParts
+    );
+    assert.deepEqual(
+      DuckDBTimestampTZValue.fromParts(timestampParts).toParts(),
+      timestampParts
+    );
 
-    assert.deepEqual(DuckDBDecimalValue.fromDouble(3.14159, 6, 5), decimalValue(314159n, 6, 5));
+    assert.deepEqual(
+      DuckDBDecimalValue.fromDouble(3.14159, 6, 5),
+      decimalValue(314159n, 6, 5)
+    );
     assert.deepEqual(decimalValue(314159n, 6, 5).toDouble(), 3.14159);
   });
   test('result inspection conveniences', async () => {
     await withConnection(async (connection) => {
-      const result = await connection.run('select i::int as a, i::int + 10 as b from range(3) t(i)');
+      const result = await connection.run(
+        'select i::int as a, i::int + 10 as b from range(3) t(i)'
+      );
       assert.deepEqual(result.columnNames(), ['a', 'b']);
-      assert.deepEqual(result.columnTypes(), [DuckDBIntegerType.instance, DuckDBIntegerType.instance]);
+      assert.deepEqual(result.columnTypes(), [INTEGER, INTEGER]);
       const chunks = await result.fetchAllChunks();
-      const chunkColumns = chunks.map(chunk => chunk.getColumns());
-      assert.deepEqual(chunkColumns, [[[0, 1, 2], [10, 11, 12]]]);
-      const chunkRows = chunks.map(chunk => chunk.getRows());
-      assert.deepEqual(chunkRows, [[[0, 10], [1, 11], [2, 12]]]);
+      const chunkColumns = chunks.map((chunk) => chunk.getColumns());
+      assert.deepEqual(chunkColumns, [
+        [
+          [0, 1, 2],
+          [10, 11, 12],
+        ],
+      ]);
+      const chunkRows = chunks.map((chunk) => chunk.getRows());
+      assert.deepEqual(chunkRows, [
+        [
+          [0, 10],
+          [1, 11],
+          [2, 12],
+        ],
+      ]);
     });
   });
   test('result reader', async () => {
     await withConnection(async (connection) => {
-      const reader = await connection.runAndReadAll('select i::int as a, i::int + 10000 as b from range(5000) t(i)');
+      const reader = await connection.runAndReadAll(
+        'select i::int as a, i::int + 10000 as b from range(5000) t(i)'
+      );
       assert.deepEqual(reader.columnNames(), ['a', 'b']);
-      assert.deepEqual(reader.columnTypes(), [DuckDBIntegerType.instance, DuckDBIntegerType.instance]);
+      assert.deepEqual(reader.columnTypes(), [INTEGER, INTEGER]);
       const columns = reader.getColumns();
       assert.equal(columns.length, 2);
       assert.equal(columns[0][0], 0);
@@ -1004,44 +934,58 @@ describe('api', () => {
   test('default duckdb_api without explicit options', async () => {
     const instance = await DuckDBInstance.create();
     const connection = await instance.connect();
-    const result = await connection.run(`select current_setting('duckdb_api') as duckdb_api`);
-    assertColumns(result, [{ name: 'duckdb_api', type: DuckDBVarCharType.instance }]);
+    const result = await connection.run(
+      `select current_setting('duckdb_api') as duckdb_api`
+    );
+    assertColumns(result, [{ name: 'duckdb_api', type: VARCHAR }]);
     const chunk = await result.fetchChunk();
     assert.isDefined(chunk);
     if (chunk) {
       assert.strictEqual(chunk.columnCount, 1);
       assert.strictEqual(chunk.rowCount, 1);
-      assertValues<string, DuckDBVarCharVector>(chunk, 0, DuckDBVarCharVector, ['node-neo-api']);
+      assertValues<string, DuckDBVarCharVector>(chunk, 0, DuckDBVarCharVector, [
+        'node-neo-api',
+      ]);
     }
   });
   test('default duckdb_api with explicit options', async () => {
     const instance = await DuckDBInstance.create(undefined, {});
     const connection = await instance.connect();
-    const result = await connection.run(`select current_setting('duckdb_api') as duckdb_api`);
-    assertColumns(result, [{ name: 'duckdb_api', type: DuckDBVarCharType.instance }]);
+    const result = await connection.run(
+      `select current_setting('duckdb_api') as duckdb_api`
+    );
+    assertColumns(result, [{ name: 'duckdb_api', type: VARCHAR }]);
     const chunk = await result.fetchChunk();
     assert.isDefined(chunk);
     if (chunk) {
       assert.strictEqual(chunk.columnCount, 1);
       assert.strictEqual(chunk.rowCount, 1);
-      assertValues<string, DuckDBVarCharVector>(chunk, 0, DuckDBVarCharVector, ['node-neo-api']);
+      assertValues<string, DuckDBVarCharVector>(chunk, 0, DuckDBVarCharVector, [
+        'node-neo-api',
+      ]);
     }
   });
   test('overriding duckdb_api', async () => {
-    const instance = await DuckDBInstance.create(undefined, { 'duckdb_api': 'custom-duckdb-api' });
+    const instance = await DuckDBInstance.create(undefined, {
+      'duckdb_api': 'custom-duckdb-api',
+    });
     const connection = await instance.connect();
-    const result = await connection.run(`select current_setting('duckdb_api') as duckdb_api`);
-    assertColumns(result, [{ name: 'duckdb_api', type: DuckDBVarCharType.instance }]);
+    const result = await connection.run(
+      `select current_setting('duckdb_api') as duckdb_api`
+    );
+    assertColumns(result, [{ name: 'duckdb_api', type: VARCHAR }]);
     const chunk = await result.fetchChunk();
     assert.isDefined(chunk);
     if (chunk) {
       assert.strictEqual(chunk.columnCount, 1);
       assert.strictEqual(chunk.rowCount, 1);
-      assertValues<string, DuckDBVarCharVector>(chunk, 0, DuckDBVarCharVector, ['custom-duckdb-api']);
+      assertValues<string, DuckDBVarCharVector>(chunk, 0, DuckDBVarCharVector, [
+        'custom-duckdb-api',
+      ]);
     }
   });
   test('write integer vector', () => {
-    const chunk = DuckDBDataChunk.create([DuckDBIntegerType.instance]);
+    const chunk = DuckDBDataChunk.create([INTEGER]);
     chunk.rowCount = 3;
     const vector = chunk.getColumnVector(0) as DuckDBIntegerVector;
     assert.equal(vector.itemCount, 3);
@@ -1053,7 +997,7 @@ describe('api', () => {
     assert.equal(vector.getItem(2), 67890);
   });
   test('write integer vector with nulls', () => {
-    const chunk = DuckDBDataChunk.create([DuckDBIntegerType.instance]);
+    const chunk = DuckDBDataChunk.create([INTEGER]);
     chunk.rowCount = 3;
     const vector = chunk.getColumnVector(0) as DuckDBIntegerVector;
     assert.equal(vector.itemCount, 3);
@@ -1068,7 +1012,7 @@ describe('api', () => {
     await withConnection(async (connection) => {
       const values = [42, 12345, null];
 
-      const chunk = DuckDBDataChunk.create([DuckDBIntegerType.instance]);
+      const chunk = DuckDBDataChunk.create([INTEGER]);
       chunk.rowCount = values.length;
       chunk.setColumnValues(0, values);
 
@@ -1092,7 +1036,7 @@ describe('api', () => {
       const baselineValues = [10, 11, 12];
       const targetValues = [42, 12345, null];
 
-      const chunk = DuckDBDataChunk.create([DuckDBIntegerType.instance]);
+      const chunk = DuckDBDataChunk.create([INTEGER]);
       chunk.rowCount = targetValues.length;
       const vector = chunk.getColumnVector(0) as DuckDBIntegerVector;
 
@@ -1143,7 +1087,7 @@ describe('api', () => {
     await withConnection(async (connection) => {
       const values = ['xyz', 'abcdefghijkl', 'ABCDEFGHIJKLM', null];
 
-      const chunk = DuckDBDataChunk.create([DuckDBVarCharType.instance]);
+      const chunk = DuckDBDataChunk.create([VARCHAR]);
       chunk.rowCount = values.length;
       chunk.setColumnValues(0, values);
 
@@ -1165,12 +1109,22 @@ describe('api', () => {
   test('create and append data chunk with blobs', async () => {
     await withConnection(async (connection) => {
       const values = [
-        blobValue(new Uint8Array([0xAB, 0xCD, 0xEF])),
-        blobValue(new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C])),
-        blobValue(new Uint8Array([0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D])),
+        blobValue(new Uint8Array([0xab, 0xcd, 0xef])),
+        blobValue(
+          new Uint8Array([
+            0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b,
+            0x0c,
+          ])
+        ),
+        blobValue(
+          new Uint8Array([
+            0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1a, 0x1b,
+            0x1c, 0x1d,
+          ])
+        ),
         null,
       ];
-      const chunk = DuckDBDataChunk.create([DuckDBBlobType.instance]);
+      const chunk = DuckDBDataChunk.create([BLOB]);
       chunk.rowCount = values.length;
       chunk.setColumnValues(0, values);
 
@@ -1198,7 +1152,7 @@ describe('api', () => {
         null,
       ];
 
-      const chunk = DuckDBDataChunk.create([new DuckDBListType(DuckDBIntegerType.instance)]);
+      const chunk = DuckDBDataChunk.create([LIST(INTEGER)]);
       chunk.rowCount = values.length;
       chunk.setColumnValues(0, values);
 
@@ -1226,7 +1180,7 @@ describe('api', () => {
         null,
       ];
 
-      const chunk = DuckDBDataChunk.create([new DuckDBArrayType(DuckDBIntegerType.instance, 3)]);
+      const chunk = DuckDBDataChunk.create([ARRAY(INTEGER, 3)]);
       chunk.rowCount = values.length;
       chunk.setColumnValues(0, values);
 
@@ -1254,7 +1208,7 @@ describe('api', () => {
         null,
       ];
 
-      const chunk = DuckDBDataChunk.create([new DuckDBArrayType(DuckDBVarCharType.instance, 3)]);
+      const chunk = DuckDBDataChunk.create([ARRAY(VARCHAR, 3)]);
       chunk.rowCount = values.length;
       chunk.setColumnValues(0, values);
 
@@ -1283,15 +1237,14 @@ describe('api', () => {
       ];
 
       const chunk = DuckDBDataChunk.create([
-        new DuckDBStructType(
-          ['num', 'str'],
-          [DuckDBIntegerType.instance, DuckDBVarCharType.instance]
-        ),
+        STRUCT({ 'num': INTEGER, 'str': VARCHAR }),
       ]);
       chunk.rowCount = values.length;
       chunk.setColumnValues(0, values);
 
-      await connection.run('create table target(col0 struct(num integer, str varchar))');
+      await connection.run(
+        'create table target(col0 struct(num integer, str varchar))'
+      );
       const appender = await connection.createAppender('main', 'target');
       appender.appendDataChunk(chunk);
       appender.flush();
@@ -1306,33 +1259,32 @@ describe('api', () => {
       }
     });
   });
-  test('create and append data chunk with all types', async () => {
+  test('create and append data chunk with rows', async () => {
     await withConnection(async (connection) => {
-      const types: DuckDBType[] = [
-        DuckDBBooleanType.instance,
-        DuckDBTinyIntType.instance,
-        DuckDBSmallIntType.instance,
-        DuckDBIntegerType.instance,
-      ];
+      const types: DuckDBType[] = [BOOLEAN, TINYINT, SMALLINT, INTEGER];
       const columnData: DuckDBValue[][] = [
         [false, true, null],
-        [DuckDBTinyIntType.Min, DuckDBTinyIntType.Max, null],
-        [DuckDBSmallIntType.Min, DuckDBSmallIntType.Max, null],
-        [DuckDBIntegerType.Min, DuckDBIntegerType.Max, null],
+        [TINYINT.min, TINYINT.max, null],
+        [SMALLINT.min, SMALLINT.max, null],
+        [INTEGER.min, INTEGER.max, null],
+      ];
+      const rows: DuckDBValue[][] = [
+        [false, TINYINT.min, SMALLINT.min, INTEGER.min],
+        [true, TINYINT.max, SMALLINT.max, INTEGER.max],
+        [null, null, null, null],
       ];
 
-      assert.equal(types.length, columnData.length);
-
       const chunk = DuckDBDataChunk.create(types);
-      chunk.rowCount = 3;
-      chunk.setColumns(columnData);
+      chunk.setRows(rows);
 
-      await connection.run('create table target(\
-        bool boolean,\
-        tinyint tinyint,\
-        smallint smallint,\
-        int integer\
-      )');
+      await connection.run(
+        'create table target(\
+          bool boolean,\
+          tinyint tinyint,\
+          smallint smallint,\
+          int integer\
+        )'
+      );
       const appender = await connection.createAppender('main', 'target');
       appender.appendDataChunk(chunk);
       appender.flush();
@@ -1350,35 +1302,25 @@ describe('api', () => {
       }
     });
   });
-  test('create and append data chunk with rows', async () => {
+  test('create and append data chunk with all types', async () => {
     await withConnection(async (connection) => {
-      const types: DuckDBType[] = [
-        DuckDBBooleanType.instance,
-        DuckDBTinyIntType.instance,
-        DuckDBSmallIntType.instance,
-        DuckDBIntegerType.instance,
-      ];
-      const columnData: DuckDBValue[][] = [
-        [false, true, null],
-        [DuckDBTinyIntType.Min, DuckDBTinyIntType.Max, null],
-        [DuckDBSmallIntType.Min, DuckDBSmallIntType.Max, null],
-        [DuckDBIntegerType.Min, DuckDBIntegerType.Max, null],
-      ];
-      const rows: DuckDBValue[][] = [
-        [false, DuckDBTinyIntType.Min, DuckDBSmallIntType.Min, DuckDBIntegerType.Min],
-        [true, DuckDBTinyIntType.Max, DuckDBSmallIntType.Max, DuckDBIntegerType.Max],
-        [null, null, null, null],
-      ];
+      const columnCount = 5;
+      const types = testAllTypesColumnTypes.slice(0, columnCount);
+      const columns = testAllTypesColumns.slice(0, columnCount);
+      const columnNamesAndTypes = testAllTypesColumnsNamesAndTypes.slice(
+        0,
+        columnCount
+      );
 
       const chunk = DuckDBDataChunk.create(types);
-      chunk.setRows(rows);
+      chunk.rowCount = 3;
+      chunk.setColumns(columns);
 
-      await connection.run('create table target(\
-        bool boolean,\
-        tinyint tinyint,\
-        smallint smallint,\
-        int integer\
-      )');
+      await connection.run(
+        `create table target(${columnNamesAndTypes
+          .map(({ name, type }) => `${name} ${type}`)
+          .join(', ')})`
+      );
       const appender = await connection.createAppender('main', 'target');
       appender.appendDataChunk(chunk);
       appender.flush();
@@ -1387,12 +1329,13 @@ describe('api', () => {
       const resultChunk = await result.fetchChunk();
       assert.isDefined(resultChunk);
       if (resultChunk) {
-        assert.strictEqual(resultChunk.columnCount, types.length);
+        assert.strictEqual(resultChunk.columnCount, columns.length);
         assert.strictEqual(resultChunk.rowCount, 3);
-        assertValues(resultChunk, 0, DuckDBBooleanVector, columnData[0]);
-        assertValues(resultChunk, 1, DuckDBTinyIntVector, columnData[1]);
-        assertValues(resultChunk, 2, DuckDBSmallIntVector, columnData[2]);
-        assertValues(resultChunk, 3, DuckDBIntegerVector, columnData[3]);
+        assertValues(resultChunk, 0, DuckDBBooleanVector, columns[0]);
+        assertValues(resultChunk, 1, DuckDBTinyIntVector, columns[1]);
+        assertValues(resultChunk, 2, DuckDBSmallIntVector, columns[2]);
+        assertValues(resultChunk, 3, DuckDBIntegerVector, columns[3]);
+        assertValues(resultChunk, 4, DuckDBBigIntVector, columns[4]);
       }
     });
   });

--- a/api/test/util/testAllTypes.ts
+++ b/api/test/util/testAllTypes.ts
@@ -1,0 +1,350 @@
+import {
+  ARRAY,
+  arrayValue,
+  BIGINT,
+  BIT,
+  bitValue,
+  BLOB,
+  blobValue,
+  BOOLEAN,
+  DATE,
+  dateValue,
+  DECIMAL,
+  decimalValue,
+  DOUBLE,
+  DuckDBType,
+  DuckDBValue,
+  ENUM16,
+  ENUM32,
+  ENUM8,
+  FLOAT,
+  HUGEINT,
+  INTEGER,
+  INTERVAL,
+  intervalValue,
+  LIST,
+  listValue,
+  MAP,
+  mapValue,
+  SMALLINT,
+  STRUCT,
+  structValue,
+  TIME,
+  TIMESTAMP,
+  TIMESTAMP_MS,
+  TIMESTAMP_NS,
+  TIMESTAMP_S,
+  TIMESTAMPTZ,
+  timestampTZValue,
+  timestampValue,
+  TIMETZ,
+  TINYINT,
+  UBIGINT,
+  UHUGEINT,
+  UINTEGER,
+  UNION,
+  unionValue,
+  USMALLINT,
+  UTINYINT,
+  UUID,
+  VARCHAR,
+  VARINT,
+} from '../../src';
+
+const BI_10_8 = 100000000n;
+const BI_10_10 = 10000000000n;
+const BI_18_9s = BI_10_8 * BI_10_10 - 1n;
+const BI_38_9s = BI_10_8 * BI_10_10 * BI_10_10 * BI_10_10 - 1n;
+
+const smallEnumValues = ['DUCK_DUCK_ENUM', 'GOOSE'];
+const mediumEnumValues = Array.from({ length: 300 }).map((_, i) => `enum_${i}`);
+const largeEnumValues = Array.from({ length: 70000 }).map(
+  (_, i) => `enum_${i}`
+);
+
+export interface ColumnNameAndType {
+  readonly name: string;
+  readonly type: DuckDBType;
+}
+
+export interface ColumnNameTypeAndRows extends ColumnNameAndType {
+  readonly name: string;
+  readonly type: DuckDBType;
+  readonly rows: readonly DuckDBValue[];
+}
+
+function col(
+  name: string,
+  type: DuckDBType,
+  rows: readonly DuckDBValue[]
+): ColumnNameTypeAndRows {
+  return { name, type, rows };
+}
+
+export const testAllTypesData: ColumnNameTypeAndRows[] = [
+  col('bool', BOOLEAN, [false, true, null]),
+  col('tinyint', TINYINT, [TINYINT.min, TINYINT.max, null]),
+  col('smallint', SMALLINT, [SMALLINT.min, SMALLINT.max, null]),
+  col('int', INTEGER, [INTEGER.min, INTEGER.max, null]),
+  col('bigint', BIGINT, [BIGINT.min, BIGINT.max, null]),
+  col('hugeint', HUGEINT, [HUGEINT.min, HUGEINT.max, null]),
+  col('uhugeint', UHUGEINT, [UHUGEINT.min, UHUGEINT.max, null]),
+  col('utinyint', UTINYINT, [UTINYINT.min, UTINYINT.max, null]),
+  col('usmallint', USMALLINT, [USMALLINT.min, USMALLINT.max, null]),
+  col('uint', UINTEGER, [UINTEGER.min, UINTEGER.max, null]),
+  col('ubigint', UBIGINT, [UBIGINT.min, UBIGINT.max, null]),
+  col('varint', VARINT, [VARINT.min, VARINT.max, null]),
+  col('date', DATE, [DATE.min, DATE.max, null]),
+  col('time', TIME, [TIME.min, TIME.max, null]),
+  col('timestamp', TIMESTAMP, [TIMESTAMP.min, TIMESTAMP.max, null]),
+  col('timestamp_s', TIMESTAMP_S, [TIMESTAMP_S.min, TIMESTAMP_S.max, null]),
+  col('timestamp_ms', TIMESTAMP_MS, [TIMESTAMP_MS.min, TIMESTAMP_MS.max, null]),
+  col('timestamp_ns', TIMESTAMP_NS, [TIMESTAMP_NS.min, TIMESTAMP_NS.max, null]),
+  col('time_tz', TIMETZ, [TIMETZ.min, TIMETZ.max, null]),
+  col('timestamp_tz', TIMESTAMPTZ, [TIMESTAMPTZ.min, TIMESTAMPTZ.max, null]),
+  col('float', FLOAT, [FLOAT.min, FLOAT.max, null]),
+  col('double', DOUBLE, [DOUBLE.min, DOUBLE.max, null]),
+  col('dec_4_1', DECIMAL(4, 1), [
+    decimalValue(-9999n, 4, 1),
+    decimalValue(9999n, 4, 1),
+    null,
+  ]),
+  col('dec_9_4', DECIMAL(9, 4), [
+    decimalValue(-999999999n, 9, 4),
+    decimalValue(999999999n, 9, 4),
+    null,
+  ]),
+  col('dec_18_6', DECIMAL(18, 6), [
+    decimalValue(-BI_18_9s, 18, 6),
+    decimalValue(BI_18_9s, 18, 6),
+    null,
+  ]),
+  col('dec38_10', DECIMAL(38, 10), [
+    decimalValue(-BI_38_9s, 38, 10),
+    decimalValue(BI_38_9s, 38, 10),
+    null,
+  ]),
+  col('uuid', UUID, [UUID.min, UUID.max, null]),
+  col('interval', INTERVAL, [
+    intervalValue(0, 0, 0n),
+    intervalValue(999, 999, 999999999n),
+    null,
+  ]),
+  col('varchar', VARCHAR, ['🦆🦆🦆🦆🦆🦆', 'goo\0se', null]),
+  col('blob', BLOB, [
+    blobValue('thisisalongblob\x00withnullbytes'),
+    blobValue('\x00\x00\x00a'),
+    null,
+  ]),
+  col('bit', BIT, [
+    bitValue('0010001001011100010101011010111'),
+    bitValue('10101'),
+    null,
+  ]),
+  col('small_enum', ENUM8(smallEnumValues), [
+    smallEnumValues[0],
+    smallEnumValues[smallEnumValues.length - 1],
+    null,
+  ]),
+  col('medium_enum', ENUM16(mediumEnumValues), [
+    mediumEnumValues[0],
+    mediumEnumValues[mediumEnumValues.length - 1],
+    null,
+  ]),
+  col('large_enum', ENUM32(largeEnumValues), [
+    largeEnumValues[0],
+    largeEnumValues[largeEnumValues.length - 1],
+    null,
+  ]),
+  col('int_array', LIST(INTEGER), [
+    listValue([]),
+    listValue([42, 999, null, null, -42]),
+    null,
+  ]),
+  col('double_array', LIST(DOUBLE), [
+    listValue([]),
+    listValue([42.0, NaN, Infinity, -Infinity, null, -42.0]),
+    null,
+  ]),
+  col('date_array', LIST(DATE), [
+    listValue([]),
+    // 19124 days from the epoch is 2022-05-12
+    listValue([DATE.epoch, DATE.posInf, DATE.negInf, null, dateValue(19124)]),
+    null,
+  ]),
+  col('timestamp_array', LIST(TIMESTAMP), [
+    listValue([]),
+    listValue([
+      TIMESTAMP.epoch,
+      TIMESTAMP.posInf,
+      TIMESTAMP.negInf,
+      null,
+      // 1652372625 seconds from the epoch is 2022-05-12 16:23:45
+      timestampValue(1652372625n * 1000n * 1000n),
+    ]),
+    null,
+  ]),
+  col('timestamptz_array', LIST(TIMESTAMPTZ), [
+    listValue([]),
+    listValue([
+      TIMESTAMPTZ.epoch,
+      TIMESTAMPTZ.posInf,
+      TIMESTAMPTZ.negInf,
+      null,
+      // 1652397825 = 1652372625 + 25200, 25200 = 7 * 60 * 60 = 7 hours in seconds
+      // This 7 hour difference is hard coded into test_all_types (value is 2022-05-12 16:23:45-07)
+      timestampTZValue(1652397825n * 1000n * 1000n),
+    ]),
+    null,
+  ]),
+  col('varchar_array', LIST(VARCHAR), [
+    listValue([]),
+    // Note that the string 'goose' in varchar_array does NOT have an embedded null character.
+    listValue(['🦆🦆🦆🦆🦆🦆', 'goose', null, '']),
+    null,
+  ]),
+  col('nested_int_array', LIST(LIST(INTEGER)), [
+    listValue([]),
+    listValue([
+      listValue([]),
+      listValue([42, 999, null, null, -42]),
+      null,
+      listValue([]),
+      listValue([42, 999, null, null, -42]),
+    ]),
+    null,
+  ]),
+  col('struct', STRUCT({ 'a': INTEGER, 'b': VARCHAR }), [
+    structValue({ 'a': null, 'b': null }),
+    structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
+    null,
+  ]),
+  col('struct_of_arrays', STRUCT({ 'a': LIST(INTEGER), 'b': LIST(VARCHAR) }), [
+    structValue({ 'a': null, 'b': null }),
+    structValue({
+      'a': listValue([42, 999, null, null, -42]),
+      'b': listValue(['🦆🦆🦆🦆🦆🦆', 'goose', null, '']),
+    }),
+    null,
+  ]),
+  col('array_of_structs', LIST(STRUCT({ 'a': INTEGER, 'b': VARCHAR })), [
+    listValue([]),
+    listValue([
+      structValue({ 'a': null, 'b': null }),
+      structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
+      null,
+    ]),
+    null,
+  ]),
+  col('map', MAP(VARCHAR, VARCHAR), [
+    mapValue([]),
+    mapValue([
+      { key: 'key1', value: '🦆🦆🦆🦆🦆🦆' },
+      { key: 'key2', value: 'goose' },
+    ]),
+    null,
+  ]),
+  col('union', UNION({ 'name': VARCHAR, 'age': SMALLINT }), [
+    unionValue('name', 'Frank'),
+    unionValue('age', 5),
+    null,
+  ]),
+  col('fixed_int_array', ARRAY(INTEGER, 3), [
+    arrayValue([null, 2, 3]),
+    arrayValue([4, 5, 6]),
+    null,
+  ]),
+  col('fixed_varchar_array', ARRAY(VARCHAR, 3), [
+    arrayValue(['a', null, 'c']),
+    arrayValue(['d', 'e', 'f']),
+    null,
+  ]),
+  col('fixed_nested_int_array', ARRAY(ARRAY(INTEGER, 3), 3), [
+    arrayValue([arrayValue([null, 2, 3]), null, arrayValue([null, 2, 3])]),
+    arrayValue([
+      arrayValue([4, 5, 6]),
+      arrayValue([null, 2, 3]),
+      arrayValue([4, 5, 6]),
+    ]),
+    null,
+  ]),
+  col('fixed_nested_varchar_array', ARRAY(ARRAY(VARCHAR, 3), 3), [
+    arrayValue([
+      arrayValue(['a', null, 'c']),
+      null,
+      arrayValue(['a', null, 'c']),
+    ]),
+    arrayValue([
+      arrayValue(['d', 'e', 'f']),
+      arrayValue(['a', null, 'c']),
+      arrayValue(['d', 'e', 'f']),
+    ]),
+    null,
+  ]),
+  col('fixed_struct_array', ARRAY(STRUCT({ 'a': INTEGER, 'b': VARCHAR }), 3), [
+    arrayValue([
+      structValue({ 'a': null, 'b': null }),
+      structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
+      structValue({ 'a': null, 'b': null }),
+    ]),
+    arrayValue([
+      structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
+      structValue({ 'a': null, 'b': null }),
+      structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
+    ]),
+    null,
+  ]),
+  col(
+    'struct_of_fixed_array',
+    STRUCT({ 'a': ARRAY(INTEGER, 3), 'b': ARRAY(VARCHAR, 3) }),
+    [
+      structValue({
+        'a': arrayValue([null, 2, 3]),
+        'b': arrayValue(['a', null, 'c']),
+      }),
+      structValue({
+        'a': arrayValue([4, 5, 6]),
+        'b': arrayValue(['d', 'e', 'f']),
+      }),
+      null,
+    ]
+  ),
+  col('fixed_array_of_int_list', ARRAY(LIST(INTEGER), 3), [
+    arrayValue([
+      listValue([]),
+      listValue([42, 999, null, null, -42]),
+      listValue([]),
+    ]),
+    arrayValue([
+      listValue([42, 999, null, null, -42]),
+      listValue([]),
+      listValue([42, 999, null, null, -42]),
+    ]),
+    null,
+  ]),
+  col('list_of_fixed_int_array', LIST(ARRAY(INTEGER, 3)), [
+    listValue([
+      arrayValue([null, 2, 3]),
+      arrayValue([4, 5, 6]),
+      arrayValue([null, 2, 3]),
+    ]),
+    listValue([
+      arrayValue([4, 5, 6]),
+      arrayValue([null, 2, 3]),
+      arrayValue([4, 5, 6]),
+    ]),
+    null,
+  ]),
+];
+
+export const testAllTypesColumnNames: readonly string[] =
+  testAllTypesData.map(({ name }) => name);
+
+export const testAllTypesColumnTypes: readonly DuckDBType[] =
+  testAllTypesData.map(({ type }) => type);
+
+export const testAllTypesColumnsNamesAndTypes: readonly ColumnNameAndType[] =
+  testAllTypesData.map(({ name, type }) => ({ name, type }));
+
+export const testAllTypesColumns: readonly (readonly DuckDBValue[])[] =
+  testAllTypesData.map(({ rows }) => rows);

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -1110,3 +1110,23 @@ export function fetch_chunk(result: Result): Promise<DataChunk | null>;
  * Used to read from `duckdb_string_t`s with non-inlined data that are embedded in VARCHAR, BLOB, and BIT vectors.
  */
 export function get_data_from_pointer(array_buffer: ArrayBuffer, pointer_offset: number, byte_count: number): Uint8Array;
+
+// ADDED
+/** 
+ * Copy `source_byte_count` bytes from `source_buffer` at `source_byte_offset` into `target_vector` at `target_byte_offset`.
+ * 
+ * Used to write to data chunks.
+ *
+ * Performs an efficient-but-unsafe memory copy. Use with care.
+ */
+export function copy_data_to_vector(target_vector: Vector, target_byte_offset: number, source_buffer: ArrayBuffer, source_byte_offset: number, source_byte_count: number): void;
+
+// ADDED
+/** 
+ * Copy `source_byte_count` bytes from `source_buffer` at `source_byte_offset` into the validity of `target_vector` at `target_byte_offset`.
+ * 
+ * Used to write to data chunks.
+ *
+ * Performs an efficient-but-unsafe memory copy. Use with care.
+ */
+export function copy_data_to_vector_validity(target_vector: Vector, target_byte_offset: number, source_buffer: ArrayBuffer, source_byte_offset: number, source_byte_count: number): void;

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -840,7 +840,7 @@ export function vector_ensure_validity_writable(vector: Vector): void;
 export function vector_assign_string_element(vector: Vector, index: number, str: string): void;
 
 // DUCKDB_API void duckdb_vector_assign_string_element_len(duckdb_vector vector, idx_t index, const char *str, idx_t str_len);
-// not exposed: JS string includes length
+export function vector_assign_string_element_len(vector: Vector, index: number, data: Uint8Array): void;
 
 // DUCKDB_API duckdb_vector duckdb_list_vector_get_child(duckdb_vector vector);
 export function list_vector_get_child(vector: Vector): Vector;

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -1174,6 +1174,8 @@ public:
       InstanceMethod("fetch_chunk", &DuckDBNodeAddon::fetch_chunk),
 
       InstanceMethod("get_data_from_pointer", &DuckDBNodeAddon::get_data_from_pointer),
+      InstanceMethod("copy_data_to_vector", &DuckDBNodeAddon::copy_data_to_vector),
+      InstanceMethod("copy_data_to_vector_validity", &DuckDBNodeAddon::copy_data_to_vector_validity),
     });
   }
 
@@ -3685,6 +3687,34 @@ private:
     return Napi::Buffer<uint8_t>::NewOrCopy(env, pointer, byte_count);
   }
 
+  // ADDED
+  // function copy_data_to_vector(target_vector: Vector, target_byte_offset: number, source_buffer: ArrayBuffer, source_byte_offset: number, source_byte_count: number): void
+  Napi::Value copy_data_to_vector(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto target_vector = GetVectorFromExternal(env, info[0]);
+    auto target_byte_offset = info[1].As<Napi::Number>().Uint32Value();
+    auto source_data = reinterpret_cast<uint8_t*>(info[2].As<Napi::ArrayBuffer>().Data());
+    auto source_byte_offset = info[3].As<Napi::Number>().Uint32Value();
+    auto source_byte_count = info[4].As<Napi::Number>().Uint32Value();
+    auto target_data = reinterpret_cast<uint8_t*>(duckdb_vector_get_data(target_vector));
+    memcpy(target_data + target_byte_offset, source_data + source_byte_offset, source_byte_count);
+    return env.Undefined();
+  }
+
+  // ADDED
+  // function copy_data_to_vector_validity(target_vector: Vector, target_byte_offset: number, source_buffer: ArrayBuffer, source_byte_offset: number, source_byte_count: number): void
+  Napi::Value copy_data_to_vector_validity(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto target_vector = GetVectorFromExternal(env, info[0]);
+    auto target_byte_offset = info[1].As<Napi::Number>().Uint32Value();
+    auto source_data = reinterpret_cast<uint8_t*>(info[2].As<Napi::ArrayBuffer>().Data());
+    auto source_byte_offset = info[3].As<Napi::Number>().Uint32Value();
+    auto source_byte_count = info[4].As<Napi::Number>().Uint32Value();
+    auto target_data = reinterpret_cast<uint8_t*>(duckdb_vector_get_validity(target_vector));
+    memcpy(target_data + target_byte_offset, source_data + source_byte_offset, source_byte_count);
+    return env.Undefined();
+  }
+
 };
 
 NODE_API_ADDON(DuckDBNodeAddon)
@@ -3692,11 +3722,11 @@ NODE_API_ADDON(DuckDBNodeAddon)
 /*
 
   371 duckdb api functions
-+   1 added function
++   3 added functions
   ---
-  372 total functions
+  374 total functions
 
-  206 instance methods
+  209 instance methods
     1 unimplemented logical type functions
    13 unimplemented scalar function functions
     4 unimplemented scalar function set functions
@@ -3711,9 +3741,9 @@ NODE_API_ADDON(DuckDBNodeAddon)
     4 unimplemented table description functions
     8 unimplemented tasks functions
    12 unimplemented cast function functions
-   26 functions not exposed
+   25 functions not exposed
 +  41 unimplemented deprecated functions (of 47)
   ---
-  372 functions accounted for
+  374 functions accounted for
 
 */

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -3072,7 +3072,9 @@ private:
     auto vector = GetVectorFromExternal(env, info[0]);
     auto index = info[1].As<Napi::Number>().Uint32Value();
     std::string str = info[2].As<Napi::String>();
-    duckdb_vector_assign_string_element(vector, index, str.c_str());
+    auto size = str.size();
+    // Use the _len variant to handle embedded null characters.
+    duckdb_vector_assign_string_element_len(vector, index, str.c_str(), size);
     return env.Undefined();
   }
   

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -1131,6 +1131,7 @@ public:
       InstanceMethod("vector_get_validity", &DuckDBNodeAddon::vector_get_validity),
       InstanceMethod("vector_ensure_validity_writable", &DuckDBNodeAddon::vector_ensure_validity_writable),
       InstanceMethod("vector_assign_string_element", &DuckDBNodeAddon::vector_assign_string_element),
+      InstanceMethod("vector_assign_string_element_len", &DuckDBNodeAddon::vector_assign_string_element_len),
       InstanceMethod("list_vector_get_child", &DuckDBNodeAddon::list_vector_get_child),
       InstanceMethod("list_vector_get_size", &DuckDBNodeAddon::list_vector_get_size),
       InstanceMethod("list_vector_set_size", &DuckDBNodeAddon::list_vector_set_size),
@@ -3076,7 +3077,17 @@ private:
   }
   
   // DUCKDB_API void duckdb_vector_assign_string_element_len(duckdb_vector vector, idx_t index, const char *str, idx_t str_len);
-  // not exposed: JS string includes length
+  // function vector_assign_string_element_len(vector: Vector, index: number, data: Uint8Array): void
+  Napi::Value vector_assign_string_element_len(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto vector = GetVectorFromExternal(env, info[0]);
+    auto index = info[1].As<Napi::Number>().Uint32Value();
+    auto array = info[2].As<Napi::Uint8Array>();
+    auto data = reinterpret_cast<const char *>(array.Data());
+    auto length = array.ByteLength();
+    duckdb_vector_assign_string_element_len(vector, index, data, length);
+    return env.Undefined();
+  }
 
   // DUCKDB_API duckdb_vector duckdb_list_vector_get_child(duckdb_vector vector);
   // function list_vector_get_child(vector: Vector): Vector
@@ -3726,7 +3737,7 @@ NODE_API_ADDON(DuckDBNodeAddon)
   ---
   374 total functions
 
-  209 instance methods
+  210 instance methods
     1 unimplemented logical type functions
    13 unimplemented scalar function functions
     4 unimplemented scalar function set functions
@@ -3741,7 +3752,7 @@ NODE_API_ADDON(DuckDBNodeAddon)
     4 unimplemented table description functions
     8 unimplemented tasks functions
    12 unimplemented cast function functions
-   25 functions not exposed
+   24 functions not exposed
 +  41 unimplemented deprecated functions (of 47)
   ---
   374 functions accounted for

--- a/bindings/test/data_chunk.test.ts
+++ b/bindings/test/data_chunk.test.ts
@@ -90,6 +90,26 @@ suite('data chunk', () => {
     expect(dv.getUint32(32, true)).toBe('longer than twelve characters'.length);
     expect([data[36], data[37], data[38], data[39]]).toStrictEqual([0x6c, 0x6f, 0x6e, 0x67]); // l, o, n, g
   });
+  test('write blob vector', () => {
+    const blob_type = duckdb.create_logical_type(duckdb.Type.BLOB);
+    const chunk = duckdb.create_data_chunk([blob_type]);
+    duckdb.data_chunk_set_size(chunk, 3);
+    const vector = duckdb.data_chunk_get_vector(chunk, 0);
+    duckdb.vector_assign_string_element_len(vector, 0, new Uint8Array([0xAB, 0xCD, 0xEF]));
+    duckdb.vector_assign_string_element_len(vector, 1,
+      new Uint8Array([0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C]));
+    duckdb.vector_assign_string_element_len(vector, 2,
+      new Uint8Array([0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D])
+    );
+    const data = duckdb.vector_get_data(vector, 3 * 16);
+    const dv = new DataView(data.buffer);
+    expect(dv.getUint32(0, true)).toBe(3);
+    expect([data[4], data[5], data[6]]).toStrictEqual([0xAB, 0xCD, 0xEF]);
+    expect(dv.getUint32(16, true)).toBe(12);
+    expect([data[20], data[31]]).toStrictEqual([0x01, 0x0C]);
+    expect(dv.getUint32(32, true)).toBe(13);
+    expect([data[36], data[37], data[38], data[39]]).toStrictEqual([0x11, 0x12, 0x13, 0x14]);
+  });
   test('set list vector size', () => {
     const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
     const list_type = duckdb.create_list_type(int_type);

--- a/bindings/test/data_chunk.test.ts
+++ b/bindings/test/data_chunk.test.ts
@@ -110,6 +110,19 @@ suite('data chunk', () => {
     expect(dv.getUint32(32, true)).toBe(13);
     expect([data[36], data[37], data[38], data[39]]).toStrictEqual([0x11, 0x12, 0x13, 0x14]);
   });
+  test.skip('write varint vector', () => { // See https://github.com/duckdb/duckdb/pull/15670
+    const varint_type = duckdb.create_logical_type(duckdb.Type.VARINT);
+    const chunk = duckdb.create_data_chunk([varint_type]);
+    duckdb.data_chunk_set_size(chunk, 1);
+    const vector = duckdb.data_chunk_get_vector(chunk, 0);
+    expect(vector).toBeDefined();
+    duckdb.vector_assign_string_element_len(vector, 0, new Uint8Array([0x80, 0x00, 0x01, 0x2a])); // VARINT 42
+    const data = duckdb.vector_get_data(vector, 1);
+    expect(data).toBeDefined();
+    const dv = new DataView(data.buffer);
+    expect(dv.getUint32(0, true)).toBe(4);
+    expect([data[4], data[5], data[6], data[7]]).toStrictEqual([0x80, 0x00, 0x01, 0x2a]); // VARINT 42
+  });
   test('set list vector size', () => {
     const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
     const list_type = duckdb.create_list_type(int_type);


### PR DESCRIPTION
- Support writing to vectors of all types.
- Add convenience methods for writing to data chunks.
- Add convenience methods for creating types, as well as convenience getters for important values of each type.
- Add way to get a DuckDBLogicalType from a DuckDBType.
- Refactor data for test_all_types so it can be shared with appender tests.
- Add many tests for writing vectors, data chunks, and appending data chunks, including an "append all data types" test.
- To support the above, add two new functions to the bindings layer, for writing data to vector and validity buffers.
