### PR TITLE
json result helpers

### DIFF
--- a/api/src/DuckDBResult.ts
+++ b/api/src/DuckDBResult.ts
@@ -3,6 +3,11 @@ import { DuckDBDataChunk } from './DuckDBDataChunk';
 import { DuckDBLogicalType } from './DuckDBLogicalType';
 import { DuckDBType } from './DuckDBType';
 import { DuckDBTypeId } from './DuckDBTypeId';
+import { DuckDBValueToJsonConverter, Json } from './DuckDBValueToJsonConverter';
+import { convertColumnsFromChunks } from './convertColumnsFromChunks';
+import { convertColumnsObjectFromChunks } from './convertColumnsObjectFromChunks';
+import { convertRowObjectsFromChunks } from './convertRowObjectsFromChunks';
+import { convertRowsFromChunks } from './convertRowsFromChunks';
 import { ResultReturnType, StatementType } from './enums';
 import { getColumnsFromChunks } from './getColumnsFromChunks';
 import { getColumnsObjectFromChunks } from './getColumnsObjectFromChunks';
@@ -99,16 +104,40 @@ export class DuckDBResult {
     const chunks = await this.fetchAllChunks();
     return getColumnsFromChunks(chunks);
   }
+  public async getColumnsJson(): Promise<Json[][]> {
+    const chunks = await this.fetchAllChunks();
+    return convertColumnsFromChunks(chunks, DuckDBValueToJsonConverter.default);
+  }
   public async getColumnsObject(): Promise<Record<string, DuckDBValue[]>> {
     const chunks = await this.fetchAllChunks();
     return getColumnsObjectFromChunks(chunks, this.deduplicatedColumnNames());
+  }
+  public async getColumnsObjectJson(): Promise<Record<string, Json[]>> {
+    const chunks = await this.fetchAllChunks();
+    return convertColumnsObjectFromChunks(
+      chunks,
+      this.deduplicatedColumnNames(),
+      DuckDBValueToJsonConverter.default
+    );
   }
   public async getRows(): Promise<DuckDBValue[][]> {
     const chunks = await this.fetchAllChunks();
     return getRowsFromChunks(chunks);
   }
+  public async getRowsJson(): Promise<Json[][]> {
+    const chunks = await this.fetchAllChunks();
+    return convertRowsFromChunks(chunks, DuckDBValueToJsonConverter.default);
+  }
   public async getRowObjects(): Promise<Record<string, DuckDBValue>[]> {
     const chunks = await this.fetchAllChunks();
     return getRowObjectsFromChunks(chunks, this.deduplicatedColumnNames());
+  }
+  public async getRowObjectsJson(): Promise<Record<string, Json>[]> {
+    const chunks = await this.fetchAllChunks();
+    return convertRowObjectsFromChunks(
+      chunks,
+      this.deduplicatedColumnNames(),
+      DuckDBValueToJsonConverter.default
+    );
   }
 }

--- a/api/src/DuckDBResultReader.ts
+++ b/api/src/DuckDBResultReader.ts
@@ -1,8 +1,13 @@
+import { convertColumnsFromChunks } from './convertColumnsFromChunks';
+import { convertColumnsObjectFromChunks } from './convertColumnsObjectFromChunks';
+import { convertRowObjectsFromChunks } from './convertRowObjectsFromChunks';
+import { convertRowsFromChunks } from './convertRowsFromChunks';
 import { DuckDBDataChunk } from './DuckDBDataChunk';
 import { DuckDBLogicalType } from './DuckDBLogicalType';
 import { DuckDBResult } from './DuckDBResult';
 import { DuckDBType } from './DuckDBType';
 import { DuckDBTypeId } from './DuckDBTypeId';
+import { DuckDBValueToJsonConverter, Json } from './DuckDBValueToJsonConverter';
 import { ResultReturnType, StatementType } from './enums';
 import { getColumnsFromChunks } from './getColumnsFromChunks';
 import { getColumnsObjectFromChunks } from './getColumnsObjectFromChunks';
@@ -163,15 +168,48 @@ export class DuckDBResultReader {
     return getColumnsFromChunks(this.chunks);
   }
 
+  public getColumnsJson(): Json[][] {
+    return convertColumnsFromChunks(
+      this.chunks,
+      DuckDBValueToJsonConverter.default
+    );
+  }
+
   public getColumnsObject(): Record<string, DuckDBValue[]> {
-    return getColumnsObjectFromChunks(this.chunks, this.deduplicatedColumnNames());
+    return getColumnsObjectFromChunks(
+      this.chunks,
+      this.deduplicatedColumnNames()
+    );
+  }
+
+  public getColumnsObjectJson(): Record<string, Json[]> {
+    return convertColumnsObjectFromChunks(
+      this.chunks,
+      this.deduplicatedColumnNames(),
+      DuckDBValueToJsonConverter.default
+    );
   }
 
   public getRows(): DuckDBValue[][] {
     return getRowsFromChunks(this.chunks);
   }
 
-  public getRowObjecs(): Record<string, DuckDBValue>[] {
+  public getRowsJson(): Json[][] {
+    return convertRowsFromChunks(
+      this.chunks,
+      DuckDBValueToJsonConverter.default
+    );
+  }
+
+  public getRowObjects(): Record<string, DuckDBValue>[] {
     return getRowObjectsFromChunks(this.chunks, this.deduplicatedColumnNames());
+  }
+
+  public getRowObjectsJson(): Record<string, Json>[] {
+    return convertRowObjectsFromChunks(
+      this.chunks,
+      this.deduplicatedColumnNames(),
+      DuckDBValueToJsonConverter.default
+    );
   }
 }

