### PR TITLE
append value

### DIFF
--- a/api/src/createValue.ts
+++ b/api/src/createValue.ts
@@ -22,6 +22,9 @@ import {
 } from './values';
 
 export function createValue(type: DuckDBType, input: DuckDBValue): Value {
+  if (input === null) {
+    return duckdb.create_null_value();
+  }
   const { typeId } = type;
   switch (typeId) {
     case DuckDBTypeId.BOOLEAN:

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -1819,23 +1819,11 @@ describe('api', () => {
             appender.appendNull();
           } else {
             switch (type.typeId) {
-              case DuckDBTypeId.DECIMAL:
-                if (value instanceof DuckDBDecimalValue) {
-                  if (type.width === 38) {
-                    appender.appendNull(); // TODO: appending decimal 128 results in numerical errors
-                  } else {
-                    appender.appendDecimal(value);
-                  }
-                } else {
-                  throw new Error(`value is not a DuckDBDecimalValue`);
-                }
-                break;
               case DuckDBTypeId.MAP:
               case DuckDBTypeId.UNION:
                 appender.appendNull(); // TODO: once the C API supports creating MAP and UNION values
                 break;
               default:
-                console.log(`appending row=${rowIndex} col=${columnIndex}`);
                 appender.appendValue(value, type);
                 break;
             }
@@ -1891,7 +1879,7 @@ describe('api', () => {
         assertValues(resultChunk, 22, DuckDBDecimal16Vector, columns[22]);
         assertValues(resultChunk, 23, DuckDBDecimal32Vector, columns[23]);
         assertValues(resultChunk, 24, DuckDBDecimal64Vector, columns[24]);
-        // assertValues(resultChunk, 25, DuckDBDecimal128Vector, columns[25]);
+        assertValues(resultChunk, 25, DuckDBDecimal128Vector, columns[25]);
         assertValues(resultChunk, 26, DuckDBUUIDVector, columns[26]);
         assertValues(resultChunk, 27, DuckDBIntervalVector, columns[27]);
         assertValues(resultChunk, 28, DuckDBVarCharVector, columns[28]);

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -1707,11 +1707,6 @@ describe('api', () => {
       const columnNamesAndTypes =
         createTestAllTypesColumnsNamesAndTypes() as ColumnNameAndType[];
 
-      // workaround until VARINT is fixed (in 1.2.0)
-      types[11] = BOOLEAN;
-      columns[11] = [false, true, null];
-      columnNamesAndTypes[11] = { name: 'varint_as_bool', type: BOOLEAN };
-
       const chunk = DuckDBDataChunk.create(types);
       chunk.setColumns(columns);
 
@@ -1741,7 +1736,7 @@ describe('api', () => {
         assertValues(resultChunk, 8, DuckDBUSmallIntVector, columns[8]);
         assertValues(resultChunk, 9, DuckDBUIntegerVector, columns[9]);
         assertValues(resultChunk, 10, DuckDBUBigIntVector, columns[10]);
-        assertValues(resultChunk, 11, DuckDBBooleanVector, columns[11]); // workaround until VARINT is fixed (in 1.2.0)
+        assertValues(resultChunk, 11, DuckDBVarIntVector, columns[11]);
         assertValues(resultChunk, 12, DuckDBDateVector, columns[12]);
         assertValues(resultChunk, 13, DuckDBTimeVector, columns[13]);
         assertValues(resultChunk, 14, DuckDBTimestampVector, columns[14]);
@@ -1791,6 +1786,132 @@ describe('api', () => {
         assertValues(resultChunk, 43, DuckDBListVector, columns[43]); // array_of_structs
         assertValues(resultChunk, 44, DuckDBMapVector, columns[44]);
         assertValues(resultChunk, 45, DuckDBUnionVector, columns[45]);
+        assertValues(resultChunk, 46, DuckDBArrayVector, columns[46]); // fixed_int_array
+        assertValues(resultChunk, 47, DuckDBArrayVector, columns[47]); // fixed_varchar_array
+        assertValues(resultChunk, 48, DuckDBArrayVector, columns[48]); // fixed_nested_int_array
+        assertValues(resultChunk, 49, DuckDBArrayVector, columns[49]); // fixed_nested_varchar_array
+        assertValues(resultChunk, 50, DuckDBArrayVector, columns[50]); // fixed_struct_array
+        assertValues(resultChunk, 51, DuckDBStructVector, columns[51]); // struct_of_fixed_array
+        assertValues(resultChunk, 52, DuckDBArrayVector, columns[52]); // fixed_array_of_int_list
+        assertValues(resultChunk, 53, DuckDBListVector, columns[53]); // list_of_fixed_int_array
+      }
+    });
+  });
+  test('append all types row-by-row', async () => {
+    await withConnection(async (connection) => {
+      const types = createTestAllTypesColumnTypes() as DuckDBType[];
+      const columns = createTestAllTypesColumns() as (readonly DuckDBValue[])[];
+      const columnNamesAndTypes =
+        createTestAllTypesColumnsNamesAndTypes() as ColumnNameAndType[];
+
+      await connection.run(
+        `create table target(${columnNamesAndTypes
+          .map(({ name, type }) => `"${name.replace(`"`, `""`)}" ${type}`)
+          .join(', ')})`
+      );
+
+      const appender = await connection.createAppender('target');
+      for (let rowIndex = 0; rowIndex < columns[0].length; rowIndex++) {
+        for (let columnIndex = 0; columnIndex < columns.length; columnIndex++) {
+          const type = types[columnIndex];
+          const value = columns[columnIndex][rowIndex];
+          if (value === null) {
+            appender.appendNull();
+          } else {
+            switch (type.typeId) {
+              case DuckDBTypeId.DECIMAL:
+                if (value instanceof DuckDBDecimalValue) {
+                  if (type.width === 38) {
+                    appender.appendNull(); // TODO: appending decimal 128 results in numerical errors
+                  } else {
+                    appender.appendDecimal(value);
+                  }
+                } else {
+                  throw new Error(`value is not a DuckDBDecimalValue`);
+                }
+                break;
+              case DuckDBTypeId.MAP:
+              case DuckDBTypeId.UNION:
+                appender.appendNull(); // TODO: once the C API supports creating MAP and UNION values
+                break;
+              default:
+                console.log(`appending row=${rowIndex} col=${columnIndex}`);
+                appender.appendValue(value, type);
+                break;
+            }
+          }
+        }
+        appender.endRow();
+      }
+      appender.flush();
+
+      const result = await connection.run('from target');
+      const resultChunk = await result.fetchChunk();
+      assert.isDefined(resultChunk);
+      if (resultChunk) {
+        assert.strictEqual(resultChunk.columnCount, columns.length);
+        assert.strictEqual(resultChunk.rowCount, 3);
+        assertValues(resultChunk, 0, DuckDBBooleanVector, columns[0]);
+        assertValues(resultChunk, 1, DuckDBTinyIntVector, columns[1]);
+        assertValues(resultChunk, 2, DuckDBSmallIntVector, columns[2]);
+        assertValues(resultChunk, 3, DuckDBIntegerVector, columns[3]);
+        assertValues(resultChunk, 4, DuckDBBigIntVector, columns[4]);
+        assertValues(resultChunk, 5, DuckDBHugeIntVector, columns[5]);
+        assertValues(resultChunk, 6, DuckDBUHugeIntVector, columns[6]);
+        assertValues(resultChunk, 7, DuckDBUTinyIntVector, columns[7]);
+        assertValues(resultChunk, 8, DuckDBUSmallIntVector, columns[8]);
+        assertValues(resultChunk, 9, DuckDBUIntegerVector, columns[9]);
+        assertValues(resultChunk, 10, DuckDBUBigIntVector, columns[10]);
+        assertValues(resultChunk, 11, DuckDBVarIntVector, columns[11]);
+        assertValues(resultChunk, 12, DuckDBDateVector, columns[12]);
+        assertValues(resultChunk, 13, DuckDBTimeVector, columns[13]);
+        assertValues(resultChunk, 14, DuckDBTimestampVector, columns[14]);
+        assertValues(
+          resultChunk,
+          15,
+          DuckDBTimestampSecondsVector,
+          columns[15]
+        );
+        assertValues(
+          resultChunk,
+          16,
+          DuckDBTimestampMillisecondsVector,
+          columns[16]
+        );
+        assertValues(
+          resultChunk,
+          17,
+          DuckDBTimestampNanosecondsVector,
+          columns[17]
+        );
+        assertValues(resultChunk, 18, DuckDBTimeTZVector, columns[18]);
+        assertValues(resultChunk, 19, DuckDBTimestampTZVector, columns[19]);
+        assertValues(resultChunk, 20, DuckDBFloatVector, columns[20]);
+        assertValues(resultChunk, 21, DuckDBDoubleVector, columns[21]);
+        assertValues(resultChunk, 22, DuckDBDecimal16Vector, columns[22]);
+        assertValues(resultChunk, 23, DuckDBDecimal32Vector, columns[23]);
+        assertValues(resultChunk, 24, DuckDBDecimal64Vector, columns[24]);
+        // assertValues(resultChunk, 25, DuckDBDecimal128Vector, columns[25]);
+        assertValues(resultChunk, 26, DuckDBUUIDVector, columns[26]);
+        assertValues(resultChunk, 27, DuckDBIntervalVector, columns[27]);
+        assertValues(resultChunk, 28, DuckDBVarCharVector, columns[28]);
+        assertValues(resultChunk, 29, DuckDBBlobVector, columns[29]);
+        assertValues(resultChunk, 30, DuckDBBitVector, columns[30]);
+        assertValues(resultChunk, 31, DuckDBEnum8Vector, columns[31]);
+        assertValues(resultChunk, 32, DuckDBEnum16Vector, columns[32]);
+        assertValues(resultChunk, 33, DuckDBEnum32Vector, columns[33]);
+        assertValues(resultChunk, 34, DuckDBListVector, columns[34]); // int_array
+        assertValues(resultChunk, 35, DuckDBListVector, columns[35]); // double_array
+        assertValues(resultChunk, 36, DuckDBListVector, columns[36]); // date_array
+        assertValues(resultChunk, 37, DuckDBListVector, columns[37]); // timestamp_array
+        assertValues(resultChunk, 38, DuckDBListVector, columns[38]); // timestamptz_array
+        assertValues(resultChunk, 39, DuckDBListVector, columns[39]); // varchar_array
+        assertValues(resultChunk, 40, DuckDBListVector, columns[40]); // nested_int_array
+        assertValues(resultChunk, 41, DuckDBStructVector, columns[41]);
+        assertValues(resultChunk, 42, DuckDBStructVector, columns[42]); // struct_of_arrays
+        assertValues(resultChunk, 43, DuckDBListVector, columns[43]); // array_of_structs
+        // assertValues(resultChunk, 44, DuckDBMapVector, columns[44]);
+        // assertValues(resultChunk, 45, DuckDBUnionVector, columns[45]);
         assertValues(resultChunk, 46, DuckDBArrayVector, columns[46]); // fixed_int_array
         assertValues(resultChunk, 47, DuckDBArrayVector, columns[47]); // fixed_varchar_array
         assertValues(resultChunk, 48, DuckDBArrayVector, columns[48]); // fixed_nested_int_array

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -1155,6 +1155,7 @@ export function append_blob(appender: Appender, data: Uint8Array): void;
 export function append_null(appender: Appender): void;
 
 // DUCKDB_API duckdb_state duckdb_append_value(duckdb_appender appender, duckdb_value value);
+export function append_value(appender: Appender, value: Value): void;
 
 // DUCKDB_API duckdb_state duckdb_append_data_chunk(duckdb_appender appender, duckdb_data_chunk chunk);
 export function append_data_chunk(appender: Appender, chunk: DataChunk): void;

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -1300,6 +1300,7 @@ public:
       InstanceMethod("append_varchar", &DuckDBNodeAddon::append_varchar),
       InstanceMethod("append_blob", &DuckDBNodeAddon::append_blob),
       InstanceMethod("append_null", &DuckDBNodeAddon::append_null),
+      InstanceMethod("append_value", &DuckDBNodeAddon::append_value),
       InstanceMethod("append_data_chunk", &DuckDBNodeAddon::append_data_chunk),
 
       InstanceMethod("fetch_chunk", &DuckDBNodeAddon::fetch_chunk),
@@ -4093,6 +4094,16 @@ private:
   }
 
   // DUCKDB_API duckdb_state duckdb_append_value(duckdb_appender appender, duckdb_value value);
+  // function append_value(appender: Appender, value: Value): void
+  Napi::Value append_value(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto appender = GetAppenderFromExternal(env, info[0]);
+    auto value = GetValueFromExternal(env, info[1]);
+    if (duckdb_append_value(appender, value)) {
+      throw Napi::Error::New(env, duckdb_appender_error(appender));
+    }
+    return env.Undefined();
+  }
 
   // DUCKDB_API duckdb_state duckdb_append_data_chunk(duckdb_appender appender, duckdb_data_chunk chunk);
   // function append_data_chunk(appender: Appender, chunk: DataChunk): void
@@ -4217,7 +4228,7 @@ NODE_API_ADDON(DuckDBNodeAddon)
   ---
   411 total functions
 
-  238 instance methods
+  239 instance methods
     3 unimplemented instance cache functions
     1 unimplemented logical type function
    13 unimplemented scalar function functions
@@ -4230,7 +4241,7 @@ NODE_API_ADDON(DuckDBNodeAddon)
     5 unimplemented function info functions
     4 unimplemented replacement scan functions
     5 unimplemented profiling info functions
-    4 unimplemented appender functions
+    3 unimplemented appender functions
     6 unimplemented table description functions
     8 unimplemented tasks functions
    12 unimplemented cast function functions

--- a/bindings/test/appender.test.ts
+++ b/bindings/test/appender.test.ts
@@ -1,33 +1,61 @@
 import duckdb from '@duckdb/node-bindings';
 import { expect, suite, test } from 'vitest';
-import { withConnection } from './utils/withConnection';
-import { expectResult } from './utils/expectResult';
 import { expectLogicalType } from './utils/expectLogicalType';
-import { BIGINT, BLOB, BOOLEAN, DATE, DOUBLE, FLOAT, HUGEINT, INTEGER, INTERVAL, SMALLINT, TIME, TIMESTAMP, TINYINT, UBIGINT, UHUGEINT, UINTEGER, USMALLINT, UTINYINT, VARCHAR } from './utils/expectedLogicalTypes';
+import { expectResult } from './utils/expectResult';
+import {
+  BIGINT,
+  BLOB,
+  BOOLEAN,
+  DATE,
+  DECIMAL,
+  DOUBLE,
+  FLOAT,
+  HUGEINT,
+  INTEGER,
+  INTERVAL,
+  SMALLINT,
+  TIME,
+  TIMESTAMP,
+  TINYINT,
+  UBIGINT,
+  UHUGEINT,
+  UINTEGER,
+  USMALLINT,
+  UTINYINT,
+  VARCHAR,
+} from './utils/expectedLogicalTypes';
 import { data } from './utils/expectedVectors';
+import { withConnection } from './utils/withConnection';
 
 suite('appender', () => {
   test('error: no table', async () => {
     await withConnection(async (connection) => {
-      expect(() => duckdb.appender_create_ext(connection, 'memory', 'main', 'bogus_table'))
-        .toThrowError(`Table "main.bogus_table" could not be found`);
+      expect(() =>
+        duckdb.appender_create_ext(connection, 'memory', 'main', 'bogus_table')
+      ).toThrowError(`Table "main.bogus_table" could not be found`);
     });
   });
   test('one column', async () => {
     await withConnection(async (connection) => {
-      const createResult = await duckdb.query(connection, 'create table appender_target(i integer)');
+      const createResult = await duckdb.query(
+        connection,
+        'create table appender_target(i integer)'
+      );
       await expectResult(createResult, {
         statementType: duckdb.StatementType.CREATE,
         resultType: duckdb.ResultType.NOTHING,
         chunkCount: 0,
         rowCount: 0,
-        columns: [
-          { name: 'Count', logicalType: BIGINT },
-        ],
+        columns: [{ name: 'Count', logicalType: BIGINT }],
         chunks: [],
       });
 
-      const appender = duckdb.appender_create_ext(connection, 'memory', 'main', 'appender_target');
+      const appender = duckdb.appender_create_ext(
+        connection,
+        'memory',
+        'main',
+        'appender_target'
+      );
       expect(duckdb.appender_column_count(appender)).toBe(1);
       const column_type = duckdb.appender_column_type(appender, 0);
       expectLogicalType(column_type, INTEGER);
@@ -40,14 +68,11 @@ suite('appender', () => {
       duckdb.appender_end_row(appender);
       duckdb.appender_flush(appender);
 
-
       const result = await duckdb.query(connection, 'from appender_target');
       await expectResult(result, {
         chunkCount: 1,
         rowCount: 3,
-        columns: [
-          { name: 'i', logicalType: INTEGER },
-        ],
+        columns: [{ name: 'i', logicalType: INTEGER }],
         chunks: [
           { rowCount: 3, vectors: [data(4, [true, true, true], [11, 22, 33])] },
         ],
@@ -56,7 +81,8 @@ suite('appender', () => {
   });
   test('multiple columns', async () => {
     await withConnection(async (connection) => {
-      const createResult = await duckdb.query(connection,
+      const createResult = await duckdb.query(
+        connection,
         'create table appender_target(\
           bool boolean, \
           int8 tinyint, \
@@ -77,24 +103,28 @@ suite('appender', () => {
           interval interval, \
           varchar varchar, \
           blob blob, \
+          dec4_1 decimal(4,1), \
           null_column integer, \
           integer_with_default integer default 42\
-        )');
+        )'
+      );
       await expectResult(createResult, {
         statementType: duckdb.StatementType.CREATE,
         resultType: duckdb.ResultType.NOTHING,
         chunkCount: 0,
         rowCount: 0,
-        columns: [
-          { name: 'Count', logicalType: BIGINT },
-        ],
+        columns: [{ name: 'Count', logicalType: BIGINT }],
         chunks: [],
       });
 
+      const appender = duckdb.appender_create_ext(
+        connection,
+        'memory',
+        'main',
+        'appender_target'
+      );
+      expect(duckdb.appender_column_count(appender)).toBe(22);
 
-      const appender = duckdb.appender_create_ext(connection, 'memory', 'main', 'appender_target');
-      expect(duckdb.appender_column_count(appender)).toBe(21);
-      
       const expectedLogicalTypes = [
         BOOLEAN,
         TINYINT,
@@ -115,6 +145,7 @@ suite('appender', () => {
         INTERVAL,
         VARCHAR,
         BLOB,
+        DECIMAL(4, 1, duckdb.Type.SMALLINT),
         INTEGER,
         INTEGER,
       ];
@@ -133,18 +164,32 @@ suite('appender', () => {
       duckdb.append_uint16(appender, 65535);
       duckdb.append_uint32(appender, 4294967295);
       duckdb.append_uint64(appender, 18446744073709551615n);
-      duckdb.append_uhugeint(appender, 340282366920938463463374607431768211455n);
-      duckdb.append_float(appender, 3.4028234663852886e+38);
-      duckdb.append_double(appender, 1.7976931348623157e+308);
+      duckdb.append_uhugeint(
+        appender,
+        340282366920938463463374607431768211455n
+      );
+      duckdb.append_float(appender, 3.4028234663852886e38);
+      duckdb.append_double(appender, 1.7976931348623157e308);
       duckdb.append_date(appender, { days: 2147483646 });
       duckdb.append_time(appender, { micros: 86400000000n });
       duckdb.append_timestamp(appender, { micros: 9223372036854775806n });
-      duckdb.append_interval(appender, { months: 999, days: 999, micros: 999999999n });
+      duckdb.append_interval(appender, {
+        months: 999,
+        days: 999,
+        micros: 999999999n,
+      });
       duckdb.append_varchar(appender, '🦆🦆🦆🦆🦆🦆');
-      duckdb.append_blob(appender, Buffer.from('thisisalongblob\x00withnullbytes'));
+      duckdb.append_blob(
+        appender,
+        Buffer.from('thisisalongblob\x00withnullbytes')
+      );
+      duckdb.append_value(
+        appender,
+        duckdb.create_decimal({ width: 4, scale: 1, value: 9876n })
+      );
       duckdb.append_null(appender);
       duckdb.append_default(appender);
-      
+
       duckdb.appender_end_row(appender);
       // explicitly calling both flush and close is unnecessary because close does a flush, but this exercises them.
       duckdb.appender_flush(appender);
@@ -174,6 +219,7 @@ suite('appender', () => {
           { name: 'interval', logicalType: INTERVAL },
           { name: 'varchar', logicalType: VARCHAR },
           { name: 'blob', logicalType: BLOB },
+          { name: 'dec4_1', logicalType: DECIMAL(4, 1, duckdb.Type.SMALLINT) },
           { name: 'null_column', logicalType: INTEGER },
           { name: 'integer_with_default', logicalType: INTEGER },
         ],
@@ -192,14 +238,23 @@ suite('appender', () => {
               data(4, [true], [4294967295]),
               data(8, [true], [18446744073709551615n]),
               data(16, [true], [340282366920938463463374607431768211455n]),
-              data(4, [true], [3.4028234663852886e+38]),
-              data(8, [true], [1.7976931348623157e+308]),
+              data(4, [true], [3.4028234663852886e38]),
+              data(8, [true], [1.7976931348623157e308]),
               data(4, [true], [2147483646]),
               data(8, [true], [86400000000n]),
               data(8, [true], [9223372036854775806n]),
-              data(16, [true], [{ months: 999, days: 999, micros: 999999999n }]),
+              data(
+                16,
+                [true],
+                [{ months: 999, days: 999, micros: 999999999n }]
+              ),
               data(16, [true], ['🦆🦆🦆🦆🦆🦆']),
-              data(16, [true], [Buffer.from('thisisalongblob\x00withnullbytes')]),
+              data(
+                16,
+                [true],
+                [Buffer.from('thisisalongblob\x00withnullbytes')]
+              ),
+              data(2, [true], [9876]),
               data(4, [false], [null]),
               data(4, [true], [42]),
             ],
@@ -210,22 +265,31 @@ suite('appender', () => {
   });
   test('data chunk', async () => {
     await withConnection(async (connection) => {
-      const createResult = await duckdb.query(connection, 'create table appender_target(i integer, v varchar)');
+      const createResult = await duckdb.query(
+        connection,
+        'create table appender_target(i integer, v varchar)'
+      );
       await expectResult(createResult, {
         statementType: duckdb.StatementType.CREATE,
         resultType: duckdb.ResultType.NOTHING,
         chunkCount: 0,
         rowCount: 0,
-        columns: [
-          { name: 'Count', logicalType: BIGINT },
-        ],
+        columns: [{ name: 'Count', logicalType: BIGINT }],
         chunks: [],
       });
 
-      const appender = duckdb.appender_create_ext(connection, 'memory', 'main', 'appender_target');
+      const appender = duckdb.appender_create_ext(
+        connection,
+        'memory',
+        'main',
+        'appender_target'
+      );
       expect(duckdb.appender_column_count(appender)).toBe(2);
 
-      const source_result = await duckdb.query(connection, 'select int, varchar from test_all_types()');
+      const source_result = await duckdb.query(
+        connection,
+        'select int, varchar from test_all_types()'
+      );
       const source_chunk = await duckdb.fetch_chunk(source_result);
       expect(source_chunk).toBeDefined();
       if (source_chunk) {

--- a/bindings/test/appender.test.ts
+++ b/bindings/test/appender.test.ts
@@ -104,6 +104,9 @@ suite('appender', () => {
           varchar varchar, \
           blob blob, \
           dec4_1 decimal(4,1), \
+          dec9_4 decimal(9,4), \
+          dec18_6 decimal(18,6), \
+          dec38_10 decimal(38,10), \
           null_column integer, \
           integer_with_default integer default 42\
         )'
@@ -123,7 +126,7 @@ suite('appender', () => {
         'main',
         'appender_target'
       );
-      expect(duckdb.appender_column_count(appender)).toBe(22);
+      expect(duckdb.appender_column_count(appender)).toBe(25);
 
       const expectedLogicalTypes = [
         BOOLEAN,
@@ -146,6 +149,9 @@ suite('appender', () => {
         VARCHAR,
         BLOB,
         DECIMAL(4, 1, duckdb.Type.SMALLINT),
+        DECIMAL(9, 4, duckdb.Type.INTEGER),
+        DECIMAL(18, 6, duckdb.Type.BIGINT),
+        DECIMAL(38, 10, duckdb.Type.HUGEINT),
         INTEGER,
         INTEGER,
       ];
@@ -185,7 +191,19 @@ suite('appender', () => {
       );
       duckdb.append_value(
         appender,
-        duckdb.create_decimal({ width: 4, scale: 1, value: 9876n })
+        duckdb.create_decimal({ width: 4, scale: 1, value: 9999n })
+      );
+      duckdb.append_value(
+        appender,
+        duckdb.create_decimal({ width: 9, scale: 4, value: 999999999n })
+      );
+      duckdb.append_value(
+        appender,
+        duckdb.create_decimal({ width: 18, scale: 6, value: 999999999999999999n })
+      );
+      duckdb.append_value(
+        appender,
+        duckdb.create_decimal({ width: 38, scale: 10, value: -99999999999999999999999999999999999999n })
       );
       duckdb.append_null(appender);
       duckdb.append_default(appender);
@@ -220,6 +238,9 @@ suite('appender', () => {
           { name: 'varchar', logicalType: VARCHAR },
           { name: 'blob', logicalType: BLOB },
           { name: 'dec4_1', logicalType: DECIMAL(4, 1, duckdb.Type.SMALLINT) },
+          { name: 'dec9_4', logicalType: DECIMAL(9, 4, duckdb.Type.INTEGER) },
+          { name: 'dec18_6', logicalType: DECIMAL(18, 6, duckdb.Type.BIGINT) },
+          { name: 'dec38_10', logicalType: DECIMAL(38, 10, duckdb.Type.HUGEINT) },
           { name: 'null_column', logicalType: INTEGER },
           { name: 'integer_with_default', logicalType: INTEGER },
         ],
@@ -254,7 +275,10 @@ suite('appender', () => {
                 [true],
                 [Buffer.from('thisisalongblob\x00withnullbytes')]
               ),
-              data(2, [true], [9876]),
+              data(2, [true], [9999]),
+              data(4, [true], [999999999]),
+              data(8, [true], [999999999999999999n]),
+              data(16, [true], [-99999999999999999999999999999999999999n]),
               data(4, [false], [null]),
               data(4, [true], [42]),
             ],

--- a/bindings/test/values.test.ts
+++ b/bindings/test/values.test.ts
@@ -123,10 +123,28 @@ suite('values', () => {
     expectLogicalType(duckdb.get_value_type(varint_value), VARINT);
     expect(duckdb.get_varint(varint_value)).toBe(input);
   });
-  test('decimal', () => {
-    const input: Decimal = { width: 9, scale: 4, value: 987654321n };
+  test('decimal_4_1', () => {
+    const input: Decimal = { width: 4, scale: 1, value: 9999n };
+    const decimal_value = duckdb.create_decimal(input);
+    expectLogicalType(duckdb.get_value_type(decimal_value), DECIMAL(4, 1, duckdb.Type.SMALLINT));
+    expect(duckdb.get_decimal(decimal_value)).toStrictEqual(input);
+  });
+  test('decimal_9_4', () => {
+    const input: Decimal = { width: 9, scale: 4, value: 999999999n };
     const decimal_value = duckdb.create_decimal(input);
     expectLogicalType(duckdb.get_value_type(decimal_value), DECIMAL(9, 4, duckdb.Type.INTEGER));
+    expect(duckdb.get_decimal(decimal_value)).toStrictEqual(input);
+  });
+  test('decimal_18_6', () => {
+    const input: Decimal = { width: 18, scale: 6, value: 999999999999999999n };
+    const decimal_value = duckdb.create_decimal(input);
+    expectLogicalType(duckdb.get_value_type(decimal_value), DECIMAL(18, 6, duckdb.Type.BIGINT));
+    expect(duckdb.get_decimal(decimal_value)).toStrictEqual(input);
+  });
+  test('decimal_38_10', () => {
+    const input: Decimal = { width: 38, scale: 10, value: -99999999999999999999999999999999999999n };
+    const decimal_value = duckdb.create_decimal(input);
+    expectLogicalType(duckdb.get_value_type(decimal_value), DECIMAL(38, 10, duckdb.Type.HUGEINT));
     expect(duckdb.get_decimal(decimal_value)).toStrictEqual(input);
   });
   test('float', () => {


### PR DESCRIPTION
Add support for `append_value` and use it to implement most of the rest of the appender functions. (MAP and UNION still don't have value-creation functions in the C API.)

Also found and fixed a bug with conversion between hugeints and JS BigInts.