### PR TITLE
is_finite for non-standard timestamps

### DIFF
--- a/api/src/DuckDBType.ts
+++ b/api/src/DuckDBType.ts
@@ -436,6 +436,12 @@ export class DuckDBTimestampSecondsType extends BaseDuckDBType<DuckDBTypeId.TIME
   public get min() {
     return DuckDBTimestampSecondsValue.Min;
   }
+  public get posInf() {
+    return DuckDBTimestampSecondsValue.PosInf;
+  }
+  public get negInf() {
+    return DuckDBTimestampSecondsValue.NegInf;
+  }
 }
 export const TIMESTAMP_S = DuckDBTimestampSecondsType.instance;
 
@@ -458,6 +464,12 @@ export class DuckDBTimestampMillisecondsType extends BaseDuckDBType<DuckDBTypeId
   public get min() {
     return DuckDBTimestampMillisecondsValue.Min;
   }
+  public get posInf() {
+    return DuckDBTimestampMillisecondsValue.PosInf;
+  }
+  public get negInf() {
+    return DuckDBTimestampMillisecondsValue.NegInf;
+  }
 }
 export const TIMESTAMP_MS = DuckDBTimestampMillisecondsType.instance;
 
@@ -479,6 +491,12 @@ export class DuckDBTimestampNanosecondsType extends BaseDuckDBType<DuckDBTypeId.
   }
   public get min() {
     return DuckDBTimestampNanosecondsValue.Min;
+  }
+  public get posInf() {
+    return DuckDBTimestampNanosecondsValue.PosInf;
+  }
+  public get negInf() {
+    return DuckDBTimestampNanosecondsValue.NegInf;
   }
 }
 export const TIMESTAMP_NS = DuckDBTimestampNanosecondsType.instance;

