### PR TITLE
column names and types json

### DIFF
--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -405,6 +405,127 @@ const columnsObject = reader.getColumnsObjectJson();
 // }
 ```
 
+Column names and types can also be serialized to JSON:
+```ts
+const columnNamesAndTypes = reader.columnNamesAndTypesJson();
+// {
+//   "columnNames": [
+//     "int_array",
+//     "struct",
+//     "map",
+//     "union"
+//   ],
+//   "columnTypes": [
+//     {
+//       "typeId": 24,
+//       "valueType": {
+//         "typeId": 4
+//       }
+//     },
+//     {
+//       "typeId": 25,
+//       "entryNames": [
+//         "a",
+//         "b"
+//       ],
+//       "entryTypes": [
+//         {
+//           "typeId": 4
+//         },
+//         {
+//           "typeId": 17
+//         }
+//       ]
+//     },
+//     {
+//       "typeId": 26,
+//       "keyType": {
+//         "typeId": 17
+//       },
+//       "valueType": {
+//         "typeId": 17
+//       }
+//     },
+//     {
+//       "typeId": 28,
+//       "memberTags": [
+//         "name",
+//         "age"
+//       ],
+//       "memberTypes": [
+//         {
+//           "typeId": 17
+//         },
+//         {
+//           "typeId": 3
+//         }
+//       ]
+//     }
+//   ]
+// }
+
+const columnNameAndTypeObjects = reader.columnNameAndTypeObjectsJson();
+// [
+//   {
+//     "columnName": "int_array",
+//     "columnType": {
+//       "typeId": 24,
+//       "valueType": {
+//         "typeId": 4
+//       }
+//     }
+//   },
+//   {
+//     "columnName": "struct",
+//     "columnType": {
+//       "typeId": 25,
+//       "entryNames": [
+//         "a",
+//         "b"
+//       ],
+//       "entryTypes": [
+//         {
+//           "typeId": 4
+//         },
+//         {
+//           "typeId": 17
+//         }
+//       ]
+//     }
+//   },
+//   {
+//     "columnName": "map",
+//     "columnType": {
+//       "typeId": 26,
+//       "keyType": {
+//         "typeId": 17
+//       },
+//       "valueType": {
+//         "typeId": 17
+//       }
+//     }
+//   },
+//   {
+//     "columnName": "union",
+//     "columnType": {
+//       "typeId": 28,
+//       "memberTags": [
+//         "name",
+//         "age"
+//       ],
+//       "memberTypes": [
+//         {
+//           "typeId": 17
+//         },
+//         {
+//           "typeId": 3
+//         }
+//       ]
+//     }
+//   }
+// ]
+```
+
 ### Fetch Chunks
 
 Fetch all chunks:

--- a/api/src/DuckDBResult.ts
+++ b/api/src/DuckDBResult.ts
@@ -3,7 +3,8 @@ import { DuckDBDataChunk } from './DuckDBDataChunk';
 import { DuckDBLogicalType } from './DuckDBLogicalType';
 import { DuckDBType } from './DuckDBType';
 import { DuckDBTypeId } from './DuckDBTypeId';
-import { DuckDBValueToJsonConverter, Json } from './DuckDBValueToJsonConverter';
+import { DuckDBValueToJsonConverter } from './DuckDBValueToJsonConverter';
+import { Json } from './Json';
 import { convertColumnsFromChunks } from './convertColumnsFromChunks';
 import { convertColumnsObjectFromChunks } from './convertColumnsObjectFromChunks';
 import { convertRowObjectsFromChunks } from './convertRowObjectsFromChunks';
@@ -72,6 +73,9 @@ export class DuckDBResult {
       duckdb.column_logical_type(this.result, columnIndex)
     ).asType();
   }
+  public columnTypeJson(columnIndex: number): Json {
+    return this.columnType(columnIndex).toJson();
+  }
   public columnTypes(): DuckDBType[] {
     const columnTypes: DuckDBType[] = [];
     const columnCount = this.columnCount;
@@ -79,6 +83,31 @@ export class DuckDBResult {
       columnTypes.push(this.columnType(columnIndex));
     }
     return columnTypes;
+  }
+  public columnTypesJson(): Json {
+    const columnTypesJson: Json[] = [];
+    const columnCount = this.columnCount;
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      columnTypesJson.push(this.columnTypeJson(columnIndex));
+    }
+    return columnTypesJson;
+  }
+  public columnNamesAndTypesJson(): Json {
+    return {
+      columnNames: this.columnNames(),
+      columnTypes: this.columnTypesJson(),
+    };
+  }
+  public columnNameAndTypeObjectsJson(): Json {
+    const columnNameAndTypeObjects: Json[] = [];
+    const columnCount = this.columnCount;
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      columnNameAndTypeObjects.push({
+        columnName: this.columnName(columnIndex),
+        columnType: this.columnTypeJson(columnIndex),
+      });
+    }
+    return columnNameAndTypeObjects;
   }
   public get isStreaming(): boolean {
     return duckdb.result_is_streaming(this.result);

--- a/api/src/DuckDBResultReader.ts
+++ b/api/src/DuckDBResultReader.ts
@@ -7,12 +7,13 @@ import { DuckDBLogicalType } from './DuckDBLogicalType';
 import { DuckDBResult } from './DuckDBResult';
 import { DuckDBType } from './DuckDBType';
 import { DuckDBTypeId } from './DuckDBTypeId';
-import { DuckDBValueToJsonConverter, Json } from './DuckDBValueToJsonConverter';
+import { DuckDBValueToJsonConverter } from './DuckDBValueToJsonConverter';
 import { ResultReturnType, StatementType } from './enums';
 import { getColumnsFromChunks } from './getColumnsFromChunks';
 import { getColumnsObjectFromChunks } from './getColumnsObjectFromChunks';
 import { getRowObjectsFromChunks } from './getRowObjectsFromChunks';
 import { getRowsFromChunks } from './getRowsFromChunks';
+import { Json } from './Json';
 import { DuckDBValue } from './values';
 
 interface ChunkSizeRun {
@@ -63,8 +64,20 @@ export class DuckDBResultReader {
   public columnType(columnIndex: number): DuckDBType {
     return this.result.columnType(columnIndex);
   }
+  public columnTypeJson(columnIndex: number): Json {
+    return this.result.columnTypeJson(columnIndex);
+  }
   public columnTypes(): DuckDBType[] {
     return this.result.columnTypes();
+  }
+  public columnTypesJson(): Json {
+    return this.result.columnTypesJson();
+  }
+  public columnNamesAndTypesJson(): Json {
+    return this.result.columnNamesAndTypesJson();
+  }
+  public columnNameAndTypeObjectsJson(): Json {
+    return this.result.columnNameAndTypeObjectsJson();
   }
   public get rowsChanged(): number {
     return this.result.rowsChanged;

--- a/api/src/DuckDBType.ts
+++ b/api/src/DuckDBType.ts
@@ -1,6 +1,7 @@
 import duckdb from '@duckdb/node-bindings';
 import { DuckDBLogicalType } from './DuckDBLogicalType';
 import { DuckDBTypeId } from './DuckDBTypeId';
+import { Json } from './Json';
 import { quotedIdentifier, quotedString } from './sql';
 import {
   DuckDBDateValue,
@@ -32,6 +33,12 @@ export abstract class BaseDuckDBType<T extends DuckDBTypeId> {
       logicalType.alias = this.alias;
     }
     return logicalType;
+  }
+  public toJson(): Json {
+    return {
+      typeId: this.typeId,
+      ...(this.alias ? { alias: this.alias } : {}),
+    };
   }
 }
 
@@ -401,6 +408,14 @@ export class DuckDBDecimalType extends BaseDuckDBType<DuckDBTypeId.DECIMAL> {
     }
     return logicalType;
   }
+  public override toJson(): Json {
+    return {
+      typeId: this.typeId,
+      width: this.width,
+      scale: this.scale,
+      ...(this.alias ? { alias: this.alias } : {}),
+    };
+  }
   public static readonly default = new DuckDBDecimalType(18, 3);
 }
 export function DECIMAL(
@@ -532,6 +547,14 @@ export class DuckDBEnumType extends BaseDuckDBType<DuckDBTypeId.ENUM> {
     }
     return logicalType;
   }
+  public override toJson(): Json {
+    return {
+      typeId: this.typeId,
+      values: [...this.values],
+      internalTypeId: this.internalTypeId,
+      ...(this.alias ? { alias: this.alias } : {}),
+    };
+  }
 }
 export function ENUM8(
   values: readonly string[],
@@ -585,6 +608,13 @@ export class DuckDBListType extends BaseDuckDBType<DuckDBTypeId.LIST> {
       logicalType.alias = this.alias;
     }
     return logicalType;
+  }
+  public override toJson(): Json {
+    return {
+      typeId: this.typeId,
+      valueType: this.valueType.toJson(),
+      ...(this.alias ? { alias: this.alias } : {}),
+    };
   }
 }
 export function LIST(valueType: DuckDBType, alias?: string): DuckDBListType {
@@ -641,6 +671,14 @@ export class DuckDBStructType extends BaseDuckDBType<DuckDBTypeId.STRUCT> {
     }
     return logicalType;
   }
+  public override toJson(): Json {
+    return {
+      typeId: this.typeId,
+      entryNames: [...this.entryNames],
+      entryTypes: this.entryTypes.map(t => t.toJson()),
+      ...(this.alias ? { alias: this.alias } : {}),
+    };
+  }
 }
 export function STRUCT(
   entries: Record<string, DuckDBType>,
@@ -676,6 +714,14 @@ export class DuckDBMapType extends BaseDuckDBType<DuckDBTypeId.MAP> {
     }
     return logicalType;
   }
+  public override toJson(): Json {
+    return {
+      typeId: this.typeId,
+      keyType: this.keyType.toJson(),
+      valueType: this.valueType.toJson(),
+      ...(this.alias ? { alias: this.alias } : {}),
+    };
+  }
 }
 export function MAP(
   keyType: DuckDBType,
@@ -705,6 +751,14 @@ export class DuckDBArrayType extends BaseDuckDBType<DuckDBTypeId.ARRAY> {
       logicalType.alias = this.alias;
     }
     return logicalType;
+  }
+  public override toJson(): Json {
+    return {
+      typeId: this.typeId,
+      valueType: this.valueType.toJson(),
+      length: this.length,
+      ...(this.alias ? { alias: this.alias } : {}),
+    };
   }
 }
 export function ARRAY(
@@ -781,6 +835,14 @@ export class DuckDBUnionType extends BaseDuckDBType<DuckDBTypeId.UNION> {
       logicalType.alias = this.alias;
     }
     return logicalType;
+  }
+  public override toJson(): Json {
+    return {
+      typeId: this.typeId,
+      memberTags: [...this.memberTags],
+      memberTypes: this.memberTypes.map(t => t.toJson()),
+      ...(this.alias ? { alias: this.alias } : {}),
+    };
   }
 }
 export function UNION(

--- a/api/src/DuckDBValueToJsonConverter.ts
+++ b/api/src/DuckDBValueToJsonConverter.ts
@@ -1,6 +1,7 @@
 import { DuckDBType } from './DuckDBType';
 import { DuckDBTypeId } from './DuckDBTypeId';
 import { DuckDBValueConverter } from './DuckDBValueConverter';
+import { Json } from './Json';
 import {
   DuckDBArrayValue,
   DuckDBIntervalValue,
@@ -10,14 +11,6 @@ import {
   DuckDBUnionValue,
   DuckDBValue,
 } from './values';
-
-export type Json =
-  | null
-  | boolean
-  | number
-  | string
-  | Json[]
-  | { [key: string]: Json };
 
 export class DuckDBValueToJsonConverter implements DuckDBValueConverter<Json> {
   public static readonly default = new DuckDBValueToJsonConverter();

--- a/api/src/Json.ts
+++ b/api/src/Json.ts
@@ -1,0 +1,7 @@
+export type Json =
+  | null
+  | boolean
+  | number
+  | string
+  | Json[]
+  | { [key: string]: Json };

--- a/api/src/duckdb.ts
+++ b/api/src/duckdb.ts
@@ -1,9 +1,10 @@
 export {
-  hugeint_to_double,
   double_to_hugeint,
-  uhugeint_to_double,
   double_to_uhugeint,
+  hugeint_to_double,
+  uhugeint_to_double,
 } from '@duckdb/node-bindings';
+export * from './configurationOptionDescriptions';
 export * from './DuckDBAppender';
 export * from './DuckDBConnection';
 export * from './DuckDBDataChunk';
@@ -19,8 +20,8 @@ export * from './DuckDBTypeId';
 export * from './DuckDBValueConverter';
 export * from './DuckDBValueToJsonConverter';
 export * from './DuckDBVector';
-export * from './configurationOptionDescriptions';
 export * from './enums';
+export * from './Json';
 export * from './sql';
 export * from './values';
 export * from './version';

--- a/api/test/util/testAllTypes.ts
+++ b/api/test/util/testAllTypes.ts
@@ -68,172 +68,205 @@ export interface ColumnNameAndType {
   readonly type: DuckDBType;
 }
 
-export interface ColumnNameTypeAndRows extends ColumnNameAndType {
+export interface ColumnNameTypeAndValues extends ColumnNameAndType {
   readonly name: string;
   readonly type: DuckDBType;
-  readonly rows: readonly DuckDBValue[];
-  readonly json: readonly Json[];
+  readonly typeJson: Json;
+  readonly values: readonly DuckDBValue[];
+  readonly valuesJson: readonly Json[];
 }
 
 function col(
   name: string,
   type: DuckDBType,
-  rows: readonly DuckDBValue[],
-  json: readonly Json[]
-): ColumnNameTypeAndRows {
-  return { name, type, rows, json };
+  typeJson: Json,
+  values: readonly DuckDBValue[],
+  valuesJson: readonly Json[]
+): ColumnNameTypeAndValues {
+  return { name, type, typeJson, values, valuesJson };
 }
 
-export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
+export function createTestAllTypesData(): ColumnNameTypeAndValues[] {
   return [
-    col('bool', BOOLEAN, [false, true, null], [false, true, null]),
+    col(
+      'bool',
+      BOOLEAN,
+      { typeId: 1 },
+      [false, true, null],
+      [false, true, null]
+    ),
     col(
       'tinyint',
       TINYINT,
+      { typeId: 2 },
       [TINYINT.min, TINYINT.max, null],
       [TINYINT.min, TINYINT.max, null]
     ),
     col(
       'smallint',
       SMALLINT,
+      { typeId: 3 },
       [SMALLINT.min, SMALLINT.max, null],
       [SMALLINT.min, SMALLINT.max, null]
     ),
     col(
       'int',
       INTEGER,
+      { typeId: 4 },
       [INTEGER.min, INTEGER.max, null],
       [INTEGER.min, INTEGER.max, null]
     ),
     col(
       'bigint',
       BIGINT,
+      { typeId: 5 },
       [BIGINT.min, BIGINT.max, null],
       [String(BIGINT.min), String(BIGINT.max), null]
     ),
     col(
       'hugeint',
       HUGEINT,
+      { typeId: 16 },
       [HUGEINT.min, HUGEINT.max, null],
       [String(HUGEINT.min), String(HUGEINT.max), null]
     ),
     col(
       'uhugeint',
       UHUGEINT,
+      { typeId: 32 },
       [UHUGEINT.min, UHUGEINT.max, null],
       [String(UHUGEINT.min), String(UHUGEINT.max), null]
     ),
     col(
       'utinyint',
       UTINYINT,
+      { typeId: 6 },
       [UTINYINT.min, UTINYINT.max, null],
       [UTINYINT.min, UTINYINT.max, null]
     ),
     col(
       'usmallint',
       USMALLINT,
+      { typeId: 7 },
       [USMALLINT.min, USMALLINT.max, null],
       [USMALLINT.min, USMALLINT.max, null]
     ),
     col(
       'uint',
       UINTEGER,
+      { typeId: 8 },
       [UINTEGER.min, UINTEGER.max, null],
       [UINTEGER.min, UINTEGER.max, null]
     ),
     col(
       'ubigint',
       UBIGINT,
+      { typeId: 9 },
       [UBIGINT.min, UBIGINT.max, null],
       [String(UBIGINT.min), String(UBIGINT.max), null]
     ),
     col(
       'varint',
       VARINT,
+      { typeId: 35 },
       [VARINT.min, VARINT.max, null],
       [String(VARINT.min), String(VARINT.max), null]
     ),
     col(
       'date',
       DATE,
+      { typeId: 13 },
       [DATE.min, DATE.max, null],
       [String(DATE.min), String(DATE.max), null]
     ),
     col(
       'time',
       TIME,
+      { typeId: 14 },
       [TIME.min, TIME.max, null],
       [String(TIME.min), String(TIME.max), null]
     ),
     col(
       'timestamp',
       TIMESTAMP,
+      { typeId: 12 },
       [TIMESTAMP.min, TIMESTAMP.max, null],
       [String(TIMESTAMP.min), String(TIMESTAMP.max), null]
     ),
     col(
       'timestamp_s',
       TIMESTAMP_S,
+      { typeId: 20 },
       [TIMESTAMP_S.min, TIMESTAMP_S.max, null],
       [String(TIMESTAMP_S.min), String(TIMESTAMP_S.max), null]
     ),
     col(
       'timestamp_ms',
       TIMESTAMP_MS,
+      { typeId: 21 },
       [TIMESTAMP_MS.min, TIMESTAMP_MS.max, null],
       [String(TIMESTAMP_MS.min), String(TIMESTAMP_MS.max), null]
     ),
     col(
       'timestamp_ns',
       TIMESTAMP_NS,
+      { typeId: 22 },
       [TIMESTAMP_NS.min, TIMESTAMP_NS.max, null],
       [String(TIMESTAMP_NS.min), String(TIMESTAMP_NS.max), null]
     ),
     col(
       'time_tz',
       TIMETZ,
+      { typeId: 30 },
       [TIMETZ.min, TIMETZ.max, null],
       [String(TIMETZ.min), String(TIMETZ.max), null]
     ),
     col(
       'timestamp_tz',
       TIMESTAMPTZ,
+      { typeId: 31 },
       [TIMESTAMPTZ.min, TIMESTAMPTZ.max, null],
       [String(TIMESTAMPTZ.min), String(TIMESTAMPTZ.max), null]
     ),
     col(
       'float',
       FLOAT,
+      { typeId: 10 },
       [FLOAT.min, FLOAT.max, null],
       [FLOAT.min, FLOAT.max, null]
     ),
     col(
       'double',
       DOUBLE,
+      { typeId: 11 },
       [DOUBLE.min, DOUBLE.max, null],
       [DOUBLE.min, DOUBLE.max, null]
     ),
     col(
       'dec_4_1',
       DECIMAL(4, 1),
+      { typeId: 19, width: 4, scale: 1 },
       [decimalValue(-9999n, 4, 1), decimalValue(9999n, 4, 1), null],
       ['-999.9', '999.9', null]
     ),
     col(
       'dec_9_4',
       DECIMAL(9, 4),
+      { typeId: 19, width: 9, scale: 4 },
       [decimalValue(-999999999n, 9, 4), decimalValue(999999999n, 9, 4), null],
       ['-99999.9999', '99999.9999', null]
     ),
     col(
       'dec_18_6',
       DECIMAL(18, 6),
+      { typeId: 19, width: 18, scale: 6 },
       [decimalValue(-BI_18_9s, 18, 6), decimalValue(BI_18_9s, 18, 6), null],
       ['-999999999999.999999', '999999999999.999999', null]
     ),
     col(
       'dec38_10',
       DECIMAL(38, 10),
+      { typeId: 19, width: 38, scale: 10 },
       [decimalValue(-BI_38_9s, 38, 10), decimalValue(BI_38_9s, 38, 10), null],
       [
         '-9999999999999999999999999999.9999999999',
@@ -244,12 +277,14 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'uuid',
       UUID,
+      { typeId: 27 },
       [UUID.min, UUID.max, null],
       [String(UUID.min), String(UUID.max), null]
     ),
     col(
       'interval',
       INTERVAL,
+      { typeId: 15 },
       [intervalValue(0, 0, 0n), intervalValue(999, 999, 999999999n), null],
       [
         { months: 0, days: 0, micros: '0' },
@@ -260,12 +295,14 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'varchar',
       VARCHAR,
+      { typeId: 17 },
       ['🦆🦆🦆🦆🦆🦆', 'goo\0se', null],
       ['🦆🦆🦆🦆🦆🦆', 'goo\0se', null]
     ),
     col(
       'blob',
       BLOB,
+      { typeId: 18 },
       [
         blobValue('thisisalongblob\x00withnullbytes'),
         blobValue('\x00\x00\x00a'),
@@ -276,18 +313,21 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'bit',
       BIT,
+      { typeId: 29 },
       [bitValue('0010001001011100010101011010111'), bitValue('10101'), null],
       ['0010001001011100010101011010111', '10101', null]
     ),
     col(
       'small_enum',
       ENUM8(smallEnumValues),
+      { typeId: 23, values: smallEnumValues, internalTypeId: 6 },
       [smallEnumValues[0], smallEnumValues[smallEnumValues.length - 1], null],
       [smallEnumValues[0], smallEnumValues[smallEnumValues.length - 1], null]
     ),
     col(
       'medium_enum',
       ENUM16(mediumEnumValues),
+      { typeId: 23, values: mediumEnumValues, internalTypeId: 7 },
       [
         mediumEnumValues[0],
         mediumEnumValues[mediumEnumValues.length - 1],
@@ -298,18 +338,21 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'large_enum',
       ENUM32(largeEnumValues),
+      { typeId: 23, values: largeEnumValues, internalTypeId: 8 },
       [largeEnumValues[0], largeEnumValues[largeEnumValues.length - 1], null],
       [largeEnumValues[0], largeEnumValues[largeEnumValues.length - 1], null]
     ),
     col(
       'int_array',
       LIST(INTEGER),
+      { typeId: 24, valueType: { typeId: 4 } },
       [listValue([]), listValue([42, 999, null, null, -42]), null],
       [[], [42, 999, null, null, -42], null]
     ),
     col(
       'double_array',
       LIST(DOUBLE),
+      { typeId: 24, valueType: { typeId: 11 } },
       [
         listValue([]),
         listValue([42.0, NaN, Infinity, -Infinity, null, -42.0]),
@@ -320,6 +363,7 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'date_array',
       LIST(DATE),
+      { typeId: 24, valueType: { typeId: 13 } },
       [
         listValue([]),
         // 19124 days from the epoch is 2022-05-12
@@ -347,6 +391,7 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'timestamp_array',
       LIST(TIMESTAMP),
+      { typeId: 24, valueType: { typeId: 12 } },
       [
         listValue([]),
         listValue([
@@ -374,6 +419,7 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'timestamptz_array',
       LIST(TIMESTAMPTZ),
+      { typeId: 24, valueType: { typeId: 31 } },
       [
         listValue([]),
         listValue([
@@ -402,6 +448,7 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'varchar_array',
       LIST(VARCHAR),
+      { typeId: 24, valueType: { typeId: 17 } },
       [
         listValue([]),
         // Note that the string 'goose' in varchar_array does NOT have an embedded null character.
@@ -413,6 +460,7 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'nested_int_array',
       LIST(LIST(INTEGER)),
+      { typeId: 24, valueType: { typeId: 24, valueType: { typeId: 4 } } },
       [
         listValue([]),
         listValue([
@@ -433,6 +481,11 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'struct',
       STRUCT({ 'a': INTEGER, 'b': VARCHAR }),
+      {
+        typeId: 25,
+        entryNames: ['a', 'b'],
+        entryTypes: [{ typeId: 4 }, { typeId: 17 }],
+      },
       [
         structValue({ 'a': null, 'b': null }),
         structValue({ 'a': 42, 'b': '🦆🦆🦆🦆🦆🦆' }),
@@ -443,6 +496,14 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'struct_of_arrays',
       STRUCT({ 'a': LIST(INTEGER), 'b': LIST(VARCHAR) }),
+      {
+        typeId: 25,
+        entryNames: ['a', 'b'],
+        entryTypes: [
+          { typeId: 24, valueType: { typeId: 4 } },
+          { typeId: 24, valueType: { typeId: 17 } },
+        ],
+      },
       [
         structValue({ 'a': null, 'b': null }),
         structValue({
@@ -463,6 +524,14 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'array_of_structs',
       LIST(STRUCT({ 'a': INTEGER, 'b': VARCHAR })),
+      {
+        typeId: 24,
+        valueType: {
+          typeId: 25,
+          entryNames: ['a', 'b'],
+          entryTypes: [{ typeId: 4 }, { typeId: 17 }],
+        },
+      },
       [
         listValue([]),
         listValue([
@@ -481,6 +550,7 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'map',
       MAP(VARCHAR, VARCHAR),
+      { typeId: 26, keyType: { typeId: 17 }, valueType: { typeId: 17 } },
       [
         mapValue([]),
         mapValue([
@@ -501,24 +571,36 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'union',
       UNION({ 'name': VARCHAR, 'age': SMALLINT }),
+      {
+        typeId: 28,
+        memberTags: ['name', 'age'],
+        memberTypes: [{ typeId: 17 }, { typeId: 3 }],
+      },
       [unionValue('name', 'Frank'), unionValue('age', 5), null],
       [{ 'tag': 'name', 'value': 'Frank' }, { 'tag': 'age', 'value': 5 }, null]
     ),
     col(
       'fixed_int_array',
       ARRAY(INTEGER, 3),
+      { typeId: 33, valueType: { typeId: 4 }, length: 3 },
       [arrayValue([null, 2, 3]), arrayValue([4, 5, 6]), null],
       [[null, 2, 3], [4, 5, 6], null]
     ),
     col(
       'fixed_varchar_array',
       ARRAY(VARCHAR, 3),
+      { typeId: 33, valueType: { typeId: 17 }, length: 3 },
       [arrayValue(['a', null, 'c']), arrayValue(['d', 'e', 'f']), null],
       [['a', null, 'c'], ['d', 'e', 'f'], null]
     ),
     col(
       'fixed_nested_int_array',
       ARRAY(ARRAY(INTEGER, 3), 3),
+      {
+        typeId: 33,
+        valueType: { typeId: 33, valueType: { typeId: 4 }, length: 3 },
+        length: 3,
+      },
       [
         arrayValue([arrayValue([null, 2, 3]), null, arrayValue([null, 2, 3])]),
         arrayValue([
@@ -541,6 +623,11 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'fixed_nested_varchar_array',
       ARRAY(ARRAY(VARCHAR, 3), 3),
+      {
+        typeId: 33,
+        valueType: { typeId: 33, valueType: { typeId: 17 }, length: 3 },
+        length: 3,
+      },
       [
         arrayValue([
           arrayValue(['a', null, 'c']),
@@ -567,6 +654,15 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'fixed_struct_array',
       ARRAY(STRUCT({ 'a': INTEGER, 'b': VARCHAR }), 3),
+      {
+        typeId: 33,
+        valueType: {
+          typeId: 25,
+          entryNames: ['a', 'b'],
+          entryTypes: [{ typeId: 4 }, { typeId: 17 }],
+        },
+        length: 3,
+      },
       [
         arrayValue([
           structValue({ 'a': null, 'b': null }),
@@ -597,6 +693,14 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'struct_of_fixed_array',
       STRUCT({ 'a': ARRAY(INTEGER, 3), 'b': ARRAY(VARCHAR, 3) }),
+      {
+        typeId: 25,
+        entryNames: ['a', 'b'],
+        entryTypes: [
+          { typeId: 33, valueType: { typeId: 4 }, length: 3 },
+          { typeId: 33, valueType: { typeId: 17 }, length: 3 },
+        ],
+      },
       [
         structValue({
           'a': arrayValue([null, 2, 3]),
@@ -617,6 +721,11 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'fixed_array_of_int_list',
       ARRAY(LIST(INTEGER), 3),
+      {
+        typeId: 33,
+        valueType: { typeId: 24, valueType: { typeId: 4 } },
+        length: 3,
+      },
       [
         arrayValue([
           listValue([]),
@@ -639,6 +748,10 @@ export function createTestAllTypesData(): ColumnNameTypeAndRows[] {
     col(
       'list_of_fixed_int_array',
       LIST(ARRAY(INTEGER, 3)),
+      {
+        typeId: 24,
+        valueType: { typeId: 33, valueType: { typeId: 4 }, length: 3 },
+      },
       [
         listValue([
           arrayValue([null, 2, 3]),
@@ -677,16 +790,34 @@ export function createTestAllTypesColumnTypes(): readonly DuckDBType[] {
   return createTestAllTypesData().map(({ type }) => type);
 }
 
-export function createTestAllTypesColumnsNamesAndTypes(): readonly ColumnNameAndType[] {
+export function createTestAllTypesColumnTypesJson(): readonly Json[] {
+  return createTestAllTypesData().map(({ typeJson }) => typeJson);
+}
+
+export function createTestAllTypesColumnNamesAndTypesJson(): Json {
+  return {
+    columnNames: [...createTestAllTypesColumnNames()],
+    columnTypes: [...createTestAllTypesColumnTypesJson()],
+  };
+}
+
+export function createTestAllTypesColumnNameAndTypeObjects(): readonly ColumnNameAndType[] {
   return createTestAllTypesData().map(({ name, type }) => ({ name, type }));
 }
 
+export function createTestAllTypesColumnNameAndTypeObjectsJson(): Json {
+  return createTestAllTypesData().map(({ name, typeJson }) => ({
+    columnName: name,
+    columnType: typeJson,
+  }));
+}
+
 export function createTestAllTypesColumns(): readonly (readonly DuckDBValue[])[] {
-  return createTestAllTypesData().map(({ rows }) => rows);
+  return createTestAllTypesData().map(({ values }) => values);
 }
 
 export function createTestAllTypesColumnsJson(): readonly (readonly Json[])[] {
-  return createTestAllTypesData().map(({ json }) => json);
+  return createTestAllTypesData().map(({ valuesJson }) => valuesJson);
 }
 
 export function createTestAllTypesColumnsObjectJson(): Record<
@@ -696,7 +827,7 @@ export function createTestAllTypesColumnsObjectJson(): Record<
   const columnsObject: Record<string, readonly Json[]> = {};
   const data = createTestAllTypesData();
   for (const columnData of data) {
-    columnsObject[columnData.name] = columnData.json;
+    columnsObject[columnData.name] = columnData.valuesJson;
   }
   return columnsObject;
 }
@@ -704,9 +835,9 @@ export function createTestAllTypesColumnsObjectJson(): Record<
 export function createTestAllTypesRowsJson(): readonly (readonly Json[])[] {
   const data = createTestAllTypesData();
   return [
-    data.map(({ json }) => json[0]),
-    data.map(({ json }) => json[1]),
-    data.map(({ json }) => json[2]),
+    data.map(({ valuesJson }) => valuesJson[0]),
+    data.map(({ valuesJson }) => valuesJson[1]),
+    data.map(({ valuesJson }) => valuesJson[2]),
   ];
 }
 
@@ -717,9 +848,9 @@ export function createTestAllTypesRowObjectsJson(): readonly Record<
   const rowObjects: Record<string, Json>[] = [{}, {}, {}];
   const data = createTestAllTypesData();
   for (const columnData of data) {
-    rowObjects[0][columnData.name] = columnData.json[0];
-    rowObjects[1][columnData.name] = columnData.json[1];
-    rowObjects[2][columnData.name] = columnData.json[2];
+    rowObjects[0][columnData.name] = columnData.valuesJson[0];
+    rowObjects[1][columnData.name] = columnData.valuesJson[1];
+    rowObjects[2][columnData.name] = columnData.valuesJson[2];
   }
   return rowObjects;
 }


### PR DESCRIPTION
Add functions to return column names and types as JSON, on both DuckDBResult and DuckDBResultReader:
- columnTypeJson(columnIndex)
- columnTypesJson()
- columnNamesAndTypesJson()
- columnNameAndTypeObjectsJson()

Add tests and documentation for the above.