### PR TITLE
bind type inference improvements

### DIFF
--- a/api/src/DuckDBConnection.ts
+++ b/api/src/DuckDBConnection.ts
@@ -36,7 +36,7 @@ export class DuckDBConnection {
   public async run(
     sql: string,
     values?: DuckDBValue[] | Record<string, DuckDBValue>,
-    types?: DuckDBType[] | Record<string, DuckDBType>
+    types?: DuckDBType[] | Record<string, DuckDBType | undefined>
   ): Promise<DuckDBMaterializedResult> {
     if (values) {
       const prepared = await this.prepare(sql);
@@ -51,14 +51,14 @@ export class DuckDBConnection {
   public async runAndRead(
     sql: string,
     values?: DuckDBValue[] | Record<string, DuckDBValue>,
-    types?: DuckDBType[] | Record<string, DuckDBType>
+    types?: DuckDBType[] | Record<string, DuckDBType | undefined>
   ): Promise<DuckDBResultReader> {
     return new DuckDBResultReader(await this.run(sql, values, types));
   }
   public async runAndReadAll(
     sql: string,
     values?: DuckDBValue[] | Record<string, DuckDBValue>,
-    types?: DuckDBType[] | Record<string, DuckDBType>
+    types?: DuckDBType[] | Record<string, DuckDBType | undefined>
   ): Promise<DuckDBResultReader> {
     const reader = new DuckDBResultReader(await this.run(sql, values, types));
     await reader.readAll();
@@ -68,7 +68,7 @@ export class DuckDBConnection {
     sql: string,
     targetRowCount: number,
     values?: DuckDBValue[] | Record<string, DuckDBValue>,
-    types?: DuckDBType[] | Record<string, DuckDBType>
+    types?: DuckDBType[] | Record<string, DuckDBType | undefined>
   ): Promise<DuckDBResultReader> {
     const reader = new DuckDBResultReader(await this.run(sql, values, types));
     await reader.readUntil(targetRowCount);
@@ -77,7 +77,7 @@ export class DuckDBConnection {
   public async stream(
     sql: string,
     values?: DuckDBValue[] | Record<string, DuckDBValue>,
-    types?: DuckDBType[] | Record<string, DuckDBType>
+    types?: DuckDBType[] | Record<string, DuckDBType | undefined>
   ): Promise<DuckDBResult> {
     const prepared = await this.prepare(sql);
     if (values) {
@@ -88,14 +88,14 @@ export class DuckDBConnection {
   public async streamAndRead(
     sql: string,
     values?: DuckDBValue[] | Record<string, DuckDBValue>,
-    types?: DuckDBType[] | Record<string, DuckDBType>
+    types?: DuckDBType[] | Record<string, DuckDBType | undefined>
   ): Promise<DuckDBResultReader> {
     return new DuckDBResultReader(await this.stream(sql, values, types));
   }
   public async streamAndReadAll(
     sql: string,
     values?: DuckDBValue[] | Record<string, DuckDBValue>,
-    types?: DuckDBType[] | Record<string, DuckDBType>
+    types?: DuckDBType[] | Record<string, DuckDBType | undefined>
   ): Promise<DuckDBResultReader> {
     const reader = new DuckDBResultReader(
       await this.stream(sql, values, types)
@@ -107,7 +107,7 @@ export class DuckDBConnection {
     sql: string,
     targetRowCount: number,
     values?: DuckDBValue[] | Record<string, DuckDBValue>,
-    types?: DuckDBType[] | Record<string, DuckDBType>
+    types?: DuckDBType[] | Record<string, DuckDBType | undefined>
   ): Promise<DuckDBResultReader> {
     const reader = new DuckDBResultReader(
       await this.stream(sql, values, types)
@@ -118,7 +118,7 @@ export class DuckDBConnection {
   public async start(
     sql: string,
     values?: DuckDBValue[] | Record<string, DuckDBValue>,
-    types?: DuckDBType[] | Record<string, DuckDBType>
+    types?: DuckDBType[] | Record<string, DuckDBType | undefined>
   ): Promise<DuckDBPendingResult> {
     const prepared = await this.prepare(sql);
     if (values) {
@@ -129,7 +129,7 @@ export class DuckDBConnection {
   public async startStream(
     sql: string,
     values?: DuckDBValue[] | Record<string, DuckDBValue>,
-    types?: DuckDBType[] | Record<string, DuckDBType>
+    types?: DuckDBType[] | Record<string, DuckDBType | undefined>
   ): Promise<DuckDBPendingResult> {
     const prepared = await this.prepare(sql);
     if (values) {

--- a/api/src/DuckDBPreparedStatement.ts
+++ b/api/src/DuckDBPreparedStatement.ts
@@ -164,17 +164,28 @@ export class DuckDBPreparedStatement {
       createValue(type, value)
     );
   }
-  public bind(values: DuckDBValue[] | Record<string, DuckDBValue>, types?: DuckDBType[] | Record<string, DuckDBType>) {
+  public bind(
+    values: DuckDBValue[] | Record<string, DuckDBValue>,
+    types?: DuckDBType[] | Record<string, DuckDBType | undefined>
+  ) {
     if (Array.isArray(values)) {
       const typesIsArray = Array.isArray(types);
       for (let i = 0; i < values.length; i++) {
-        this.bindValue(i + 1, values[i], typesIsArray ? types[i] : typeForValue(values[i]));
+        this.bindValue(
+          i + 1,
+          values[i],
+          typesIsArray ? types[i] : typeForValue(values[i])
+        );
       }
     } else {
       const typesIsRecord = types && !Array.isArray(types);
       for (const key in values) {
         const index = this.parameterIndex(key);
-        this.bindValue(index, values[key], typesIsRecord ? types[key] : typeForValue(values[key]));
+        let type = typesIsRecord ? types[key] : undefined;
+        if (type === undefined) {
+          type = typeForValue(values[key]);
+        }
+        this.bindValue(index, values[key], type);
       }
     }
   }

--- a/api/src/typeForValue.ts
+++ b/api/src/typeForValue.ts
@@ -9,6 +9,7 @@ import {
   DOUBLE,
   DuckDBType,
   HUGEINT,
+  INTEGER,
   INTERVAL,
   LIST,
   MAP,
@@ -55,7 +56,11 @@ export function typeForValue(value: DuckDBValue): DuckDBType {
       case 'boolean':
         return BOOLEAN;
       case 'number':
-        return DOUBLE;
+        if (Math.round(value) === value) {
+          return INTEGER;
+        } else {
+          return DOUBLE;
+        }
       case 'bigint':
         return HUGEINT;
       case 'string':


### PR DESCRIPTION
Two improvements to bind type inference & specification:
- If a number value has no fractional part, infer INTEGER instead of DOUBLE.
- Allow explicitly type specification by name to only contain some types (and infer the rest).