### PR TITLE
update duckdb to 1.2.1

### DIFF
--- a/api/pkgs/@duckdb/node-api/package.json
+++ b/api/pkgs/@duckdb/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-api",
-  "version": "1.2.0-alpha.15",
+  "version": "1.2.1-alpha.16",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/api/src/createValue.ts
+++ b/api/src/createValue.ts
@@ -183,7 +183,7 @@ export function createValue(type: DuckDBType, input: DuckDBValue): Value {
       }
       throw new Error(`input is not a DuckDBStructValue`);
     case DuckDBTypeId.MAP:
-      throw new Error(`not yet implemented for MAP`); // TODO: implement when available, hopefully in 1.2.0
+      throw new Error(`not yet implemented for MAP`); // TODO: implement when available
     case DuckDBTypeId.ARRAY:
       if (input instanceof DuckDBArrayValue) {
         if (type.valueType.typeId === DuckDBTypeId.ANY) {
@@ -203,7 +203,7 @@ export function createValue(type: DuckDBType, input: DuckDBValue): Value {
       }
       throw new Error(`input is not a bigint`);
     case DuckDBTypeId.UNION:
-      throw new Error(`not yet implemented for UNION`); // TODO: implement when available, hopefully in 1.2.0
+      throw new Error(`not yet implemented for UNION`); // TODO: implement when available
     case DuckDBTypeId.BIT:
       if (input instanceof DuckDBBitValue) {
         return duckdb.create_bit(input.data);

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-arm64",
-  "version": "1.2.0-alpha.15",
+  "version": "1.2.1-alpha.16",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-x64",
-  "version": "1.2.0-alpha.15",
+  "version": "1.2.1-alpha.16",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-arm64",
-  "version": "1.2.0-alpha.15",
+  "version": "1.2.1-alpha.16",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-x64",
-  "version": "1.2.0-alpha.15",
+  "version": "1.2.1-alpha.16",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-x64",
-  "version": "1.2.0-alpha.15",
+  "version": "1.2.1-alpha.16",
   "license": "MIT",
   "os": [
     "win32"

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings",
-  "version": "1.2.0-alpha.15",
+  "version": "1.2.1-alpha.16",
   "license": "MIT",
   "main": "./duckdb.js",
   "types": "./duckdb.d.ts",

--- a/bindings/scripts/fetch_libduckdb_linux_aarch64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_aarch64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.0/libduckdb-linux-aarch64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-linux-aarch64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_linux_amd64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_amd64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.0/libduckdb-linux-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-linux-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_osx_universal.py
+++ b/bindings/scripts/fetch_libduckdb_osx_universal.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.0/libduckdb-osx-universal.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-osx-universal.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_windows_amd64.py
+++ b/bindings/scripts/fetch_libduckdb_windows_amd64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.0/libduckdb-windows-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.1/libduckdb-windows-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/test/config.test.ts
+++ b/bindings/test/config.test.ts
@@ -5,11 +5,11 @@ import { data } from './utils/expectedVectors';
 
 suite('config', () => {
   test('config_count', () => {
-    expect(duckdb.config_count()).toBe(170);
+    expect(duckdb.config_count()).toBe(173);
   });
   test('get_config_flag', () => {
     expect(duckdb.get_config_flag(0).name).toBe('access_mode');
-    expect(duckdb.get_config_flag(169).name).toBe('unsafe_enable_version_guessing');
+    expect(duckdb.get_config_flag(172).name).toBe('unsafe_enable_version_guessing');
   });
   test('get_config_flag out of bounds', () => {
     expect(() => duckdb.get_config_flag(-1)).toThrowError(/^Config option not found$/);

--- a/bindings/test/constants.test.ts
+++ b/bindings/test/constants.test.ts
@@ -6,7 +6,7 @@ suite('constants', () => {
     expect(duckdb.sizeof_bool).toBe(1);
   });
   test('library_version', () => {
-    expect(duckdb.library_version()).toBe('v1.2.0');
+    expect(duckdb.library_version()).toBe('v1.2.1');
   });
   test('vector_size', () => {
     expect(duckdb.vector_size()).toBe(2048);

--- a/bindings/test/prepared_statements.test.ts
+++ b/bindings/test/prepared_statements.test.ts
@@ -124,7 +124,7 @@ suite('prepared statements', () => {
       expect(duckdb.parameter_name(prepared, 2)).toBe('y');
       expect(duckdb.bind_parameter_index(prepared, 'y')).toBe(2);
       duckdb.bind_varchar(prepared, 2, 'a');
-      // expect(duckdb.param_type(prepared, 2)).toBe(duckdb.Type.VARCHAR); // TODO 1.2.0 - param_type is returning INVALID for VARCHAR
+      // expect(duckdb.param_type(prepared, 2)).toBe(duckdb.Type.VARCHAR); // TODO 1.2.1 - support STRING_LITERAL
 
       const result = await duckdb.execute_prepared(prepared);
       await expectResult(result, {
@@ -257,7 +257,7 @@ suite('prepared statements', () => {
       expect(duckdb.param_type(prepared, 19)).toBe(duckdb.Type.INTERVAL);
 
       duckdb.bind_varchar(prepared, 20, '🦆🦆🦆\x00🦆🦆🦆');
-      // expect(duckdb.param_type(prepared, 20)).toBe(duckdb.Type.VARCHAR); // TODO 1.2.0 - param_type is returning INVALID for VARCHAR
+      // expect(duckdb.param_type(prepared, 20)).toBe(duckdb.Type.VARCHAR); // TODO 1.2.1 - support STRING_LITERAL
 
       duckdb.bind_blob(prepared, 21, Buffer.from('thisisalongblob\x00withnullbytes'));
       expect(duckdb.param_type(prepared, 21)).toBe(duckdb.Type.BLOB);


### PR DESCRIPTION
Also bump package version to `alpha-16`. This version contains a couple additional changes:
- https://github.com/duckdb/duckdb-node-neo/pull/172
- https://github.com/duckdb/duckdb-node-neo/pull/174