### PR TITLE
fix crash on finalization for logical_type from get_value_type

### DIFF
--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -267,10 +267,9 @@ jobs:
         working-directory: bindings
         run: pnpm run build
       
-      # Fails for unknown reasons
-      # - name: Bindings - Test
-      #   working-directory: bindings
-      #   run: pnpm test
+      - name: Bindings - Test
+        working-directory: bindings
+        run: pnpm test
       
       - name: API - Build
         working-directory: api

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -360,14 +360,15 @@ static const napi_type_tag LogicalTypeTypeTag = {
 };
 
 void FinalizeLogicalType(Napi::BasicEnv, duckdb_logical_type logical_type) {
-  if (logical_type) {
-    duckdb_destroy_logical_type(&logical_type);
-    logical_type = nullptr;
-  }
+  duckdb_destroy_logical_type(&logical_type);
 }
 
 Napi::External<_duckdb_logical_type> CreateExternalForLogicalType(Napi::Env env, duckdb_logical_type logical_type) {
   return CreateExternal<_duckdb_logical_type>(env, LogicalTypeTypeTag, logical_type, FinalizeLogicalType);
+}
+
+Napi::External<_duckdb_logical_type> CreateExternalForLogicalTypeWithoutFinalizer(Napi::Env env, duckdb_logical_type logical_type) {
+  return CreateExternalWithoutFinalizer<_duckdb_logical_type>(env, LogicalTypeTypeTag, logical_type);
 }
 
 duckdb_logical_type GetLogicalTypeFromExternal(Napi::Env env, Napi::Value value) {
@@ -2554,7 +2555,7 @@ private:
     auto env = info.Env();
     auto value = GetValueFromExternal(env, info[0]);
     auto logical_type = duckdb_get_value_type(value);
-    return CreateExternalForLogicalType(env, logical_type);
+    return CreateExternalForLogicalTypeWithoutFinalizer(env, logical_type);
   }
 
   // DUCKDB_API duckdb_blob duckdb_get_blob(duckdb_value val);


### PR DESCRIPTION
Fix a crash caused by destroying the `logical_type` returned by `get_value_type` in the finalizer for the returned External. Apparently, unlike all other `logical_type`s returned by the C API, this one must not be explicitly destroyed; it's tied to the lifetime of the value.

This was the cause of the frequent but inconsistent failures in the bindings tests for Windows. Probably it was only happening on Windows and not the other platforms due to timing differences. I re-enabled the Windows tests.