--- a/api/src/DuckDBType.ts
+++ b/api/src/DuckDBType.ts
@@ -576,6 +576,7 @@ export function LIST(valueType: DuckDBType, alias?: string): DuckDBListType {
 export class DuckDBStructType extends BaseDuckDBType<DuckDBTypeId.STRUCT> {
   public readonly entryNames: readonly string[];
   public readonly entryTypes: readonly DuckDBType[];
+  public readonly entryIndexes: Readonly<Record<string, number>>;
   public constructor(
     entryNames: readonly string[],
     entryTypes: readonly DuckDBType[],
@@ -588,9 +589,20 @@ export class DuckDBStructType extends BaseDuckDBType<DuckDBTypeId.STRUCT> {
     }
     this.entryNames = entryNames;
     this.entryTypes = entryTypes;
+    const entryIndexes: Record<string, number> = {};
+    for (let i = 0; i < entryNames.length; i++) {
+      entryIndexes[entryNames[i]] = i;
+    }
+    this.entryIndexes = entryIndexes;
   }
   public get entryCount() {
     return this.entryNames.length;
+  }
+  public indexForEntry(entryName: string): number {
+    return this.entryIndexes[entryName];
+  }
+  public typeForEntry(entryName: string): DuckDBType {
+    return this.entryTypes[this.entryIndexes[entryName]];
   }
   public toString(): string {
     const parts: string[] = [];
@@ -726,6 +738,9 @@ export class DuckDBUnionType extends BaseDuckDBType<DuckDBTypeId.UNION> {
   }
   public memberIndexForTag(tag: string): number {
     return this.tagMemberIndexes[tag];
+  }
+  public memberTypeForTag(tag: string): DuckDBType {
+    return this.memberTypes[this.tagMemberIndexes[tag]];
   }
   public get memberCount() {
     return this.memberTags.length;

--- a/api/src/DuckDBValueConverter.ts
+++ b/api/src/DuckDBValueConverter.ts
@@ -1,0 +1,6 @@
+import { DuckDBType } from './DuckDBType';
+import { DuckDBValue } from './values';
+
+export interface DuckDBValueConverter<T> {
+  convertValue(value: DuckDBValue, type: DuckDBType): T;
+}

--- a/api/src/DuckDBValueToJsonConverter.ts
+++ b/api/src/DuckDBValueToJsonConverter.ts
@@ -1,0 +1,123 @@
+import { DuckDBType } from './DuckDBType';
+import { DuckDBTypeId } from './DuckDBTypeId';
+import { DuckDBValueConverter } from './DuckDBValueConverter';
+import {
+  DuckDBArrayValue,
+  DuckDBIntervalValue,
+  DuckDBListValue,
+  DuckDBMapValue,
+  DuckDBStructValue,
+  DuckDBUnionValue,
+  DuckDBValue,
+} from './values';
+
+export type Json =
+  | null
+  | boolean
+  | number
+  | string
+  | Json[]
+  | { [key: string]: Json };
+
+export class DuckDBValueToJsonConverter implements DuckDBValueConverter<Json> {
+  public static readonly default = new DuckDBValueToJsonConverter();
+
+  public convertValue(value: DuckDBValue, type: DuckDBType): Json {
+    if (value == null) {
+      return null;
+    }
+    switch (type.typeId) {
+      case DuckDBTypeId.BOOLEAN:
+        return Boolean(value);
+      case DuckDBTypeId.TINYINT:
+      case DuckDBTypeId.SMALLINT:
+      case DuckDBTypeId.INTEGER:
+      case DuckDBTypeId.UTINYINT:
+      case DuckDBTypeId.USMALLINT:
+      case DuckDBTypeId.UINTEGER:
+        return Number(value);
+      case DuckDBTypeId.FLOAT:
+      case DuckDBTypeId.DOUBLE:
+        if (Number.isFinite(value)) {
+          return Number(value);
+        }
+        return String(value);
+      case DuckDBTypeId.BIGINT:
+      case DuckDBTypeId.UBIGINT:
+      case DuckDBTypeId.HUGEINT:
+      case DuckDBTypeId.UHUGEINT:
+        return String(value);
+      case DuckDBTypeId.DATE:
+      case DuckDBTypeId.TIME:
+      case DuckDBTypeId.TIMESTAMP:
+      case DuckDBTypeId.TIMESTAMP_S:
+      case DuckDBTypeId.TIMESTAMP_MS:
+      case DuckDBTypeId.TIMESTAMP_NS:
+      case DuckDBTypeId.TIME_TZ:
+      case DuckDBTypeId.TIMESTAMP_TZ:
+        return String(value);
+      case DuckDBTypeId.INTERVAL:
+        if (value instanceof DuckDBIntervalValue) {
+          return {
+            months: value.months,
+            days: value.days,
+            micros: String(value.micros),
+          };
+        }
+        return null;
+      case DuckDBTypeId.VARCHAR:
+      case DuckDBTypeId.BLOB:
+      case DuckDBTypeId.BIT:
+        return String(value);
+      case DuckDBTypeId.DECIMAL:
+      case DuckDBTypeId.VARINT:
+        return String(value);
+      case DuckDBTypeId.ENUM:
+        return String(value);
+      case DuckDBTypeId.LIST:
+        if (value instanceof DuckDBListValue) {
+          return value.items.map((v) => this.convertValue(v, type.valueType));
+        }
+        return null;
+      case DuckDBTypeId.STRUCT:
+        if (value instanceof DuckDBStructValue) {
+          const result: { [key: string]: Json } = {};
+          for (const key in value.entries) {
+            result[key] = this.convertValue(
+              value.entries[key],
+              type.typeForEntry(key)
+            );
+          }
+          return result;
+        }
+        return null;
+      case DuckDBTypeId.MAP:
+        if (value instanceof DuckDBMapValue) {
+          return value.entries.map((entry) => ({
+            key: this.convertValue(entry.key, type.keyType),
+            value: this.convertValue(entry.value, type.valueType),
+          }));
+        }
+        return null;
+      case DuckDBTypeId.ARRAY:
+        if (value instanceof DuckDBArrayValue) {
+          return value.items.map((v) => this.convertValue(v, type.valueType));
+        }
+        return null;
+      case DuckDBTypeId.UNION:
+        if (value instanceof DuckDBUnionValue) {
+          return {
+            tag: value.tag,
+            value: this.convertValue(
+              value.value,
+              type.memberTypeForTag(value.tag)
+            ),
+          };
+        }
+        return null;
+      case DuckDBTypeId.UUID:
+        return String(value);
+    }
+    return null;
+  }
+}

--- a/api/src/convertColumnsFromChunks.ts
+++ b/api/src/convertColumnsFromChunks.ts
@@ -1,0 +1,29 @@
+import { DuckDBDataChunk } from './DuckDBDataChunk';
+import { DuckDBValueConverter } from './DuckDBValueConverter';
+
+export function convertColumnsFromChunks<T>(
+  chunks: readonly DuckDBDataChunk[],
+  converter: DuckDBValueConverter<T>
+): T[][] {
+  if (chunks.length === 0) {
+    return [];
+  }
+  const convertedColumns = chunks[0].convertColumns(converter);
+  for (let chunkIndex = 1; chunkIndex < chunks.length; chunkIndex++) {
+    for (
+      let columnIndex = 0;
+      columnIndex < convertedColumns.length;
+      columnIndex++
+    ) {
+      const chunk = chunks[chunkIndex];
+      chunk.visitColumnValues(
+        columnIndex,
+        (value, _rowIndex, _columnIndex, type) =>
+          convertedColumns[columnIndex].push(
+            converter.convertValue(value, type)
+          )
+      );
+    }
+  }
+  return convertedColumns;
+}

--- a/api/src/convertColumnsObjectFromChunks.ts
+++ b/api/src/convertColumnsObjectFromChunks.ts
@@ -1,0 +1,29 @@
+import { DuckDBDataChunk } from './DuckDBDataChunk';
+import { DuckDBValueConverter } from './DuckDBValueConverter';
+
+export function convertColumnsObjectFromChunks<T>(
+  chunks: readonly DuckDBDataChunk[],
+  columnNames: readonly string[],
+  converter: DuckDBValueConverter<T>
+): Record<string, T[]> {
+  const convertedColumnsObject: Record<string, T[]> = {};
+  for (const columnName of columnNames) {
+    convertedColumnsObject[columnName] = [];
+  }
+  if (chunks.length === 0) {
+    return convertedColumnsObject;
+  }
+  const columnCount = chunks[0].columnCount;
+  for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      chunks[chunkIndex].visitColumnValues(
+        columnIndex,
+        (value, _rowIndex, _columnIndex, type) =>
+          convertedColumnsObject[columnNames[columnIndex]].push(
+            converter.convertValue(value, type)
+          )
+      );
+    }
+  }
+  return convertedColumnsObject;
+}

--- a/api/src/convertRowObjectsFromChunks.ts
+++ b/api/src/convertRowObjectsFromChunks.ts
@@ -1,0 +1,24 @@
+import { DuckDBDataChunk } from './DuckDBDataChunk';
+import { DuckDBValueConverter } from './DuckDBValueConverter';
+
+export function convertRowObjectsFromChunks<T>(
+  chunks: readonly DuckDBDataChunk[],
+  columnNames: readonly string[],
+  converter: DuckDBValueConverter<T>
+): Record<string, T>[] {
+  const rowObjects: Record<string, T>[] = [];
+  for (const chunk of chunks) {
+    const rowCount = chunk.rowCount;
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      const rowObject: Record<string, T> = {};
+      chunk.visitRowValues(rowIndex, (value, _rowIndex, columnIndex, type) => {
+        rowObject[columnNames[columnIndex]] = converter.convertValue(
+          value,
+          type
+        );
+      });
+      rowObjects.push(rowObject);
+    }
+  }
+  return rowObjects;
+}

--- a/api/src/convertRowsFromChunks.ts
+++ b/api/src/convertRowsFromChunks.ts
@@ -1,0 +1,16 @@
+import { DuckDBDataChunk } from './DuckDBDataChunk';
+import { DuckDBValueConverter } from './DuckDBValueConverter';
+
+export function convertRowsFromChunks<T>(
+  chunks: readonly DuckDBDataChunk[],
+  converter: DuckDBValueConverter<T>
+): T[][] {
+  const rows: T[][] = [];
+  for (const chunk of chunks) {
+    const rowCount = chunk.rowCount;
+    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
+      rows.push(chunk.convertRowValues(rowIndex, converter));
+    }
+  }
+  return rows;
+}

