### PR TITLE
convenience arguments to bind with run

### DIFF
--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -126,6 +126,20 @@ prepared.bind({
 const result = await prepared.run();
 ```
 
+or even:
+
+```ts
+const result = await connection.run('select $a, $b, $c', {
+  'a': 'duck',
+  'b': 42,
+  'c': listValue([10, 11, 12]),
+}, {
+  'a': VARCHAR,
+  'b': INTEGER,
+  'c': LIST(INTEGER),
+});
+```
+
 ### Stream Results
 
 Streaming results evaluate lazily when rows are read.

--- a/api/src/DuckDBConnection.ts
+++ b/api/src/DuckDBConnection.ts
@@ -3,10 +3,12 @@ import { DuckDBAppender } from './DuckDBAppender';
 import { DuckDBExtractedStatements } from './DuckDBExtractedStatements';
 import { DuckDBInstance } from './DuckDBInstance';
 import { DuckDBMaterializedResult } from './DuckDBMaterializedResult';
+import { DuckDBPendingResult } from './DuckDBPendingResult';
 import { DuckDBPreparedStatement } from './DuckDBPreparedStatement';
 import { DuckDBResult } from './DuckDBResult';
 import { DuckDBResultReader } from './DuckDBResultReader';
-import { DuckDBPendingResult } from './DuckDBPendingResult';
+import { DuckDBType } from './DuckDBType';
+import { DuckDBValue } from './values';
 
 export class DuckDBConnection {
   private readonly connection: duckdb.Connection;
@@ -31,45 +33,108 @@ export class DuckDBConnection {
   public get progress(): duckdb.QueryProgress {
     return duckdb.query_progress(this.connection);
   }
-  public async run(sql: string): Promise<DuckDBMaterializedResult> {
-    return new DuckDBMaterializedResult(await duckdb.query(this.connection, sql));
+  public async run(
+    sql: string,
+    values?: DuckDBValue[] | Record<string, DuckDBValue>,
+    types?: DuckDBType[] | Record<string, DuckDBType>
+  ): Promise<DuckDBMaterializedResult> {
+    if (values) {
+      const prepared = await this.prepare(sql);
+      prepared.bind(values, types);
+      return prepared.run();
+    } else {
+      return new DuckDBMaterializedResult(
+        await duckdb.query(this.connection, sql)
+      );
+    }
   }
-  public async runAndRead(sql: string): Promise<DuckDBResultReader> {
-    return new DuckDBResultReader(await this.run(sql));
+  public async runAndRead(
+    sql: string,
+    values?: DuckDBValue[] | Record<string, DuckDBValue>,
+    types?: DuckDBType[] | Record<string, DuckDBType>
+  ): Promise<DuckDBResultReader> {
+    return new DuckDBResultReader(await this.run(sql, values, types));
   }
-  public async runAndReadAll(sql: string): Promise<DuckDBResultReader> {
-    const reader = new DuckDBResultReader(await this.run(sql));
+  public async runAndReadAll(
+    sql: string,
+    values?: DuckDBValue[] | Record<string, DuckDBValue>,
+    types?: DuckDBType[] | Record<string, DuckDBType>
+  ): Promise<DuckDBResultReader> {
+    const reader = new DuckDBResultReader(await this.run(sql, values, types));
     await reader.readAll();
     return reader;
   }
-  public async runAndReadUntil(sql: string, targetRowCount: number): Promise<DuckDBResultReader> {
-    const reader = new DuckDBResultReader(await this.run(sql));
+  public async runAndReadUntil(
+    sql: string,
+    targetRowCount: number,
+    values?: DuckDBValue[] | Record<string, DuckDBValue>,
+    types?: DuckDBType[] | Record<string, DuckDBType>
+  ): Promise<DuckDBResultReader> {
+    const reader = new DuckDBResultReader(await this.run(sql, values, types));
     await reader.readUntil(targetRowCount);
     return reader;
   }
-  public async stream(sql: string): Promise<DuckDBResult> {
+  public async stream(
+    sql: string,
+    values?: DuckDBValue[] | Record<string, DuckDBValue>,
+    types?: DuckDBType[] | Record<string, DuckDBType>
+  ): Promise<DuckDBResult> {
     const prepared = await this.prepare(sql);
+    if (values) {
+      prepared.bind(values, types);
+    }
     return prepared.stream();
   }
-  public async streamAndRead(sql: string): Promise<DuckDBResultReader> {
-    return new DuckDBResultReader(await this.stream(sql));
+  public async streamAndRead(
+    sql: string,
+    values?: DuckDBValue[] | Record<string, DuckDBValue>,
+    types?: DuckDBType[] | Record<string, DuckDBType>
+  ): Promise<DuckDBResultReader> {
+    return new DuckDBResultReader(await this.stream(sql, values, types));
   }
-  public async streamAndReadAll(sql: string): Promise<DuckDBResultReader> {
-    const reader = new DuckDBResultReader(await this.stream(sql));
+  public async streamAndReadAll(
+    sql: string,
+    values?: DuckDBValue[] | Record<string, DuckDBValue>,
+    types?: DuckDBType[] | Record<string, DuckDBType>
+  ): Promise<DuckDBResultReader> {
+    const reader = new DuckDBResultReader(
+      await this.stream(sql, values, types)
+    );
     await reader.readAll();
     return reader;
   }
-  public async streamAndReadUntil(sql: string, targetRowCount: number): Promise<DuckDBResultReader> {
-    const reader = new DuckDBResultReader(await this.stream(sql));
+  public async streamAndReadUntil(
+    sql: string,
+    targetRowCount: number,
+    values?: DuckDBValue[] | Record<string, DuckDBValue>,
+    types?: DuckDBType[] | Record<string, DuckDBType>
+  ): Promise<DuckDBResultReader> {
+    const reader = new DuckDBResultReader(
+      await this.stream(sql, values, types)
+    );
     await reader.readUntil(targetRowCount);
     return reader;
   }
-  public async start(sql: string): Promise<DuckDBPendingResult> {
+  public async start(
+    sql: string,
+    values?: DuckDBValue[] | Record<string, DuckDBValue>,
+    types?: DuckDBType[] | Record<string, DuckDBType>
+  ): Promise<DuckDBPendingResult> {
     const prepared = await this.prepare(sql);
+    if (values) {
+      prepared.bind(values, types);
+    }
     return prepared.start();
   }
-  public async startStream(sql: string): Promise<DuckDBPendingResult> {
+  public async startStream(
+    sql: string,
+    values?: DuckDBValue[] | Record<string, DuckDBValue>,
+    types?: DuckDBType[] | Record<string, DuckDBType>
+  ): Promise<DuckDBPendingResult> {
     const prepared = await this.prepare(sql);
+    if (values) {
+      prepared.bind(values, types);
+    }
     return prepared.startStream();
   }
   public async prepare(sql: string): Promise<DuckDBPreparedStatement> {


### PR DESCRIPTION
Add optional arguments to various `run` methods on `DuckDBConnection` to bind values to parameters without having to explicitly create a prepared statement. Add example to README.