### PR TITLE
instance close

### DIFF
--- a/api/src/DuckDBInstance.ts
+++ b/api/src/DuckDBInstance.ts
@@ -28,4 +28,8 @@ export class DuckDBInstance {
   public async connect(): Promise<DuckDBConnection> {
     return new DuckDBConnection(await duckdb.connect(this.db));
   }
+
+  public close() {
+    duckdb.close(this.db);
+  }
 }

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -382,6 +382,7 @@ describe('api', () => {
         42,
       ]);
     }
+    instance.close();
   });
   test('disconnecting connections', async () => {
     const instance = await DuckDBInstance.create();

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -259,7 +259,7 @@ export function open(path?: string, config?: Config): Promise<Database>;
 // not exposed: consolidated into open
 
 // DUCKDB_API void duckdb_close(duckdb_database *database);
-// not exposed: closed in finalizer
+export function close(database: Database): void;
 
 // DUCKDB_API duckdb_state duckdb_connect(duckdb_database database, duckdb_connection *out_connection);
 export function connect(database: Database): Promise<Connection>;

--- a/bindings/test/open.test.ts
+++ b/bindings/test/open.test.ts
@@ -5,15 +5,28 @@ suite('open', () => {
   test('no args', async () => {
     const db = await duckdb.open();
     expect(db).toBeTruthy();
+    duckdb.close(db);
   });
   test('memory arg', async () => {
     const db = await duckdb.open(':memory:');
     expect(db).toBeTruthy();
+    duckdb.close(db);
   });
   test('with config', async () => {
-    const config = duckdb.create_config()
+    const config = duckdb.create_config();
     duckdb.set_config(config, 'custom_user_agent', 'my_user_agent');
     const db = await duckdb.open(':memory:', config);
     expect(db).toBeTruthy();
+    duckdb.close(db);
+  });
+  test('close', async () => {
+    const db = await duckdb.open();
+    expect(db).toBeTruthy();
+    duckdb.close(db);
+    await expect(async () => await duckdb.connect(db)).rejects.toStrictEqual(
+      new Error('Failed to connect: instance closed')
+    );
+    // double-close should be a no-op
+    duckdb.close(db);
   });
 });


### PR DESCRIPTION
Support closing an instance, using the same "holder" pattern used for supporting disconnecting connections.