### PR TITLE
bump pkgs to 1.2.0-alpha.15

### DIFF
--- a/api/pkgs/@duckdb/node-api/package.json
+++ b/api/pkgs/@duckdb/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-api",
-  "version": "1.2.0-alpha.14",
+  "version": "1.2.0-alpha.15",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-arm64",
-  "version": "1.2.0-alpha.14",
+  "version": "1.2.0-alpha.15",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-x64",
-  "version": "1.2.0-alpha.14",
+  "version": "1.2.0-alpha.15",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-arm64",
-  "version": "1.2.0-alpha.14",
+  "version": "1.2.0-alpha.15",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-x64",
-  "version": "1.2.0-alpha.14",
+  "version": "1.2.0-alpha.15",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-x64",
-  "version": "1.2.0-alpha.14",
+  "version": "1.2.0-alpha.15",
   "license": "MIT",
   "os": [
     "win32"

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings",
-  "version": "1.2.0-alpha.14",
+  "version": "1.2.0-alpha.15",
   "license": "MIT",
   "main": "./duckdb.js",
   "types": "./duckdb.d.ts",


### PR DESCRIPTION
Version notes:
- Binding most types to parameters is now supported. The only remaining unsupported types are MAP and UNION; these still need C API support for creating values (see this [PR](https://github.com/duckdb/duckdb/pull/14613)).
- Appending most types row-by-row is now supported. MAP and UNION are not yet supported for the same reason as above.
- Added support for specifying the database/catalog name when creating an appender. (Support for this was added to the C API in 1.2.0.)
- Breaking change: Reversed the order of the arguments to `createAppender`, in order to make both the schema and database/catalog optional.
- Fixed a bug in converting very large (>=2^64) negative hugeints to JS bigints.

Changes in this version:
- https://github.com/duckdb/duckdb-node-neo/pull/156
- https://github.com/duckdb/duckdb-node-neo/pull/157
- https://github.com/duckdb/duckdb-node-neo/pull/158
- https://github.com/duckdb/duckdb-node-neo/pull/159
- https://github.com/duckdb/duckdb-node-neo/pull/160
- https://github.com/duckdb/duckdb-node-neo/pull/161
- https://github.com/duckdb/duckdb-node-neo/pull/162
- https://github.com/duckdb/duckdb-node-neo/pull/163
- https://github.com/duckdb/duckdb-node-neo/pull/164
- https://github.com/duckdb/duckdb-node-neo/pull/165