### PR TITLE
bind helper

### DIFF
--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -110,6 +110,22 @@ prepared.bindList(3, listValue([10, 11, 12]), LIST(INTEGER));
 const result = await prepared.run();
 ```
 
+or:
+
+```ts
+const prepared = await connection.prepare('select $a, $b, $c');
+prepared.bind({
+  'a': 'duck',
+  'b': 42,
+  'c': listValue([10, 11, 12]),
+}, {
+  'a': VARCHAR,
+  'b': INTEGER,
+  'c': LIST(INTEGER),
+});
+const result = await prepared.run();
+```
+
 ### Stream Results
 
 Streaming results evaluate lazily when rows are read.

--- a/api/src/DuckDBPreparedStatement.ts
+++ b/api/src/DuckDBPreparedStatement.ts
@@ -14,6 +14,7 @@ import {
 } from './DuckDBType';
 import { DuckDBTypeId } from './DuckDBTypeId';
 import { StatementType } from './enums';
+import { typeForValue } from './typeForValue';
 import {
   DuckDBArrayValue,
   DuckDBDateValue,
@@ -162,6 +163,20 @@ export class DuckDBPreparedStatement {
       parameterIndex,
       createValue(type, value)
     );
+  }
+  public bind(values: DuckDBValue[] | Record<string, DuckDBValue>, types?: DuckDBType[] | Record<string, DuckDBType>) {
+    if (Array.isArray(values)) {
+      const typesIsArray = Array.isArray(types);
+      for (let i = 0; i < values.length; i++) {
+        this.bindValue(i + 1, values[i], typesIsArray ? types[i] : typeForValue(values[i]));
+      }
+    } else {
+      const typesIsRecord = types && !Array.isArray(types);
+      for (const key in values) {
+        const index = this.parameterIndex(key);
+        this.bindValue(index, values[key], typesIsRecord ? types[key] : typeForValue(values[key]));
+      }
+    }
   }
   public async run(): Promise<DuckDBMaterializedResult> {
     return new DuckDBMaterializedResult(

--- a/api/src/DuckDBVector.ts
+++ b/api/src/DuckDBVector.ts
@@ -3283,7 +3283,6 @@ export class DuckDBUnionVector extends DuckDBVector<DuckDBUnionValue> {
   public override setItem(itemIndex: number, value: DuckDBUnionValue | null) {
     if (value != null) {
       const memberIndex = this.unionType.memberIndexForTag(value.tag);
-      console.log({ value, memberIndex });
       this.structVector.setItemValue(itemIndex, 0, memberIndex);
       const entryIndex = memberIndex + 1;
       this.structVector.setItemValue(itemIndex, entryIndex, value.value);

--- a/api/src/typeForValue.ts
+++ b/api/src/typeForValue.ts
@@ -1,0 +1,112 @@
+import {
+  ANY,
+  ARRAY,
+  BIT,
+  BLOB,
+  BOOLEAN,
+  DATE,
+  DECIMAL,
+  DOUBLE,
+  DuckDBType,
+  HUGEINT,
+  INTERVAL,
+  LIST,
+  MAP,
+  SQLNULL,
+  STRUCT,
+  TIME,
+  TIMESTAMP,
+  TIMESTAMP_MS,
+  TIMESTAMP_NS,
+  TIMESTAMP_S,
+  TIMESTAMPTZ,
+  TIMETZ,
+  UNION,
+  UUID,
+  VARCHAR,
+} from './DuckDBType';
+import {
+  DuckDBArrayValue,
+  DuckDBBitValue,
+  DuckDBBlobValue,
+  DuckDBDateValue,
+  DuckDBDecimalValue,
+  DuckDBIntervalValue,
+  DuckDBListValue,
+  DuckDBMapValue,
+  DuckDBStructValue,
+  DuckDBTimestampMillisecondsValue,
+  DuckDBTimestampNanosecondsValue,
+  DuckDBTimestampSecondsValue,
+  DuckDBTimestampTZValue,
+  DuckDBTimestampValue,
+  DuckDBTimeTZValue,
+  DuckDBTimeValue,
+  DuckDBUnionValue,
+  DuckDBUUIDValue,
+  DuckDBValue,
+} from './values';
+
+export function typeForValue(value: DuckDBValue): DuckDBType {
+  if (value === null) {
+    return SQLNULL;
+  } else {
+    switch (typeof value) {
+      case 'boolean':
+        return BOOLEAN;
+      case 'number':
+        return DOUBLE;
+      case 'bigint':
+        return HUGEINT;
+      case 'string':
+        return VARCHAR;
+      case 'object':
+        if (value instanceof DuckDBArrayValue) {
+          return ARRAY(typeForValue(value.items[0]), value.items.length);
+        } else if (value instanceof DuckDBBitValue) {
+          return BIT;
+        } else if (value instanceof DuckDBBlobValue) {
+          return BLOB;
+        } else if (value instanceof DuckDBDateValue) {
+          return DATE;
+        } else if (value instanceof DuckDBDecimalValue) {
+          return DECIMAL(value.width, value.scale);
+        } else if (value instanceof DuckDBIntervalValue) {
+          return INTERVAL;
+        } else if (value instanceof DuckDBListValue) {
+          return LIST(typeForValue(value.items[0]));
+        } else if (value instanceof DuckDBMapValue) {
+          return MAP(
+            typeForValue(value.entries[0].key),
+            typeForValue(value.entries[0].value)
+          );
+        } else if (value instanceof DuckDBStructValue) {
+          const entryTypes: Record<string, DuckDBType> = {};
+          for (const key in value.entries) {
+            entryTypes[key] = typeForValue(value.entries[key]);
+          }
+          return STRUCT(entryTypes);
+        } else if (value instanceof DuckDBTimestampMillisecondsValue) {
+          return TIMESTAMP_MS;
+        } else if (value instanceof DuckDBTimestampNanosecondsValue) {
+          return TIMESTAMP_NS;
+        } else if (value instanceof DuckDBTimestampSecondsValue) {
+          return TIMESTAMP_S;
+        } else if (value instanceof DuckDBTimestampTZValue) {
+          return TIMESTAMPTZ;
+        } else if (value instanceof DuckDBTimestampValue) {
+          return TIMESTAMP;
+        } else if (value instanceof DuckDBTimeTZValue) {
+          return TIMETZ;
+        } else if (value instanceof DuckDBTimeValue) {
+          return TIME;
+        } else if (value instanceof DuckDBUnionValue) {
+          return UNION({ [value.tag]: typeForValue(value.value) });
+        } else if (value instanceof DuckDBUUIDValue) {
+          return UUID;
+        }
+        break;
+    }
+  }
+  return ANY;
+}


### PR DESCRIPTION
Add a `bind` convenience method to DuckDBPreparedStatement, that can take either an array or object of parameters, and can optional take an array or object of types. If no types are provided, the types will be inferred.