### PR TITLE
bindings for instance cache

### DIFF
--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -204,6 +204,10 @@ export interface ExtractedStatements {
   __duckdb_type: 'duckdb_extracted_statements';
 }
 
+export interface InstanceCache {
+  __duckdb_type: 'duckdb_instance_cache';
+}
+
 export interface LogicalType {
   __duckdb_type: 'duckdb_logical_type';
 }
@@ -240,8 +244,13 @@ export interface ExtractedStatementsAndCount {
 // Functions
 
 // DUCKDB_API duckdb_instance_cache duckdb_create_instance_cache();
+export function create_instance_cache(): InstanceCache;
+
 // DUCKDB_API duckdb_state duckdb_get_or_create_from_cache(duckdb_instance_cache instance_cache, const char *path, duckdb_database *out_database, duckdb_config config, char **out_error);
+export function get_or_create_from_cache(cache: InstanceCache, path?: string, config?: Config): Promise<Database>;
+
 // DUCKDB_API void duckdb_destroy_instance_cache(duckdb_instance_cache *instance_cache);
+// not exposed: destroyed in finalizer
 
 // DUCKDB_API duckdb_state duckdb_open(const char *path, duckdb_database *out_database);
 export function open(path?: string, config?: Config): Promise<Database>;

--- a/bindings/test/instance_cache.test.ts
+++ b/bindings/test/instance_cache.test.ts
@@ -1,0 +1,27 @@
+import duckdb from '@duckdb/node-bindings';
+import { expect, suite, test } from 'vitest';
+
+suite('instance_cache', () => {
+  test('create', async () => {
+    const cache = duckdb.create_instance_cache();
+    expect(cache).toBeTruthy();
+  });
+  test('empty path', async () => {
+    const cache = duckdb.create_instance_cache();
+    const db1 = await duckdb.get_or_create_from_cache(cache, '');
+    expect(db1).toBeTruthy();
+    console.log(db1);
+    const db2 = await duckdb.get_or_create_from_cache(cache, '');
+    expect(db2).toStrictEqual(db1);
+    console.log(db2);
+  });
+  test('memory path', async () => {
+    const cache = duckdb.create_instance_cache();
+    const db1 = await duckdb.get_or_create_from_cache(cache, ':memory:');
+    expect(db1).toBeTruthy();
+    console.log(db1);
+    const db2 = await duckdb.get_or_create_from_cache(cache, ':memory:');
+    expect(db2).toStrictEqual(db1);
+    console.log(db2);
+  });
+});


### PR DESCRIPTION
Add bindings for `create_instance_cache` and `get_or_create_from_cache`. Not yet exposed at the API level.