--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -16,6 +16,8 @@ export * from './DuckDBPreparedStatement';
 export * from './DuckDBResult';
 export * from './DuckDBType';
 export * from './DuckDBTypeId';
+export * from './DuckDBValueConverter';
+export * from './DuckDBValueToJsonConverter';
 export * from './DuckDBVector';
 export * from './configurationOptionDescriptions';
 export * from './enums';

--- a/api/test/util/testAllTypes.ts
+++ b/api/test/util/testAllTypes.ts
@@ -22,6 +22,7 @@ import {
   INTEGER,
   INTERVAL,
   intervalValue,
+  Json,
   LIST,
   listValue,
   MAP,
@@ -71,229 +72,511 @@ export interface ColumnNameTypeAndRows extends ColumnNameAndType {
   readonly name: string;
   readonly type: DuckDBType;
   readonly rows: readonly DuckDBValue[];
+  readonly json: readonly Json[];
 }
 
 function col(
   name: string,
   type: DuckDBType,
-  rows: readonly DuckDBValue[]
+  rows: readonly DuckDBValue[],
+  json: readonly Json[]
 ): ColumnNameTypeAndRows {
-  return { name, type, rows };
+  return { name, type, rows, json };
 }
 
 export const testAllTypesData: ColumnNameTypeAndRows[] = [
-  col('bool', BOOLEAN, [false, true, null]),
-  col('tinyint', TINYINT, [TINYINT.min, TINYINT.max, null]),
-  col('smallint', SMALLINT, [SMALLINT.min, SMALLINT.max, null]),
-  col('int', INTEGER, [INTEGER.min, INTEGER.max, null]),
-  col('bigint', BIGINT, [BIGINT.min, BIGINT.max, null]),
-  col('hugeint', HUGEINT, [HUGEINT.min, HUGEINT.max, null]),
-  col('uhugeint', UHUGEINT, [UHUGEINT.min, UHUGEINT.max, null]),
-  col('utinyint', UTINYINT, [UTINYINT.min, UTINYINT.max, null]),
-  col('usmallint', USMALLINT, [USMALLINT.min, USMALLINT.max, null]),
-  col('uint', UINTEGER, [UINTEGER.min, UINTEGER.max, null]),
-  col('ubigint', UBIGINT, [UBIGINT.min, UBIGINT.max, null]),
-  col('varint', VARINT, [VARINT.min, VARINT.max, null]),
-  col('date', DATE, [DATE.min, DATE.max, null]),
-  col('time', TIME, [TIME.min, TIME.max, null]),
-  col('timestamp', TIMESTAMP, [TIMESTAMP.min, TIMESTAMP.max, null]),
-  col('timestamp_s', TIMESTAMP_S, [TIMESTAMP_S.min, TIMESTAMP_S.max, null]),
-  col('timestamp_ms', TIMESTAMP_MS, [TIMESTAMP_MS.min, TIMESTAMP_MS.max, null]),
-  col('timestamp_ns', TIMESTAMP_NS, [TIMESTAMP_NS.min, TIMESTAMP_NS.max, null]),
-  col('time_tz', TIMETZ, [TIMETZ.min, TIMETZ.max, null]),
-  col('timestamp_tz', TIMESTAMPTZ, [TIMESTAMPTZ.min, TIMESTAMPTZ.max, null]),
-  col('float', FLOAT, [FLOAT.min, FLOAT.max, null]),
-  col('double', DOUBLE, [DOUBLE.min, DOUBLE.max, null]),
-  col('dec_4_1', DECIMAL(4, 1), [
-    decimalValue(-9999n, 4, 1),
-    decimalValue(9999n, 4, 1),
-    null,
-  ]),
-  col('dec_9_4', DECIMAL(9, 4), [
-    decimalValue(-999999999n, 9, 4),
-    decimalValue(999999999n, 9, 4),
-    null,
-  ]),
-  col('dec_18_6', DECIMAL(18, 6), [
-    decimalValue(-BI_18_9s, 18, 6),
-    decimalValue(BI_18_9s, 18, 6),
-    null,
-  ]),
-  col('dec38_10', DECIMAL(38, 10), [
-    decimalValue(-BI_38_9s, 38, 10),
-    decimalValue(BI_38_9s, 38, 10),
-    null,
-  ]),
-  col('uuid', UUID, [UUID.min, UUID.max, null]),
-  col('interval', INTERVAL, [
-    intervalValue(0, 0, 0n),
-    intervalValue(999, 999, 999999999n),
-    null,
-  ]),
-  col('varchar', VARCHAR, ['🦆🦆🦆🦆🦆🦆', 'goo\0se', null]),
-  col('blob', BLOB, [
-    blobValue('thisisalongblob\x00withnullbytes'),
-    blobValue('\x00\x00\x00a'),
-    null,
-  ]),
-  col('bit', BIT, [
-    bitValue('0010001001011100010101011010111'),
-    bitValue('10101'),
-    null,
-  ]),
-  col('small_enum', ENUM8(smallEnumValues), [
-    smallEnumValues[0],
-    smallEnumValues[smallEnumValues.length - 1],
-    null,
-  ]),
-  col('medium_enum', ENUM16(mediumEnumValues), [
-    mediumEnumValues[0],
-    mediumEnumValues[mediumEnumValues.length - 1],
-    null,
-  ]),
-  col('large_enum', ENUM32(largeEnumValues), [
-    largeEnumValues[0],
-    largeEnumValues[largeEnumValues.length - 1],
-    null,
-  ]),
-  col('int_array', LIST(INTEGER), [
-    listValue([]),
-    listValue([42, 999, null, null, -42]),
-    null,
-  ]),
-  col('double_array', LIST(DOUBLE), [
-    listValue([]),
-    listValue([42.0, NaN, Infinity, -Infinity, null, -42.0]),
-    null,
-  ]),
-  col('date_array', LIST(DATE), [
-    listValue([]),
-    // 19124 days from the epoch is 2022-05-12
-    listValue([DATE.epoch, DATE.posInf, DATE.negInf, null, dateValue(19124)]),
-    null,
-  ]),
-  col('timestamp_array', LIST(TIMESTAMP), [
-    listValue([]),
-    listValue([
-      TIMESTAMP.epoch,
-      TIMESTAMP.posInf,
-      TIMESTAMP.negInf,
+  col('bool', BOOLEAN, [false, true, null], [false, true, null]),
+  col(
+    'tinyint',
+    TINYINT,
+    [TINYINT.min, TINYINT.max, null],
+    [TINYINT.min, TINYINT.max, null]
+  ),
+  col(
+    'smallint',
+    SMALLINT,
+    [SMALLINT.min, SMALLINT.max, null],
+    [SMALLINT.min, SMALLINT.max, null]
+  ),
+  col(
+    'int',
+    INTEGER,
+    [INTEGER.min, INTEGER.max, null],
+    [INTEGER.min, INTEGER.max, null]
+  ),
+  col(
+    'bigint',
+    BIGINT,
+    [BIGINT.min, BIGINT.max, null],
+    [String(BIGINT.min), String(BIGINT.max), null]
+  ),
+  col(
+    'hugeint',
+    HUGEINT,
+    [HUGEINT.min, HUGEINT.max, null],
+    [String(HUGEINT.min), String(HUGEINT.max), null]
+  ),
+  col(
+    'uhugeint',
+    UHUGEINT,
+    [UHUGEINT.min, UHUGEINT.max, null],
+    [String(UHUGEINT.min), String(UHUGEINT.max), null]
+  ),
+  col(
+    'utinyint',
+    UTINYINT,
+    [UTINYINT.min, UTINYINT.max, null],
+    [UTINYINT.min, UTINYINT.max, null]
+  ),
+  col(
+    'usmallint',
+    USMALLINT,
+    [USMALLINT.min, USMALLINT.max, null],
+    [USMALLINT.min, USMALLINT.max, null]
+  ),
+  col(
+    'uint',
+    UINTEGER,
+    [UINTEGER.min, UINTEGER.max, null],
+    [UINTEGER.min, UINTEGER.max, null]
+  ),
+  col(
+    'ubigint',
+    UBIGINT,
+    [UBIGINT.min, UBIGINT.max, null],
+    [String(UBIGINT.min), String(UBIGINT.max), null]
+  ),
+  col(
+    'varint',
+    VARINT,
+    [VARINT.min, VARINT.max, null],
+    [String(VARINT.min), String(VARINT.max), null]
+  ),
+  col(
+    'date',
+    DATE,
+    [DATE.min, DATE.max, null],
+    [String(DATE.min), String(DATE.max), null]
+  ),
+  col(
+    'time',
+    TIME,
+    [TIME.min, TIME.max, null],
+    [String(TIME.min), String(TIME.max), null]
+  ),
+  col(
+    'timestamp',
+    TIMESTAMP,
+    [TIMESTAMP.min, TIMESTAMP.max, null],
+    [String(TIMESTAMP.min), String(TIMESTAMP.max), null]
+  ),
+  col(
+    'timestamp_s',
+    TIMESTAMP_S,
+    [TIMESTAMP_S.min, TIMESTAMP_S.max, null],
+    [String(TIMESTAMP_S.min), String(TIMESTAMP_S.max), null]
+  ),
+  col(
+    'timestamp_ms',
+    TIMESTAMP_MS,
+    [TIMESTAMP_MS.min, TIMESTAMP_MS.max, null],
+    [String(TIMESTAMP_MS.min), String(TIMESTAMP_MS.max), null]
+  ),
+  col(
+    'timestamp_ns',
+    TIMESTAMP_NS,
+    [TIMESTAMP_NS.min, TIMESTAMP_NS.max, null],
+    [String(TIMESTAMP_NS.min), String(TIMESTAMP_NS.max), null]
+  ),
+  col(
+    'time_tz',
+    TIMETZ,
+    [TIMETZ.min, TIMETZ.max, null],
+    [String(TIMETZ.min), String(TIMETZ.max), null]
+  ),
+  col(
+    'timestamp_tz',
+    TIMESTAMPTZ,
+    [TIMESTAMPTZ.min, TIMESTAMPTZ.max, null],
+    [String(TIMESTAMPTZ.min), String(TIMESTAMPTZ.max), null]
+  ),
+  col(
+    'float',
+    FLOAT,
+    [FLOAT.min, FLOAT.max, null],
+    [FLOAT.min, FLOAT.max, null]
+  ),
+  col(
+    'double',
+    DOUBLE,
+    [DOUBLE.min, DOUBLE.max, null],
+    [DOUBLE.min, DOUBLE.max, null]
+  ),
+  col(
+    'dec_4_1',
+    DECIMAL(4, 1),
+    [decimalValue(-9999n, 4, 1), decimalValue(9999n, 4, 1), null],
+    ['-999.9', '999.9', null]
+  ),
+  col(
+    'dec_9_4',
+    DECIMAL(9, 4),
+    [decimalValue(-999999999n, 9, 4), decimalValue(999999999n, 9, 4), null],
+    ['-99999.9999', '99999.9999', null]
+  ),
+  col(
+    'dec_18_6',
+    DECIMAL(18, 6),
+    [decimalValue(-BI_18_9s, 18, 6), decimalValue(BI_18_9s, 18, 6), null],
+    ['-999999999999.999999', '999999999999.999999', null]
+  ),
+  col(
+    'dec38_10',
+    DECIMAL(38, 10),
+    [decimalValue(-BI_38_9s, 38, 10), decimalValue(BI_38_9s, 38, 10), null],
+    [
+      '-9999999999999999999999999999.9999999999',
+      '9999999999999999999999999999.9999999999',
       null,
-      // 1652372625 seconds from the epoch is 2022-05-12 16:23:45
-      timestampValue(1652372625n * 1000n * 1000n),
-    ]),
-    null,
-  ]),
-  col('timestamptz_array', LIST(TIMESTAMPTZ), [
-    listValue([]),
-    listValue([
-      TIMESTAMPTZ.epoch,
-      TIMESTAMPTZ.posInf,
-      TIMESTAMPTZ.negInf,
+    ]
+  ),
+  col(
+    'uuid',
+    UUID,
+    [UUID.min, UUID.max, null],
+    [String(UUID.min), String(UUID.max), null]
+  ),
+  col(
+    'interval',
+    INTERVAL,
+    [intervalValue(0, 0, 0n), intervalValue(999, 999, 999999999n), null],
+    [
+      { months: 0, days: 0, micros: '0' },
+      { months: 999, days: 999, micros: '999999999' },
       null,
-      // 1652397825 = 1652372625 + 25200, 25200 = 7 * 60 * 60 = 7 hours in seconds
-      // This 7 hour difference is hard coded into test_all_types (value is 2022-05-12 16:23:45-07)
-      timestampTZValue(1652397825n * 1000n * 1000n),
-    ]),
-    null,
-  ]),
-  col('varchar_array', LIST(VARCHAR), [
-    listValue([]),
-    // Note that the string 'goose' in varchar_array does NOT have an embedded null character.
-    listValue(['🦆🦆🦆🦆🦆🦆', 'goose', null, '']),
-    null,
-  ]),
-  col('nested_int_array', LIST(LIST(INTEGER)), [
-    listValue([]),
-    listValue([
+    ]
+  ),
+  col(
+    'varchar',
+    VARCHAR,
+    ['🦆🦆🦆🦆🦆🦆', 'goo\0se', null],
+    ['🦆🦆🦆🦆🦆🦆', 'goo\0se', null]
+  ),
+  col(
+    'blob',
+    BLOB,
+    [
+      blobValue('thisisalongblob\x00withnullbytes'),
+      blobValue('\x00\x00\x00a'),
+      null,
+    ],
+    ['thisisalongblob\\x00withnullbytes', '\\x00\\x00\\x00a', null]
+  ),
+  col(
+    'bit',
+    BIT,
+    [bitValue('0010001001011100010101011010111'), bitValue('10101'), null],
+    ['0010001001011100010101011010111', '10101', null]
+  ),
+  col(
+    'small_enum',
+    ENUM8(smallEnumValues),
+    [smallEnumValues[0], smallEnumValues[smallEnumValues.length - 1], null],
+    [smallEnumValues[0], smallEnumValues[smallEnumValues.length - 1], null]
+  ),
+  col(
+    'medium_enum',
+    ENUM16(mediumEnumValues),
+    [mediumEnumValues[0], mediumEnumValues[mediumEnumValues.length - 1], null],
+    [mediumEnumValues[0], mediumEnumValues[mediumEnumValues.length - 1], null]
+  ),
+  col(
+    'large_enum',
+    ENUM32(largeEnumValues),
+    [largeEnumValues[0], largeEnumValues[largeEnumValues.length - 1], null],
+    [largeEnumValues[0], largeEnumValues[largeEnumValues.length - 1], null]
+  ),
+  col(
+    'int_array',
+    LIST(INTEGER),
+    [listValue([]), listValue([42, 999, null, null, -42]), null],
+    [[], [42, 999, null, null, -42], null]
+  ),
+  col(
+    'double_array',
+    LIST(DOUBLE),
+    [
       listValue([]),
-      listValue([42, 999, null, null, -42]),
+      listValue([42.0, NaN, Infinity, -Infinity, null, -42.0]),
       null,
+    ],
+    [[], [42, 'NaN', 'Infinity', '-Infinity', null, -42], null]
+  ),
+  col(
+    'date_array',
+    LIST(DATE),
+    [
       listValue([]),
-      listValue([42, 999, null, null, -42]),
-    ]),
-    null,
-  ]),
-  col('struct', STRUCT({ 'a': INTEGER, 'b': VARCHAR }), [
-    structValue({ 'a': null, 'b': null }),
-    structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
-    null,
-  ]),
-  col('struct_of_arrays', STRUCT({ 'a': LIST(INTEGER), 'b': LIST(VARCHAR) }), [
-    structValue({ 'a': null, 'b': null }),
-    structValue({
-      'a': listValue([42, 999, null, null, -42]),
-      'b': listValue(['🦆🦆🦆🦆🦆🦆', 'goose', null, '']),
-    }),
-    null,
-  ]),
-  col('array_of_structs', LIST(STRUCT({ 'a': INTEGER, 'b': VARCHAR })), [
-    listValue([]),
-    listValue([
+      // 19124 days from the epoch is 2022-05-12
+      listValue([DATE.epoch, DATE.posInf, DATE.negInf, null, dateValue(19124)]),
+      null,
+    ],
+    [
+      [],
+      ['1970-01-01', '5881580-07-11', '5877642-06-24 (BC)', null, '2022-05-12'],
+      null,
+    ]
+  ),
+  col(
+    'timestamp_array',
+    LIST(TIMESTAMP),
+    [
+      listValue([]),
+      listValue([
+        TIMESTAMP.epoch,
+        TIMESTAMP.posInf,
+        TIMESTAMP.negInf,
+        null,
+        // 1652372625 seconds from the epoch is 2022-05-12 16:23:45
+        timestampValue(1652372625n * 1000n * 1000n),
+      ]),
+      null,
+    ],
+    [
+      [],
+      [
+        '1970-01-01 00:00:00',
+        'infinity',
+        '-infinity',
+        null,
+        '2022-05-12 16:23:45',
+      ],
+      null,
+    ]
+  ),
+  col(
+    'timestamptz_array',
+    LIST(TIMESTAMPTZ),
+    [
+      listValue([]),
+      listValue([
+        TIMESTAMPTZ.epoch,
+        TIMESTAMPTZ.posInf,
+        TIMESTAMPTZ.negInf,
+        null,
+        // 1652397825 = 1652372625 + 25200, 25200 = 7 * 60 * 60 = 7 hours in seconds
+        // This 7 hour difference is hard coded into test_all_types (value is 2022-05-12 16:23:45-07)
+        timestampTZValue(1652397825n * 1000n * 1000n),
+      ]),
+      null,
+    ],
+    [
+      [],
+      [
+        '1970-01-01 00:00:00', // TODO: timestamptz timezone offset
+        'infinity',
+        '-infinity',
+        null,
+        '2022-05-12 23:23:45',
+      ],
+      null,
+    ]
+  ),
+  col(
+    'varchar_array',
+    LIST(VARCHAR),
+    [
+      listValue([]),
+      // Note that the string 'goose' in varchar_array does NOT have an embedded null character.
+      listValue(['🦆🦆🦆🦆🦆🦆', 'goose', null, '']),
+      null,
+    ],
+    [[], ['🦆🦆🦆🦆🦆🦆', 'goose', null, ''], null]
+  ),
+  col(
+    'nested_int_array',
+    LIST(LIST(INTEGER)),
+    [
+      listValue([]),
+      listValue([
+        listValue([]),
+        listValue([42, 999, null, null, -42]),
+        null,
+        listValue([]),
+        listValue([42, 999, null, null, -42]),
+      ]),
+      null,
+    ],
+    [
+      [],
+      [[], [42, 999, null, null, -42], null, [], [42, 999, null, null, -42]],
+      null,
+    ]
+  ),
+  col(
+    'struct',
+    STRUCT({ 'a': INTEGER, 'b': VARCHAR }),
+    [
       structValue({ 'a': null, 'b': null }),
       structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
       null,
-    ]),
-    null,
-  ]),
-  col('map', MAP(VARCHAR, VARCHAR), [
-    mapValue([]),
-    mapValue([
-      { key: 'key1', value: '🦆🦆🦆🦆🦆🦆' },
-      { key: 'key2', value: 'goose' },
-    ]),
-    null,
-  ]),
-  col('union', UNION({ 'name': VARCHAR, 'age': SMALLINT }), [
-    unionValue('name', 'Frank'),
-    unionValue('age', 5),
-    null,
-  ]),
-  col('fixed_int_array', ARRAY(INTEGER, 3), [
-    arrayValue([null, 2, 3]),
-    arrayValue([4, 5, 6]),
-    null,
-  ]),
-  col('fixed_varchar_array', ARRAY(VARCHAR, 3), [
-    arrayValue(['a', null, 'c']),
-    arrayValue(['d', 'e', 'f']),
-    null,
-  ]),
-  col('fixed_nested_int_array', ARRAY(ARRAY(INTEGER, 3), 3), [
-    arrayValue([arrayValue([null, 2, 3]), null, arrayValue([null, 2, 3])]),
-    arrayValue([
-      arrayValue([4, 5, 6]),
-      arrayValue([null, 2, 3]),
-      arrayValue([4, 5, 6]),
-    ]),
-    null,
-  ]),
-  col('fixed_nested_varchar_array', ARRAY(ARRAY(VARCHAR, 3), 3), [
-    arrayValue([
-      arrayValue(['a', null, 'c']),
+    ],
+    [{ 'a': null, 'b': null }, { 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }, null]
+  ),
+  col(
+    'struct_of_arrays',
+    STRUCT({ 'a': LIST(INTEGER), 'b': LIST(VARCHAR) }),
+    [
+      structValue({ 'a': null, 'b': null }),
+      structValue({
+        'a': listValue([42, 999, null, null, -42]),
+        'b': listValue(['🦆🦆🦆🦆🦆🦆', 'goose', null, '']),
+      }),
       null,
-      arrayValue(['a', null, 'c']),
-    ]),
-    arrayValue([
-      arrayValue(['d', 'e', 'f']),
-      arrayValue(['a', null, 'c']),
-      arrayValue(['d', 'e', 'f']),
-    ]),
-    null,
-  ]),
-  col('fixed_struct_array', ARRAY(STRUCT({ 'a': INTEGER, 'b': VARCHAR }), 3), [
-    arrayValue([
-      structValue({ 'a': null, 'b': null }),
-      structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
-      structValue({ 'a': null, 'b': null }),
-    ]),
-    arrayValue([
-      structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
-      structValue({ 'a': null, 'b': null }),
-      structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
-    ]),
-    null,
-  ]),
+    ],
+    [
+      { 'a': null, 'b': null },
+      {
+        'a': [42, 999, null, null, -42],
+        'b': ['🦆🦆🦆🦆🦆🦆', 'goose', null, ''],
+      },
+      null,
+    ]
+  ),
+  col(
+    'array_of_structs',
+    LIST(STRUCT({ 'a': INTEGER, 'b': VARCHAR })),
+    [
+      listValue([]),
+      listValue([
+        structValue({ 'a': null, 'b': null }),
+        structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
+        null,
+      ]),
+      null,
+    ],
+    [
+      [],
+      [{ 'a': null, 'b': null }, { 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }, null],
+      null,
+    ]
+  ),
+  col(
+    'map',
+    MAP(VARCHAR, VARCHAR),
+    [
+      mapValue([]),
+      mapValue([
+        { key: 'key1', value: '🦆🦆🦆🦆🦆🦆' },
+        { key: 'key2', value: 'goose' },
+      ]),
+      null,
+    ],
+    [
+      [],
+      [
+        { 'key': 'key1', 'value': '🦆🦆🦆🦆🦆🦆' },
+        { 'key': 'key2', 'value': 'goose' },
+      ],
+      null,
+    ]
+  ),
+  col(
+    'union',
+    UNION({ 'name': VARCHAR, 'age': SMALLINT }),
+    [unionValue('name', 'Frank'), unionValue('age', 5), null],
+    [{ 'tag': 'name', 'value': 'Frank' }, { 'tag': 'age', 'value': 5 }, null]
+  ),
+  col(
+    'fixed_int_array',
+    ARRAY(INTEGER, 3),
+    [arrayValue([null, 2, 3]), arrayValue([4, 5, 6]), null],
+    [[null, 2, 3], [4, 5, 6], null]
+  ),
+  col(
+    'fixed_varchar_array',
+    ARRAY(VARCHAR, 3),
+    [arrayValue(['a', null, 'c']), arrayValue(['d', 'e', 'f']), null],
+    [['a', null, 'c'], ['d', 'e', 'f'], null]
+  ),
+  col(
+    'fixed_nested_int_array',
+    ARRAY(ARRAY(INTEGER, 3), 3),
+    [
+      arrayValue([arrayValue([null, 2, 3]), null, arrayValue([null, 2, 3])]),
+      arrayValue([
+        arrayValue([4, 5, 6]),
+        arrayValue([null, 2, 3]),
+        arrayValue([4, 5, 6]),
+      ]),
+      null,
+    ],
+    [
+      [[null, 2, 3], null, [null, 2, 3]],
+      [
+        [4, 5, 6],
+        [null, 2, 3],
+        [4, 5, 6],
+      ],
+      null,
+    ]
+  ),
+  col(
+    'fixed_nested_varchar_array',
+    ARRAY(ARRAY(VARCHAR, 3), 3),
+    [
+      arrayValue([
+        arrayValue(['a', null, 'c']),
+        null,
+        arrayValue(['a', null, 'c']),
+      ]),
+      arrayValue([
+        arrayValue(['d', 'e', 'f']),
+        arrayValue(['a', null, 'c']),
+        arrayValue(['d', 'e', 'f']),
+      ]),
+      null,
+    ],
+    [
+      [['a', null, 'c'], null, ['a', null, 'c']],
+      [
+        ['d', 'e', 'f'],
+        ['a', null, 'c'],
+        ['d', 'e', 'f'],
+      ],
+      null,
+    ]
+  ),
+  col(
+    'fixed_struct_array',
+    ARRAY(STRUCT({ 'a': INTEGER, 'b': VARCHAR }), 3),
+    [
+      arrayValue([
+        structValue({ 'a': null, 'b': null }),
+        structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
+        structValue({ 'a': null, 'b': null }),
+      ]),
+      arrayValue([
+        structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
+        structValue({ 'a': null, 'b': null }),
+        structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
+      ]),
+      null,
+    ],
+    [
+      [
+        { 'a': null, 'b': null },
+        { 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' },
+        { 'a': null, 'b': null },
+      ],
+      [
+        { 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' },
+        { 'a': null, 'b': null },
+        { 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' },
+      ],
+      null,
+    ]
+  ),
   col(
     'struct_of_fixed_array',
     STRUCT({ 'a': ARRAY(INTEGER, 3), 'b': ARRAY(VARCHAR, 3) }),
@@ -307,38 +590,70 @@ export const testAllTypesData: ColumnNameTypeAndRows[] = [
         'b': arrayValue(['d', 'e', 'f']),
       }),
       null,
+    ],
+    [
+      { 'a': [null, 2, 3], 'b': ['a', null, 'c'] },
+      { 'a': [4, 5, 6], 'b': ['d', 'e', 'f'] },
+      null,
     ]
   ),
-  col('fixed_array_of_int_list', ARRAY(LIST(INTEGER), 3), [
-    arrayValue([
-      listValue([]),
-      listValue([42, 999, null, null, -42]),
-      listValue([]),
-    ]),
-    arrayValue([
-      listValue([42, 999, null, null, -42]),
-      listValue([]),
-      listValue([42, 999, null, null, -42]),
-    ]),
-    null,
-  ]),
-  col('list_of_fixed_int_array', LIST(ARRAY(INTEGER, 3)), [
-    listValue([
-      arrayValue([null, 2, 3]),
-      arrayValue([4, 5, 6]),
-      arrayValue([null, 2, 3]),
-    ]),
-    listValue([
-      arrayValue([4, 5, 6]),
-      arrayValue([null, 2, 3]),
-      arrayValue([4, 5, 6]),
-    ]),
-    null,
-  ]),
+  col(
+    'fixed_array_of_int_list',
+    ARRAY(LIST(INTEGER), 3),
+    [
+      arrayValue([
+        listValue([]),
+        listValue([42, 999, null, null, -42]),
+        listValue([]),
+      ]),
+      arrayValue([
+        listValue([42, 999, null, null, -42]),
+        listValue([]),
+        listValue([42, 999, null, null, -42]),
+      ]),
+      null,
+    ],
+    [
+      [[], [42, 999, null, null, -42], []],
+      [[42, 999, null, null, -42], [], [42, 999, null, null, -42]],
+      null,
+    ]
+  ),
+  col(
+    'list_of_fixed_int_array',
+    LIST(ARRAY(INTEGER, 3)),
+    [
+      listValue([
+        arrayValue([null, 2, 3]),
+        arrayValue([4, 5, 6]),
+        arrayValue([null, 2, 3]),
+      ]),
+      listValue([
+        arrayValue([4, 5, 6]),
+        arrayValue([null, 2, 3]),
+        arrayValue([4, 5, 6]),
+      ]),
+      null,
+    ],
+    [
+      [
+        [null, 2, 3],
+        [4, 5, 6],
+        [null, 2, 3],
+      ],
+      [
+        [4, 5, 6],
+        [null, 2, 3],
+        [4, 5, 6],
+      ],
+      null,
+    ]
+  ),
 ];
 
-export const testAllTypesColumnNames: readonly string[] =
-  testAllTypesData.map(({ name }) => name);
+export const testAllTypesColumnNames: readonly string[] = testAllTypesData.map(
+  ({ name }) => name
+);
 
 export const testAllTypesColumnTypes: readonly DuckDBType[] =
   testAllTypesData.map(({ type }) => type);
@@ -348,3 +663,32 @@ export const testAllTypesColumnsNamesAndTypes: readonly ColumnNameAndType[] =
 
 export const testAllTypesColumns: readonly (readonly DuckDBValue[])[] =
   testAllTypesData.map(({ rows }) => rows);
+
+export const testAllTypesColumnsJson: readonly (readonly Json[])[] =
+  testAllTypesData.map(({ json }) => json);
+
+export const testAllTypesColumnsObjectJson: Record<string, readonly Json[]> =
+  (function () {
+    const columnsObject: Record<string, readonly Json[]> = {};
+    for (const columnData of testAllTypesData) {
+      columnsObject[columnData.name] = columnData.json;
+    }
+    return columnsObject;
+  })();
+
+export const testAllTypesRowsJson: readonly (readonly Json[])[] = [
+  testAllTypesData.map(({ json }) => json[0]),
+  testAllTypesData.map(({ json }) => json[1]),
+  testAllTypesData.map(({ json }) => json[2]),
+];
+
+export const testAllTypesRowObjectsJson: readonly Record<string, Json>[] =
+  (function () {
+    const rowObjects: Record<string, Json>[] = [{}, {}, {}];
+    for (const columnData of testAllTypesData) {
+      rowObjects[0][columnData.name] = columnData.json[0];
+      rowObjects[1][columnData.name] = columnData.json[1];
+      rowObjects[2][columnData.name] = columnData.json[2];
+    }
+    return rowObjects;
+  })();


### PR DESCRIPTION
Add several new helpers for getting result data as JSON-serializable values.

Both DuckDBResult and DuckDBResultReader now have `getColumnsJson`, `getColumnsObjectJson`, `getRowsJson`, and `getRowObjectsJson`.

The conversion to JSON-serializable values is non-lossy. DuckDB data values that cannot be expressed in JSON are usually converted to a string; in a few cases (e.g. INTERVAL, MAP, UNION) they're converted to an object or array.

This is implemented using a general-purpose value conversion mechanism, which is exposed on DuckDBDataChunk. Other conversions can be implemented using this mechanism.