--- a/api/src/DuckDBVector.ts
+++ b/api/src/DuckDBVector.ts
@@ -2410,7 +2410,7 @@ export class DuckDBTimestampMillisecondsVector extends DuckDBVector<DuckDBTimest
     value: DuckDBTimestampMillisecondsValue | null
   ) {
     if (value != null) {
-      this.items[itemIndex] = value.milliseconds;
+      this.items[itemIndex] = value.millis;
       this.validity.setItemValid(itemIndex, true);
     } else {
       this.validity.setItemValid(itemIndex, false);
@@ -2482,7 +2482,7 @@ export class DuckDBTimestampNanosecondsVector extends DuckDBVector<DuckDBTimesta
     value: DuckDBTimestampNanosecondsValue | null
   ) {
     if (value != null) {
-      this.items[itemIndex] = value.nanoseconds;
+      this.items[itemIndex] = value.nanos;
       this.validity.setItemValid(itemIndex, true);
     } else {
       this.validity.setItemValid(itemIndex, false);

--- a/api/src/values/DuckDBTimestampMillisecondsValue.ts
+++ b/api/src/values/DuckDBTimestampMillisecondsValue.ts
@@ -1,22 +1,29 @@
+import duckdb, { TimestampMilliseconds } from '@duckdb/node-bindings';
 import { getDuckDBTimestampStringFromMilliseconds } from '../conversion/dateTimeStringConversion';
 import { DuckDBTimestampSecondsValue } from './DuckDBTimestampSecondsValue';
 
-export class DuckDBTimestampMillisecondsValue {
-  public readonly milliseconds: bigint;
+export class DuckDBTimestampMillisecondsValue implements TimestampMilliseconds {
+  public readonly millis: bigint;
 
-  public constructor(milliseconds: bigint) {
-    this.milliseconds = milliseconds;
+  public constructor(millis: bigint) {
+    this.millis = millis;
+  }
+
+  public get isFinite(): boolean {
+    return duckdb.is_finite_timestamp_ms(this);
   }
 
   public toString(): string {
-    return getDuckDBTimestampStringFromMilliseconds(this.milliseconds);
+    return getDuckDBTimestampStringFromMilliseconds(this.millis);
   }
 
   public static readonly Epoch = new DuckDBTimestampMillisecondsValue(0n);
   public static readonly Max = new DuckDBTimestampMillisecondsValue((2n ** 63n - 2n) / 1000n);
   public static readonly Min = new DuckDBTimestampMillisecondsValue(DuckDBTimestampSecondsValue.Min.seconds * 1000n);
+  public static readonly PosInf = new DuckDBTimestampMillisecondsValue(2n ** 63n - 1n);
+  public static readonly NegInf = new DuckDBTimestampMillisecondsValue(-(2n ** 63n - 1n));
 }
 
-export function timestampMillisValue(milliseconds: bigint): DuckDBTimestampMillisecondsValue {
-  return new DuckDBTimestampMillisecondsValue(milliseconds);
+export function timestampMillisValue(millis: bigint): DuckDBTimestampMillisecondsValue {
+  return new DuckDBTimestampMillisecondsValue(millis);
 }

--- a/api/src/values/DuckDBTimestampNanosecondsValue.ts
+++ b/api/src/values/DuckDBTimestampNanosecondsValue.ts
@@ -1,21 +1,28 @@
+import duckdb, { TimestampNanoseconds } from '@duckdb/node-bindings';
 import { getDuckDBTimestampStringFromNanoseconds } from '../conversion/dateTimeStringConversion';
 
-export class DuckDBTimestampNanosecondsValue {
-  public readonly nanoseconds: bigint;
+export class DuckDBTimestampNanosecondsValue implements TimestampNanoseconds {
+  public readonly nanos: bigint;
 
-  public constructor(nanoseconds: bigint) {
-    this.nanoseconds = nanoseconds;
+  public constructor(nanos: bigint) {
+    this.nanos = nanos;
+  }
+
+  public get isFinite(): boolean {
+    return duckdb.is_finite_timestamp_ns(this);
   }
 
   public toString(): string {
-    return getDuckDBTimestampStringFromNanoseconds(this.nanoseconds);
+    return getDuckDBTimestampStringFromNanoseconds(this.nanos);
   }
 
   public static readonly Epoch = new DuckDBTimestampNanosecondsValue(0n);
   public static readonly Max = new DuckDBTimestampNanosecondsValue(2n ** 63n - 2n);
   public static readonly Min = new DuckDBTimestampNanosecondsValue(-9223286400000000000n);
+  public static readonly PosInf = new DuckDBTimestampNanosecondsValue(2n ** 63n - 1n);
+  public static readonly NegInf = new DuckDBTimestampNanosecondsValue(-(2n ** 63n - 1n));
 }
 
-export function timestampNanosValue(nanoseconds: bigint): DuckDBTimestampNanosecondsValue {
-  return new DuckDBTimestampNanosecondsValue(nanoseconds);
+export function timestampNanosValue(nanos: bigint): DuckDBTimestampNanosecondsValue {
+  return new DuckDBTimestampNanosecondsValue(nanos);
 }

--- a/api/src/values/DuckDBTimestampSecondsValue.ts
+++ b/api/src/values/DuckDBTimestampSecondsValue.ts
@@ -1,10 +1,15 @@
+import duckdb, { TimestampSeconds } from '@duckdb/node-bindings';
 import { getDuckDBTimestampStringFromSeconds } from '../conversion/dateTimeStringConversion';
 
-export class DuckDBTimestampSecondsValue {
+export class DuckDBTimestampSecondsValue implements TimestampSeconds {
   public readonly seconds: bigint;
 
   public constructor(seconds: bigint) {
     this.seconds = seconds;
+  }
+
+  public get isFinite(): boolean {
+    return duckdb.is_finite_timestamp_s(this);
   }
 
   public toString(): string {
@@ -14,6 +19,8 @@ export class DuckDBTimestampSecondsValue {
   public static readonly Epoch = new DuckDBTimestampSecondsValue(0n);
   public static readonly Max = new DuckDBTimestampSecondsValue( 9223372036854n);
   public static readonly Min = new DuckDBTimestampSecondsValue(-9223372022400n); // from test_all_types() select epoch(timestamp_s)::bigint;
+  public static readonly PosInf = new DuckDBTimestampSecondsValue(2n ** 63n - 1n);
+  public static readonly NegInf = new DuckDBTimestampSecondsValue(-(2n ** 63n - 1n));
 }
 
 export function timestampSecondsValue(seconds: bigint): DuckDBTimestampSecondsValue {

--- a/api/src/values/DuckDBTimestampTZValue.ts
+++ b/api/src/values/DuckDBTimestampTZValue.ts
@@ -12,6 +12,10 @@ export class DuckDBTimestampTZValue implements Timestamp {
     this.micros = micros;
   }
 
+  public get isFinite(): boolean {
+    return duckdb.is_finite_timestamp(this);
+  }
+
   public toString(): string {
     return getDuckDBTimestampStringFromMicroseconds(
       this.micros,

--- a/api/src/values/DuckDBTimestampValue.ts
+++ b/api/src/values/DuckDBTimestampValue.ts
@@ -11,6 +11,10 @@ export class DuckDBTimestampValue implements Timestamp {
     this.micros = micros;
   }
 
+  public get isFinite(): boolean {
+    return duckdb.is_finite_timestamp(this);
+  }
+
   public toString(): string {
     return getDuckDBTimestampStringFromMicroseconds(this.micros);
   }
@@ -25,7 +29,7 @@ export class DuckDBTimestampValue implements Timestamp {
   
   public static readonly Epoch = new DuckDBTimestampValue(0n);
   public static readonly Max = new DuckDBTimestampValue(2n ** 63n - 2n);
-  public static readonly Min = new DuckDBTimestampValue(DuckDBTimestampMillisecondsValue.Min.milliseconds * 1000n);
+  public static readonly Min = new DuckDBTimestampValue(DuckDBTimestampMillisecondsValue.Min.millis * 1000n);
   public static readonly PosInf = new DuckDBTimestampValue(2n ** 63n - 1n);
   public static readonly NegInf = new DuckDBTimestampValue(-(2n ** 63n - 1n));
 }

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -1040,6 +1040,34 @@ describe('api', () => {
     assert.isFalse(DATE.posInf.isFinite);
     assert.isFalse(DATE.negInf.isFinite);
   });
+  test('timestamp isFinite', () => {
+    assert.isTrue(TIMESTAMP.epoch.isFinite);
+    assert.isTrue(TIMESTAMP.max.isFinite);
+    assert.isTrue(TIMESTAMP.min.isFinite);
+    assert.isFalse(TIMESTAMP.posInf.isFinite);
+    assert.isFalse(TIMESTAMP.negInf.isFinite);
+  });
+  test('timestamp_s isFinite', () => {
+    assert.isTrue(TIMESTAMP_S.epoch.isFinite);
+    assert.isTrue(TIMESTAMP_S.max.isFinite);
+    assert.isTrue(TIMESTAMP_S.min.isFinite);
+    assert.isFalse(TIMESTAMP_S.posInf.isFinite);
+    assert.isFalse(TIMESTAMP_S.negInf.isFinite);
+  });
+  test('timestamp_ms isFinite', () => {
+    assert.isTrue(TIMESTAMP_MS.epoch.isFinite);
+    assert.isTrue(TIMESTAMP_MS.max.isFinite);
+    assert.isTrue(TIMESTAMP_MS.min.isFinite);
+    assert.isFalse(TIMESTAMP_MS.posInf.isFinite);
+    assert.isFalse(TIMESTAMP_MS.negInf.isFinite);
+  });
+  test('timestamp_ns isFinite', () => {
+    assert.isTrue(TIMESTAMP_NS.epoch.isFinite);
+    assert.isTrue(TIMESTAMP_NS.max.isFinite);
+    assert.isTrue(TIMESTAMP_NS.min.isFinite);
+    assert.isFalse(TIMESTAMP_NS.posInf.isFinite);
+    assert.isFalse(TIMESTAMP_NS.negInf.isFinite);
+  });
   test('value conversion', () => {
     const dateParts: DateParts = { year: 2024, month: 6, day: 3 };
     const timeParts: TimeParts = { hour: 12, min: 34, sec: 56, micros: 789123 };

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -153,6 +153,18 @@ export interface Timestamp {
   /** Microseconds since 1970-01-01 */
   micros: bigint;
 }
+export interface TimestampSeconds {
+  /** Seconds since 1970-01-01 */
+  seconds: bigint;
+}
+export interface TimestampMilliseconds {
+  /** Milliseconds since 1970-01-01 */
+  millis: bigint;
+}
+export interface TimestampNanoseconds {
+  /** Nanoseconds since 1970-01-01 */
+  nanos: bigint;
+}
 export interface TimestampParts {
   date: DateParts;
   time: TimeParts;
@@ -404,8 +416,13 @@ export function to_timestamp(parts: TimestampParts): Timestamp;
 export function is_finite_timestamp(timestamp: Timestamp): boolean;
 
 // DUCKDB_API bool duckdb_is_finite_timestamp_s(duckdb_timestamp_s ts);
+export function is_finite_timestamp_s(timestampSeconds: TimestampSeconds): boolean;
+
 // DUCKDB_API bool duckdb_is_finite_timestamp_ms(duckdb_timestamp_ms ts);
+export function is_finite_timestamp_ms(timestampMilliseconds: TimestampMilliseconds): boolean;
+
 // DUCKDB_API bool duckdb_is_finite_timestamp_ns(duckdb_timestamp_ns ts);
+export function is_finite_timestamp_ns(timestampNanoseconds: TimestampNanoseconds): boolean;
 
 // DUCKDB_API double duckdb_hugeint_to_double(duckdb_hugeint val);
 export function hugeint_to_double(hugeint: bigint): number;

--- a/bindings/test/conversion.test.ts
+++ b/bindings/test/conversion.test.ts
@@ -178,6 +178,66 @@ suite('conversion', () => {
       expect(duckdb.is_finite_timestamp({ micros: -(2n ** 63n - 1n) })).toBe(false);
     });
   });
+  suite('is_finite_timestamp_s', () => {
+    test('mid-range', () => {
+      expect(duckdb.is_finite_timestamp_s({ seconds: 1717418096n })).toBe(true);
+    });
+    test('epoch', () => {
+      expect(duckdb.is_finite_timestamp_s({ seconds: 0n })).toBe(true);
+    });
+    test('min', () => {
+      expect(duckdb.is_finite_timestamp_s({ seconds: -9223372022400n })).toBe(true);
+    });
+    test('max', () => {
+      expect(duckdb.is_finite_timestamp_s({ seconds: 9223372036854n })).toBe(true);
+    });
+    test('infinity', () => {
+      expect(duckdb.is_finite_timestamp_s({ seconds: 2n ** 63n - 1n })).toBe(false);
+    });
+    test('-infinity', () => {
+      expect(duckdb.is_finite_timestamp_s({ seconds: -(2n ** 63n - 1n) })).toBe(false);
+    });
+  });
+  suite('is_finite_timestamp_ms', () => {
+    test('mid-range', () => {
+      expect(duckdb.is_finite_timestamp_ms({ millis: 1717418096789n })).toBe(true);
+    });
+    test('epoch', () => {
+      expect(duckdb.is_finite_timestamp_ms({ millis: 0n })).toBe(true);
+    });
+    test('min', () => {
+      expect(duckdb.is_finite_timestamp_ms({ millis: -9223372022400000n })).toBe(true);
+    });
+    test('max', () => {
+      expect(duckdb.is_finite_timestamp_ms({ millis: 9223372036854775n })).toBe(true);
+    });
+    test('infinity', () => {
+      expect(duckdb.is_finite_timestamp_ms({ millis: 2n ** 63n - 1n })).toBe(false);
+    });
+    test('-infinity', () => {
+      expect(duckdb.is_finite_timestamp_ms({ millis: -(2n ** 63n - 1n) })).toBe(false);
+    });
+  });
+  suite('is_finite_timestamp_ns', () => {
+    test('mid-range', () => {
+      expect(duckdb.is_finite_timestamp_ns({ nanos: 1717418096789123000n })).toBe(true);
+    });
+    test('epoch', () => {
+      expect(duckdb.is_finite_timestamp_ns({ nanos: 0n })).toBe(true);
+    });
+    test('min', () => {
+      expect(duckdb.is_finite_timestamp_ns({ nanos: -9223286400000000000n })).toBe(true);
+    });
+    test('max', () => {
+      expect(duckdb.is_finite_timestamp_ns({ nanos: 9223372036854775806n })).toBe(true);
+    });
+    test('infinity', () => {
+      expect(duckdb.is_finite_timestamp_ns({ nanos: 2n ** 63n - 1n })).toBe(false);
+    });
+    test('-infinity', () => {
+      expect(duckdb.is_finite_timestamp_ns({ nanos: -(2n ** 63n - 1n) })).toBe(false);
+    });
+  });
   suite('hugeint_to_double', () => {
     test('zero', () => {
       expect(duckdb.hugeint_to_double(0n)).toBe(0);


### PR DESCRIPTION
- Add support for is_finite_timestamp_s, is_finite_timestamp_ms, and is_finite_timestamp_ns.
- Add corresponding bindings types, and change API types to match.
- Add pos/neg inf constants for relevant types.
- Add tests in both bindings and API layers.