### PR TITLE
accept null or undefined for logical type alias

### DIFF
--- a/api/src/DuckDBLogicalType.ts
+++ b/api/src/DuckDBLogicalType.ts
@@ -145,8 +145,8 @@ export class DuckDBLogicalType {
   public get alias(): string | undefined {
     return duckdb.logical_type_get_alias(this.logical_type) || undefined;
   }
-  public set alias(newAlias: string) {
-    duckdb.logical_type_set_alias(this.logical_type, newAlias);
+  public set alias(newAlias: string | null | undefined) {
+    duckdb.logical_type_set_alias(this.logical_type, newAlias || '');
   }
   public asType(): DuckDBType {
     const alias = this.alias;


### PR DESCRIPTION
Older versions of TypeScript (than 5.1) require that the type of a `get` accessor be assignable to the type of the corresponding `set` accessor. Because the type of `set` accessor for `DuckDBLogicalType.alias` did not include `undefined`, it triggered a compiler error for these older TS versions. It's trivial to support these older versions by accepting `undefined` (or `null`) and treating it the same as the empty string, which matches the same behavior as the underlying C API function.

See https://github.com/duckdb/duckdb-node-neo/issues/120