### PR TITLE
guard against null errors

### DIFF
--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -590,8 +590,14 @@ protected:
       return;
     }
     result_ptr_ = reinterpret_cast<duckdb_result*>(duckdb_malloc(sizeof(duckdb_result)));
+    result_ptr_->internal_data = nullptr;
     if (duckdb_query(connection_, query_.c_str(), result_ptr_)) {
-      SetError(duckdb_result_error(result_ptr_));
+      auto error = duckdb_result_error(result_ptr_);
+      if (error) {
+        SetError(error);
+      } else {
+        SetError("Failed to query");
+      }
       duckdb_destroy_result(result_ptr_);
       duckdb_free(result_ptr_);
       result_ptr_ = nullptr;
@@ -659,8 +665,14 @@ protected:
 
   void Execute() override {
     result_ptr_ = reinterpret_cast<duckdb_result*>(duckdb_malloc(sizeof(duckdb_result)));
+    result_ptr_->internal_data = nullptr;
     if (duckdb_execute_prepared(prepared_statement_, result_ptr_)) {
-      SetError(duckdb_result_error(result_ptr_));
+      auto error = duckdb_result_error(result_ptr_);
+      if (error) {
+        SetError(error);
+      } else {
+        SetError("Failed to execute prepared statement");
+      }
       duckdb_destroy_result(result_ptr_);
       duckdb_free(result_ptr_);
       result_ptr_ = nullptr;
@@ -690,8 +702,14 @@ protected:
 
   void Execute() override {
     result_ptr_ = reinterpret_cast<duckdb_result*>(duckdb_malloc(sizeof(duckdb_result)));
+    result_ptr_->internal_data = nullptr;
     if (duckdb_execute_prepared_streaming(prepared_statement_, result_ptr_)) {
-      SetError(duckdb_result_error(result_ptr_));
+      auto error = duckdb_result_error(result_ptr_);
+      if (error) {
+        SetError(error);
+      } else {
+        SetError("Failed to execute prepared statement");
+      }
       duckdb_destroy_result(result_ptr_);
       duckdb_free(result_ptr_);
       result_ptr_ = nullptr;
@@ -793,8 +811,14 @@ protected:
 
   void Execute() override {
     result_ptr_ = reinterpret_cast<duckdb_result*>(duckdb_malloc(sizeof(duckdb_result)));
+    result_ptr_->internal_data = nullptr;
     if (duckdb_execute_pending(pending_result_, result_ptr_)) {
-      SetError(duckdb_result_error(result_ptr_));
+      auto error = duckdb_result_error(result_ptr_);
+      if (error) {
+        SetError(error);
+      } else {
+        SetError("Failed to execute pending result");
+      }
       duckdb_destroy_result(result_ptr_);
       duckdb_free(result_ptr_);
       result_ptr_ = nullptr;

--- a/bindings/test/prepared_statements.test.ts
+++ b/bindings/test/prepared_statements.test.ts
@@ -442,4 +442,12 @@ suite('prepared statements', () => {
       });
     });
   });
+  test.skip('run in parallel (throws nondeterministically, as expected)', async () => {
+    await withConnection(async (connection) => {
+      const prepared = await duckdb.prepare(connection, 'select 1');
+      for (let i = 0; i < 1000; i++) {
+        duckdb.execute_prepared(prepared);
+      }
+    });
+  });
 });


### PR DESCRIPTION
Fix a seg fault that can occur a C API function returns an error without creating a result. We need to initialize the result's internal data to `nullptr`, and also handle when `duckdb_result_error` returns `nullptr`. See https://github.com/duckdb/duckdb-node-neo/issues/142 for the scenario in which this was discovered.

It's hard to add a unit test for this because the known case where this can occur is nondeterministic. I added a test that I used to manually repro and verify the fix, but it's skipped by default because of the nondeterminism.