### PR TITLE
feat: explicit loading of native binaries

### DIFF
--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.js
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.js
@@ -1,1 +1,26 @@
-module.exports = require(`@duckdb/node-bindings-${process.platform}-${process.arch}/duckdb.node`);
+const getRuntimePlatformArch = () => `${process.platform}-${process.arch}`;
+
+let native;
+
+switch(getRuntimePlatformArch()) {
+    case 'linux-x64':
+        native = require('@duckdb/node-bindings-linux-x64/duckdb.node');
+        break;
+    case 'linux-arm64':
+        native = require('@duckdb/node-bindings-linux-arm64/duckdb.node');
+        break;
+    case 'darwin-arm64':
+        native = require('@duckdb/node-bindings-darwin-arm64/duckdb.node');
+        break;
+    case 'darwin-x64':
+        native = require('@duckdb/node-bindings-darwin-x64/duckdb.node');
+        break;
+    case 'win32-x64':
+        native = require('@duckdb/node-bindings-win32-x64/duckdb.node');
+        break;
+    default:
+        throw new Error(`Unsupported platform: ${getRuntimePlatformArch()}`);
+}
+
+module.exports = native;
+

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.js
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.js
@@ -1,26 +1,24 @@
 const getRuntimePlatformArch = () => `${process.platform}-${process.arch}`;
 
-let native;
-
-switch(getRuntimePlatformArch()) {
-    case 'linux-x64':
-        native = require('@duckdb/node-bindings-linux-x64/duckdb.node');
-        break;
-    case 'linux-arm64':
-        native = require('@duckdb/node-bindings-linux-arm64/duckdb.node');
-        break;
-    case 'darwin-arm64':
-        native = require('@duckdb/node-bindings-darwin-arm64/duckdb.node');
-        break;
-    case 'darwin-x64':
-        native = require('@duckdb/node-bindings-darwin-x64/duckdb.node');
-        break;
-    case 'win32-x64':
-        native = require('@duckdb/node-bindings-win32-x64/duckdb.node');
-        break;
-    default:
-        throw new Error(`Unsupported platform: ${getRuntimePlatformArch()}`);
+/**
+ * @throw Error if there isn't any available native binding for the current platform/arch.
+ */
+const getNativeNodeBinding = (runtimePlatformArch) => {
+    switch(runtimePlatformArch) {
+        case `linux-x64`:
+            return require('@duckdb/node-bindings-linux-x64/duckdb.node');
+        case 'linux-arm64':
+            return require('@duckdb/node-bindings-linux-arm64/duckdb.node');
+        case 'darwin-arm64':
+            return require('@duckdb/node-bindings-darwin-arm64/duckdb.node');
+        case 'darwin-x64':
+            return require('@duckdb/node-bindings-darwin-x64/duckdb.node');
+        case 'win32-x64':
+            return require('@duckdb/node-bindings-win32-x64/duckdb.node');
+        default:
+            const [platform, arch] = runtimePlatformArch.split('-')
+            throw new Error(`Error loading duckdb native binding: unsupported arch '${arch}' for platform '${platform}'`);
+    }
 }
 
-module.exports = native;
-
+module.exports = getNativeNodeBinding(getRuntimePlatformArch());


### PR DESCRIPTION
Proposal to fix: https://github.com/duckdb/duckdb-node-neo/issues/126

Before this change, the loading of node js binary was fully dynamic. 

The proposed way to do this is to explicitly define all binaries that could be loaded. That helps framework that applies tracing on node_modules such as nextjs (when deployed as lambda or standalone) to detect that the binary is in use.  It also allows to set a custom message indicating the reason of error.


- [ ] Is the proposed way good enough ?
- [x] What error message to display when an architecture isn't supported ?


There's many other ways to achieve the same idea (see esbuild, or sharp with require.resolve), this one keeps the loading as simple possible.

Happy to discuss if it makes sense
