### PR TITLE
support param_logical_type

### DIFF
--- a/api/src/DuckDBPreparedStatement.ts
+++ b/api/src/DuckDBPreparedStatement.ts
@@ -1,5 +1,6 @@
 import duckdb from '@duckdb/node-bindings';
 import { createValue } from './createValue';
+import { DuckDBLogicalType } from './DuckDBLogicalType';
 import { DuckDBMaterializedResult } from './DuckDBMaterializedResult';
 import { DuckDBPendingResult } from './DuckDBPendingResult';
 import { DuckDBResult } from './DuckDBResult';
@@ -48,6 +49,12 @@ export class DuckDBPreparedStatement {
       this.prepared_statement,
       parameterIndex
     ) as number as DuckDBTypeId;
+  }
+  public parameterType(parameterIndex: number): DuckDBType {
+    return DuckDBLogicalType.create(duckdb.param_logical_type(
+      this.prepared_statement,
+      parameterIndex
+    )).asType();
   }
   public clearBindings() {
     duckdb.clear_bindings(this.prepared_statement);

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -52,6 +52,7 @@ import {
   DuckDBTimestampVector,
   DuckDBTinyIntVector,
   DuckDBType,
+  DuckDBTypeId,
   DuckDBUBigIntVector,
   DuckDBUHugeIntVector,
   DuckDBUIntegerVector,
@@ -422,6 +423,23 @@ describe('api', () => {
       );
       prepared.bindArray(7, arrayValue([100, 200, 300]), ARRAY(INTEGER, 3));
       prepared.bindNull(8);
+      assert.equal(prepared.parameterTypeId(1), DuckDBTypeId.INTEGER);
+      assert.deepEqual(prepared.parameterType(1), INTEGER);
+      // See https://github.com/duckdb/duckdb/issues/16137
+      // assert.equal(prepared.parameterTypeId(2), DuckDBTypeId.VARCHAR);
+      // assert.deepEqual(prepared.parameterType(2), VARCHAR);
+      assert.equal(prepared.parameterTypeId(3), DuckDBTypeId.BOOLEAN);
+      assert.deepEqual(prepared.parameterType(3), BOOLEAN);
+      assert.equal(prepared.parameterTypeId(4), DuckDBTypeId.TIME_TZ);
+      assert.deepEqual(prepared.parameterType(4), TIMETZ);
+      assert.equal(prepared.parameterTypeId(5), DuckDBTypeId.LIST);
+      assert.deepEqual(prepared.parameterType(5), LIST(INTEGER));
+      assert.equal(prepared.parameterTypeId(6), DuckDBTypeId.STRUCT);
+      assert.deepEqual(prepared.parameterType(6), STRUCT({ 'a': INTEGER, 'b': VARCHAR }));
+      assert.equal(prepared.parameterTypeId(7), DuckDBTypeId.ARRAY);
+      assert.deepEqual(prepared.parameterType(7), ARRAY(INTEGER, 3));
+      assert.equal(prepared.parameterTypeId(8), DuckDBTypeId.SQLNULL);
+      assert.deepEqual(prepared.parameterType(8), SQLNULL);
       const result = await prepared.run();
       assertColumns(result, [
         { name: 'a', type: INTEGER },

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -461,6 +461,7 @@ export function parameter_name(prepared_statement: PreparedStatement, index: num
 export function param_type(prepared_statement: PreparedStatement, index: number): Type;
 
 // DUCKDB_API duckdb_logical_type duckdb_param_logical_type(duckdb_prepared_statement prepared_statement, idx_t param_idx);
+export function param_logical_type(prepared_statement: PreparedStatement, index: number): LogicalType;
 
 // DUCKDB_API duckdb_state duckdb_clear_bindings(duckdb_prepared_statement prepared_statement);
 export function clear_bindings(prepared_statement: PreparedStatement): void;

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -3908,9 +3908,8 @@ NODE_API_ADDON(DuckDBNodeAddon)
   ---
   411 total functions
 
-  213 instance methods
+  214 instance methods
     3 unimplemented instance cache functions
-    1 unimplemented prepared statement function
     1 unimplemented logical type function
    10 unimplemented value creation functions
    13 unimplemented value inspection functions

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -1056,6 +1056,7 @@ public:
       InstanceMethod("nparams", &DuckDBNodeAddon::nparams),
       InstanceMethod("parameter_name", &DuckDBNodeAddon::parameter_name),
       InstanceMethod("param_type", &DuckDBNodeAddon::param_type),
+      InstanceMethod("param_logical_type", &DuckDBNodeAddon::param_logical_type),
       InstanceMethod("clear_bindings", &DuckDBNodeAddon::clear_bindings),
       InstanceMethod("prepared_statement_type", &DuckDBNodeAddon::prepared_statement_type),
       InstanceMethod("bind_value", &DuckDBNodeAddon::bind_value),
@@ -1794,6 +1795,17 @@ private:
   }
 
   // DUCKDB_API duckdb_logical_type duckdb_param_logical_type(duckdb_prepared_statement prepared_statement, idx_t param_idx);
+  // function param_logical_type(prepared_statement: PreparedStatement, index: number): LogicalType
+  Napi::Value param_logical_type(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto prepared_statement = GetPreparedStatementFromExternal(env, info[0]);
+    auto index = info[1].As<Napi::Number>().Uint32Value();
+    auto logical_type = duckdb_param_logical_type(prepared_statement, index);
+    if (!logical_type) {
+      throw Napi::Error::New(env, "Failed to get logical type");
+    }
+    return CreateExternalForLogicalType(env, logical_type);
+  }
 
   // DUCKDB_API duckdb_state duckdb_clear_bindings(duckdb_prepared_statement prepared_statement);
   // function clear_bindings(prepared_statement: PreparedStatement): void


### PR DESCRIPTION
Adding binding for `param_logical_type` and also corresponding `parameterType` on `DuckDBPreparedStatement`. Add some API tests for it. Note that https://github.com/duckdb/duckdb/issues/16137 currently causes it to report the wrong type for VARCHAR parameters.