### PR TITLE
fix empty nested values and types

### DIFF
--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -2584,7 +2584,9 @@ private:
     auto logical_type = GetLogicalTypeFromExternal(env, info[0]);
     auto values_array = info[1].As<Napi::Array>();
     auto values_count = values_array.Length();
-    std::vector<duckdb_value> values_vector(values_count);
+    // If there are no values, we still need a valid data pointer, so create a single element vector containing a null.
+    std::vector<duckdb_value> values_vector(values_count > 0 ? values_count : 1);
+    values_vector[0] = nullptr;
     for (uint32_t i = 0; i < values_count; i++) {
       values_vector[i] = GetValueFromExternal(env, values_array.Get(i));
     }
@@ -2599,7 +2601,9 @@ private:
     auto logical_type = GetLogicalTypeFromExternal(env, info[0]);
     auto values_array = info[1].As<Napi::Array>();
     auto values_count = values_array.Length();
-    std::vector<duckdb_value> values_vector(values_count);
+    // If there are no values, we still need a valid data pointer, so create a single element vector containing a null.
+    std::vector<duckdb_value> values_vector(values_count > 0 ? values_count : 1);
+    values_vector[0] = nullptr;
     for (uint32_t i = 0; i < values_count; i++) {
       values_vector[i] = GetValueFromExternal(env, values_array.Get(i));
     }
@@ -2614,7 +2618,9 @@ private:
     auto logical_type = GetLogicalTypeFromExternal(env, info[0]);
     auto values_array = info[1].As<Napi::Array>();
     auto values_count = values_array.Length();
-    std::vector<duckdb_value> values_vector(values_count);
+    // If there are no values, we still need a valid data pointer, so create a single element vector containing a null.
+    std::vector<duckdb_value> values_vector(values_count > 0 ? values_count : 1);
+    values_vector[0] = nullptr;
     for (uint32_t i = 0; i < values_count; i++) {
       values_vector[i] = GetValueFromExternal(env, values_array.Get(i));
     }
@@ -2722,9 +2728,12 @@ private:
     auto member_types_count = member_types_array.Length();
     auto member_names_count = member_names_array.Length();
     auto member_count = member_types_count < member_names_count ? member_types_count : member_names_count;
-    std::vector<duckdb_logical_type> member_types(member_count);
+    // If there are no members, we still need valid data pointers, so create single element vectors containing nulls.
+    std::vector<duckdb_logical_type> member_types(member_count > 0 ? member_count : 1);
     std::vector<std::string> member_names_strings(member_count);
