### PR TITLE
add sync to close, disconnect, and flush

### DIFF
--- a/api/src/DuckDBAppender.ts
+++ b/api/src/DuckDBAppender.ts
@@ -42,11 +42,11 @@ export class DuckDBAppender {
   constructor(appender: duckdb.Appender) {
     this.appender = appender;
   }
-  public close() {
-    duckdb.appender_close(this.appender);
+  public closeSync() {
+    duckdb.appender_close_sync(this.appender);
   }
-  public flush() {
-    duckdb.appender_flush(this.appender);
+  public flushSync() {
+    duckdb.appender_flush_sync(this.appender);
   }
   public get columnCount(): number {
     return duckdb.appender_column_count(this.appender);

--- a/api/src/DuckDBConnection.ts
+++ b/api/src/DuckDBConnection.ts
@@ -23,12 +23,12 @@ export class DuckDBConnection {
     }
     return (await DuckDBInstance.fromCache()).connect();
   }
-  /** Same as disconnect. */
-  public close() {
-    return this.disconnect();
+  /** Same as disconnectSync. */
+  public closeSync() {
+    return this.disconnectSync();
   }
-  public disconnect() {
-    return duckdb.disconnect(this.connection);
+  public disconnectSync() {
+    return duckdb.disconnect_sync(this.connection);
   }
   public interrupt() {
     duckdb.interrupt(this.connection);

--- a/api/src/DuckDBInstance.ts
+++ b/api/src/DuckDBInstance.ts
@@ -29,7 +29,7 @@ export class DuckDBInstance {
     return new DuckDBConnection(await duckdb.connect(this.db));
   }
 
-  public close() {
-    duckdb.close(this.db);
+  public closeSync() {
+    duckdb.close_sync(this.db);
   }
 }

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -382,14 +382,14 @@ describe('api', () => {
         42,
       ]);
     }
-    instance.close();
+    instance.closeSync();
   });
   test('disconnecting connections', async () => {
     const instance = await DuckDBInstance.create();
     const connection = await instance.connect();
     const prepared1 = await connection.prepare('select 1');
     assert.isDefined(prepared1);
-    connection.disconnect();
+    connection.disconnectSync();
     try {
       await connection.prepare('select 2');
       assert.fail('should throw');
@@ -400,7 +400,7 @@ describe('api', () => {
       );
     }
     // ensure double-disconnect doesn't break anything
-    connection.disconnect();
+    connection.disconnectSync();
   });
   test('should support running prepared statements', async () => {
     await withConnection(async (connection) => {
@@ -1443,7 +1443,7 @@ describe('api', () => {
       await connection.run('create table target(col0 int)');
       const appender = await connection.createAppender('target');
       appender.appendDataChunk(chunk);
-      appender.flush();
+      appender.flushSync();
 
       const result = await connection.run('from target');
       const resultChunk = await result.fetchChunk();
@@ -1477,7 +1477,7 @@ describe('api', () => {
       await connection.run('create table target1(col0 int)');
       const appender1 = await connection.createAppender('target1');
       appender1.appendDataChunk(chunk);
-      appender1.flush();
+      appender1.flushSync();
 
       const result1 = await connection.run('from target1');
       const result1Chunk = await result1.fetchChunk();
@@ -1494,7 +1494,7 @@ describe('api', () => {
       await connection.run('create table target2(col0 int)');
       const appender2 = await connection.createAppender('target2');
       appender2.appendDataChunk(chunk);
-      appender2.flush();
+      appender2.flushSync();
 
       const result2 = await connection.run('from target2');
       const result2Chunk = await result2.fetchChunk();
@@ -1516,7 +1516,7 @@ describe('api', () => {
       await connection.run('create table target(col0 varchar)');
       const appender = await connection.createAppender('target');
       appender.appendDataChunk(chunk);
-      appender.flush();
+      appender.flushSync();
 
       const result = await connection.run('from target');
       const resultChunk = await result.fetchChunk();
@@ -1552,7 +1552,7 @@ describe('api', () => {
       await connection.run('create table target(col0 blob)');
       const appender = await connection.createAppender('target');
       appender.appendDataChunk(chunk);
-      appender.flush();
+      appender.flushSync();
 
       const result = await connection.run('from target');
       const resultChunk = await result.fetchChunk();
@@ -1579,7 +1579,7 @@ describe('api', () => {
       await connection.run('create table target(col0 integer[])');
       const appender = await connection.createAppender('target');
       appender.appendDataChunk(chunk);
-      appender.flush();
+      appender.flushSync();
 
       const result = await connection.run('from target');
       const resultChunk = await result.fetchChunk();
@@ -1626,7 +1626,7 @@ describe('api', () => {
       await connection.run('create table target(col0 integer[][])');
       const appender = await connection.createAppender('target');
       appender.appendDataChunk(chunk);
-      appender.flush();
+      appender.flushSync();
 
       const result = await connection.run('from target');
       const resultChunk = await result.fetchChunk();
@@ -1653,7 +1653,7 @@ describe('api', () => {
       await connection.run('create table target(col0 integer[3])');
       const appender = await connection.createAppender('target');
       appender.appendDataChunk(chunk);
-      appender.flush();
+      appender.flushSync();
 
       const result = await connection.run('from target');
       const resultChunk = await result.fetchChunk();
@@ -1680,7 +1680,7 @@ describe('api', () => {
       await connection.run('create table target(col0 varchar[3])');
       const appender = await connection.createAppender('target');
       appender.appendDataChunk(chunk);
-      appender.flush();
+      appender.flushSync();
 
       const result = await connection.run('from target');
       const resultChunk = await result.fetchChunk();
@@ -1712,7 +1712,7 @@ describe('api', () => {
       );
       const appender = await connection.createAppender('target');
       appender.appendDataChunk(chunk);
-      appender.flush();
+      appender.flushSync();
 
       const result = await connection.run('from target');
       const resultChunk = await result.fetchChunk();
@@ -1752,7 +1752,7 @@ describe('api', () => {
       );
       const appender = await connection.createAppender('target');
       appender.appendDataChunk(chunk);
-      appender.flush();
+      appender.flushSync();
 
       const result = await connection.run('from target');
       const resultChunk = await result.fetchChunk();
@@ -1784,7 +1784,7 @@ describe('api', () => {
       );
       const appender = await connection.createAppender('target');
       appender.appendDataChunk(chunk);
-      appender.flush();
+      appender.flushSync();
 
       const result = await connection.run('from target');
       const resultChunk = await result.fetchChunk();
@@ -1898,7 +1898,7 @@ describe('api', () => {
         }
         appender.endRow();
       }
-      appender.flush();
+      appender.flushSync();
 
       const result = await connection.run('from target');
       const resultChunk = await result.fetchChunk();

--- a/api/test/bench/write.bench.ts
+++ b/api/test/bench/write.bench.ts
@@ -55,7 +55,7 @@ for (const batchSize of [1, 1000]) {
           appender.appendFloat(Math.random() * 1_000_000);
           appender.endRow();
         }
-        appender.close();
+        appender.closeSync();
       },
       {
         setup,

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -259,7 +259,7 @@ export function open(path?: string, config?: Config): Promise<Database>;
 // not exposed: consolidated into open
 
 // DUCKDB_API void duckdb_close(duckdb_database *database);
-export function close(database: Database): void;
+export function close_sync(database: Database): void;
 
 // DUCKDB_API duckdb_state duckdb_connect(duckdb_database database, duckdb_connection *out_connection);
 export function connect(database: Database): Promise<Connection>;
@@ -271,7 +271,7 @@ export function interrupt(connection: Connection): void;
 export function query_progress(connection: Connection): QueryProgress;
 
 // DUCKDB_API void duckdb_disconnect(duckdb_connection *connection);
-export function disconnect(connection: Connection): void;
+export function disconnect_sync(connection: Connection): void;
 
 // DUCKDB_API const char *duckdb_library_version();
 export function library_version(): string;
@@ -1078,10 +1078,10 @@ export function appender_column_type(appender: Appender, column_index: number): 
 // not exposed: other appender functions throw
 
 // DUCKDB_API duckdb_state duckdb_appender_flush(duckdb_appender appender);
-export function appender_flush(appender: Appender): void;
+export function appender_flush_sync(appender: Appender): void;
 
 // DUCKDB_API duckdb_state duckdb_appender_close(duckdb_appender appender);
-export function appender_close(appender: Appender): void;
+export function appender_close_sync(appender: Appender): void;
 
 // DUCKDB_API duckdb_state duckdb_appender_destroy(duckdb_appender *appender);
 // not exposed: destroyed in finalizer

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -1182,11 +1182,11 @@ public:
       InstanceMethod("get_or_create_from_cache", &DuckDBNodeAddon::get_or_create_from_cache),
 
       InstanceMethod("open", &DuckDBNodeAddon::open),
-      InstanceMethod("close", &DuckDBNodeAddon::close),
+      InstanceMethod("close_sync", &DuckDBNodeAddon::close_sync),
       InstanceMethod("connect", &DuckDBNodeAddon::connect),
       InstanceMethod("interrupt", &DuckDBNodeAddon::interrupt),
       InstanceMethod("query_progress", &DuckDBNodeAddon::query_progress),
-      InstanceMethod("disconnect", &DuckDBNodeAddon::disconnect),
+      InstanceMethod("disconnect_sync", &DuckDBNodeAddon::disconnect_sync),
 
       InstanceMethod("library_version", &DuckDBNodeAddon::library_version),
 
@@ -1405,8 +1405,8 @@ public:
       InstanceMethod("appender_create_ext", &DuckDBNodeAddon::appender_create_ext),
       InstanceMethod("appender_column_count", &DuckDBNodeAddon::appender_column_count),
       InstanceMethod("appender_column_type", &DuckDBNodeAddon::appender_column_type),
-      InstanceMethod("appender_flush", &DuckDBNodeAddon::appender_flush),
-      InstanceMethod("appender_close", &DuckDBNodeAddon::appender_close),
+      InstanceMethod("appender_flush_sync", &DuckDBNodeAddon::appender_flush_sync),
+      InstanceMethod("appender_close_sync", &DuckDBNodeAddon::appender_close_sync),
       InstanceMethod("appender_end_row", &DuckDBNodeAddon::appender_end_row),
       InstanceMethod("append_default", &DuckDBNodeAddon::append_default),
       InstanceMethod("append_bool", &DuckDBNodeAddon::append_bool),
@@ -1497,7 +1497,7 @@ private:
 
   // DUCKDB_API void duckdb_close(duckdb_database *database);
   // function close(database: Database): void
-  Napi::Value close(const Napi::CallbackInfo& info) {
+  Napi::Value close_sync(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto database_holder_ptr = GetDatabaseHolderFromExternal(env, info[0]);
     // duckdb_close is a no-op if already closed
@@ -1539,7 +1539,7 @@ private:
 
   // DUCKDB_API void duckdb_disconnect(duckdb_connection *connection);
   // function disconnect(connection: Connection): void
-  Napi::Value disconnect(const Napi::CallbackInfo& info) {
+  Napi::Value disconnect_sync(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto connection_holder_ptr = GetConnectionHolderFromExternal(env, info[0]);
     // duckdb_disconnect is a no-op if already disconnected
@@ -3949,7 +3949,7 @@ private:
 
   // DUCKDB_API duckdb_state duckdb_appender_flush(duckdb_appender appender);
   // function appender_flush(appender: Appender): void
-  Napi::Value appender_flush(const Napi::CallbackInfo& info) {
+  Napi::Value appender_flush_sync(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto appender = GetAppenderFromExternal(env, info[0]);
     if (duckdb_appender_flush(appender)) {
@@ -3960,7 +3960,7 @@ private:
 
   // DUCKDB_API duckdb_state duckdb_appender_close(duckdb_appender appender);
   // function appender_close(appender: Appender): void
-  Napi::Value appender_close(const Napi::CallbackInfo& info) {
+  Napi::Value appender_close_sync(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto appender = GetAppenderFromExternal(env, info[0]);
     if (duckdb_appender_close(appender)) {

--- a/bindings/test/appender.test.ts
+++ b/bindings/test/appender.test.ts
@@ -66,7 +66,7 @@ suite('appender', () => {
       duckdb.appender_end_row(appender);
       duckdb.append_int32(appender, 33);
       duckdb.appender_end_row(appender);
-      duckdb.appender_flush(appender);
+      duckdb.appender_flush_sync(appender);
 
       const result = await duckdb.query(connection, 'from appender_target');
       await expectResult(result, {
@@ -210,8 +210,8 @@ suite('appender', () => {
 
       duckdb.appender_end_row(appender);
       // explicitly calling both flush and close is unnecessary because close does a flush, but this exercises them.
-      duckdb.appender_flush(appender);
-      duckdb.appender_close(appender);
+      duckdb.appender_flush_sync(appender);
+      duckdb.appender_close_sync(appender);
 
       const result = await duckdb.query(connection, 'from appender_target');
       await expectResult(result, {
@@ -319,7 +319,7 @@ suite('appender', () => {
       if (source_chunk) {
         duckdb.append_data_chunk(appender, source_chunk);
       }
-      duckdb.appender_flush(appender);
+      duckdb.appender_flush_sync(appender);
 
       const result = await duckdb.query(connection, 'from appender_target');
       await expectResult(result, {

--- a/bindings/test/connection.test.ts
+++ b/bindings/test/connection.test.ts
@@ -8,7 +8,7 @@ suite('connection', () => {
       const prepared1 = await duckdb.prepare(connection, 'select 1');
       expect(prepared1).toBeDefined();
       const { extracted_statements } = await duckdb.extract_statements(connection, 'select 10; select 20');
-      duckdb.disconnect(connection);
+      duckdb.disconnect_sync(connection);
       await expect(async () => await duckdb.prepare(connection, 'select 2'))
         .rejects.toStrictEqual(new Error('Failed to prepare: connection disconnected'));
       await expect(async () => await duckdb.query(connection, 'select 3'))
@@ -25,9 +25,9 @@ suite('connection', () => {
     await withConnection(async (connection) => {
       const prepared1 = await duckdb.prepare(connection, 'select 1');
       expect(prepared1).toBeDefined();
-      duckdb.disconnect(connection);
+      duckdb.disconnect_sync(connection);
       // ensure a second disconnect is a no-op
-      duckdb.disconnect(connection);
+      duckdb.disconnect_sync(connection);
       await expect(async () => await duckdb.prepare(connection, 'select 3'))
         .rejects.toStrictEqual(new Error('Failed to prepare: connection disconnected'));
     });

--- a/bindings/test/open.test.ts
+++ b/bindings/test/open.test.ts
@@ -5,28 +5,28 @@ suite('open', () => {
   test('no args', async () => {
     const db = await duckdb.open();
     expect(db).toBeTruthy();
-    duckdb.close(db);
+    duckdb.close_sync(db);
   });
   test('memory arg', async () => {
     const db = await duckdb.open(':memory:');
     expect(db).toBeTruthy();
-    duckdb.close(db);
+    duckdb.close_sync(db);
   });
   test('with config', async () => {
     const config = duckdb.create_config();
     duckdb.set_config(config, 'custom_user_agent', 'my_user_agent');
     const db = await duckdb.open(':memory:', config);
     expect(db).toBeTruthy();
-    duckdb.close(db);
+    duckdb.close_sync(db);
   });
   test('close', async () => {
     const db = await duckdb.open();
     expect(db).toBeTruthy();
-    duckdb.close(db);
+    duckdb.close_sync(db);
     await expect(async () => await duckdb.connect(db)).rejects.toStrictEqual(
       new Error('Failed to connect: instance closed')
     );
     // double-close should be a no-op
-    duckdb.close(db);
+    duckdb.close_sync(db);
   });
 });


### PR DESCRIPTION
- Add `Sync` suffix to close, disconnect, and flush methods that can perform significant work:
  - instance.close -> instance.closeSync
  - connection.close -> connection.closeSync
  - connection.disconnect -> connection.disconnectSync
  - appender.flush -> appender.flushSync
  - appender.close -> appender.closeSync
- Add `_sync` suffix to corresponding bindings functions:
  - close -> close_sync
  - disconnect -> disconnect_sync
  - appender_flush -> appender_flush_sync
  - appender_close -> appender_close_sync

The implementation of these functions is unchanged.

In the future, I plan to add async versions of all of these, using the name without the `Sync` or `_sync` suffix. Releasing this name change separately from adding the async versions hopefully make migration easier, because the name change will be detected by the compiler, while changing a function from sync to async is harder to detect.