-    std::vector<const char *> member_names(member_count);
+    std::vector<const char *> member_names(member_count > 0 ? member_count : 1);
+    member_types[0] = nullptr;
+    member_names[0] = nullptr;
     for (uint32_t i = 0; i < member_count; i++) {
       member_types[i] = GetLogicalTypeFromExternal(env, member_types_array.Get(i));
       member_names_strings[i] = member_names_array.Get(i).As<Napi::String>();
@@ -2743,9 +2752,12 @@ private:
     auto member_types_count = member_types_array.Length();
     auto member_names_count = member_names_array.Length();
     auto member_count = member_types_count < member_names_count ? member_types_count : member_names_count;
-    std::vector<duckdb_logical_type> member_types(member_count);
+    // If there are no members, we still need valid data pointers, so create single element vectors containing nulls.
+    std::vector<duckdb_logical_type> member_types(member_count > 0 ? member_count : 1);
     std::vector<std::string> member_names_strings(member_count);
-    std::vector<const char *> member_names(member_count);
+    std::vector<const char *> member_names(member_count > 0 ? member_count : 1);
+    member_types[0] = nullptr;
+    member_names[0] = nullptr;
     for (uint32_t i = 0; i < member_count; i++) {
       member_types[i] = GetLogicalTypeFromExternal(env, member_types_array.Get(i));
       member_names_strings[i] = member_names_array.Get(i).As<Napi::String>();
@@ -2762,7 +2774,9 @@ private:
     auto member_names_array = info[0].As<Napi::Array>();
     auto member_count = member_names_array.Length();
     std::vector<std::string> member_names_strings(member_count);
-    std::vector<const char *> member_names(member_count);
+    // If there are no members, we still need a valid data pointer, so create a single element vector containing a null.
+    std::vector<const char *> member_names(member_count > 0 ? member_count : 1);
+    member_names[0] = nullptr;
     for (uint32_t i = 0; i < member_count; i++) {
       member_names_strings[i] = member_names_array.Get(i).As<Napi::String>();
       member_names[i] = member_names_strings[i].c_str();
@@ -2966,7 +2980,9 @@ private:
     auto env = info.Env();
     auto types_array = info[0].As<Napi::Array>();
     auto types_count = types_array.Length();
-    std::vector<duckdb_logical_type> types(types_count);
+    // If there are no types, we still need a valid data pointer, so create a single element vector containing a null.
+    std::vector<duckdb_logical_type> types(types_count > 0 ? types_count : 1);
+    types[0] = nullptr;
     for (uint32_t i = 0; i < types_count; i++) {
       types[i] = GetLogicalTypeFromExternal(env, types_array.Get(i));
     }

--- a/bindings/test/data_chunk.test.ts
+++ b/bindings/test/data_chunk.test.ts
@@ -133,4 +133,8 @@ suite('data chunk', () => {
     duckdb.list_vector_set_size(vector, 5);
     expect(duckdb.list_vector_get_size(vector)).toBe(5);
   });
+  test('create no types', () => {
+    const chunk = duckdb.create_data_chunk([]);
+    expect(duckdb.data_chunk_get_column_count(chunk)).toBe(0);
+  });
 });

--- a/bindings/test/logical_type.test.ts
+++ b/bindings/test/logical_type.test.ts
@@ -77,6 +77,13 @@ suite('logical_type', () => {
     expect(duckdb.enum_dictionary_value(enum_type, 0)).toBe('enum_0');
     expect(duckdb.enum_dictionary_value(enum_type, 69999)).toBe('enum_69999');
   });
+  test('empty enum', () => {
+    const enum_type = duckdb.create_enum_type([]);
+    expect(duckdb.get_type_id(enum_type)).toBe(duckdb.Type.ENUM);
+    expect(duckdb.logical_type_get_alias(enum_type)).toBeNull();
+    expect(duckdb.enum_internal_type(enum_type)).toBe(duckdb.Type.UTINYINT);
+    expect(duckdb.enum_dictionary_size(enum_type)).toBe(0);
+  });
   test('list', () => {
     const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
     const list_type = duckdb.create_list_type(int_type);
@@ -110,6 +117,12 @@ suite('logical_type', () => {
     const member_type_1 = duckdb.struct_type_child_type(struct_type, 1);
     expect(duckdb.get_type_id(member_type_1)).toBe(duckdb.Type.VARCHAR);
   });
+  test('empty struct', () => {
+    const struct_type = duckdb.create_struct_type([], []);
+    expect(duckdb.get_type_id(struct_type)).toBe(duckdb.Type.STRUCT);
+    expect(duckdb.logical_type_get_alias(struct_type)).toBeNull();
+    expect(duckdb.struct_type_child_count(struct_type)).toBe(0);
+  });
   test('union', () => {
     const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
     const smallint_type = duckdb.create_logical_type(duckdb.Type.SMALLINT);
@@ -123,5 +136,11 @@ suite('logical_type', () => {
     expect(duckdb.get_type_id(member_type_0)).toBe(duckdb.Type.VARCHAR);
     const member_type_1 = duckdb.union_type_member_type(union_type, 1);
     expect(duckdb.get_type_id(member_type_1)).toBe(duckdb.Type.SMALLINT);
+  });
+  test('empty union', () => {
+    const union_type = duckdb.create_union_type([], []);
+    expect(duckdb.get_type_id(union_type)).toBe(duckdb.Type.UNION);
+    expect(duckdb.logical_type_get_alias(union_type)).toBeNull();
+    expect(duckdb.union_type_member_count(union_type)).toBe(0);
   });
 });

--- a/bindings/test/values.test.ts
+++ b/bindings/test/values.test.ts
@@ -2,16 +2,20 @@ import duckdb from '@duckdb/node-bindings';
 import { expect, suite, test } from 'vitest';
 import { expectLogicalType } from './utils/expectLogicalType';
 import {
+  ARRAY,
   BIGINT,
   BLOB,
   BOOLEAN,
   DATE,
   DOUBLE,
+  ENTRY,
   FLOAT,
   HUGEINT,
   INTEGER,
   INTERVAL,
+  LIST,
   SMALLINT,
+  STRUCT,
   TIME,
   TIME_TZ,
   TIMESTAMP,
@@ -144,5 +148,39 @@ suite('values', () => {
     const varchar_value = duckdb.create_varchar(input);
     expectLogicalType(duckdb.get_value_type(varchar_value), VARCHAR);
     expect(duckdb.get_varchar(varchar_value)).toBe(input);
+  });
+  test('struct', () => {
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    const struct_type = duckdb.create_struct_type([int_type], ['a']);
+    const int32_value = duckdb.create_int32(42);
+    const struct_value = duckdb.create_struct_value(struct_type, [int32_value]);
+    expectLogicalType(duckdb.get_value_type(struct_value), STRUCT(ENTRY('a', INTEGER)));
+  });
+  test('empty struct', () => {
+    const struct_type = duckdb.create_struct_type([], []);
+    const struct_value = duckdb.create_struct_value(struct_type, []);
+    expectLogicalType(duckdb.get_value_type(struct_value), STRUCT());
+  });
+  test('list', () => {
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    const int32_value = duckdb.create_int32(42);
+    const list_value = duckdb.create_list_value(int_type, [int32_value]);
+    expectLogicalType(duckdb.get_value_type(list_value), LIST(INTEGER));
+  });
+  test('empty list', () => {
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    const list_value = duckdb.create_list_value(int_type, []);
+    expectLogicalType(duckdb.get_value_type(list_value), LIST(INTEGER));
+  });
+  test('array', () => {
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    const int32_value = duckdb.create_int32(42);
+    const array_value = duckdb.create_array_value(int_type, [int32_value]);
+    expectLogicalType(duckdb.get_value_type(array_value), ARRAY(INTEGER, 1));
+  });
+  test('empty array', () => {
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    const array_value = duckdb.create_array_value(int_type, []);
+    expectLogicalType(duckdb.get_value_type(array_value), ARRAY(INTEGER, 0));
   });
 });


### PR DESCRIPTION
Fix for https://github.com/duckdb/duckdb-node-neo/issues/128.

When creating struct, list, or array values, or struct, union, or enum types, or data chunks, special handling is needed when empty arrays are provided. The underlying C API functions need valid data pointers even though the supplied count is zero.

Added unit tests for all relevant cases.