### PR TITLE
chunk objects methods

### DIFF
--- a/api/src/getColumnsFromChunks.ts
+++ b/api/src/getColumnsFromChunks.ts
@@ -5,16 +5,8 @@ export function getColumnsFromChunks(
   chunks: readonly DuckDBDataChunk[]
 ): DuckDBValue[][] {
   const columns: DuckDBValue[][] = [];
-  if (chunks.length === 0) {
-    return columns;
-  }
-  chunks[0].visitColumns((column) => columns.push(column));
-  for (let chunkIndex = 1; chunkIndex < chunks.length; chunkIndex++) {
-    for (let columnIndex = 0; columnIndex < columns.length; columnIndex++) {
-      chunks[chunkIndex].visitColumnValues(columnIndex, (value) =>
-        columns[columnIndex].push(value)
-      );
-    }
+  for (const chunk of chunks) {
+    chunk.appendToColumns(columns);
   }
   return columns;
 }

--- a/api/src/getColumnsObjectFromChunks.ts
+++ b/api/src/getColumnsObjectFromChunks.ts
@@ -3,22 +3,11 @@ import { DuckDBValue } from './values';
 
 export function getColumnsObjectFromChunks(
   chunks: readonly DuckDBDataChunk[],
-  columnNames: readonly string[],
+  columnNames: readonly string[]
 ): Record<string, DuckDBValue[]> {
   const columnsObject: Record<string, DuckDBValue[]> = {};
-  for (const columnName of columnNames) {
-    columnsObject[columnName] = [];
-  }
-  if (chunks.length === 0) {
-    return columnsObject;
-  }
-  const columnCount = chunks[0].columnCount;
-  for (let chunkIndex = 0; chunkIndex < chunks.length; chunkIndex++) {
-    for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
-      chunks[chunkIndex].visitColumnValues(columnIndex, (value) =>
-        columnsObject[columnNames[columnIndex]].push(value)
-      );
-    }
+  for (const chunk of chunks) {
+    chunk.appendToColumnsObject(columnNames, columnsObject);
   }
   return columnsObject;
 }

--- a/api/src/getRowObjectsFromChunks.ts
+++ b/api/src/getRowObjectsFromChunks.ts
@@ -7,14 +7,7 @@ export function getRowObjectsFromChunks(
 ): Record<string, DuckDBValue>[] {
   const rowObjects: Record<string, DuckDBValue>[] = [];
   for (const chunk of chunks) {
-    const rowCount = chunk.rowCount;
-    for (let rowIndex = 0; rowIndex < rowCount; rowIndex++) {
-      const rowObject: Record<string, DuckDBValue> = {};
-      chunk.visitRowValues(rowIndex, (value, _, columnIndex) => {
-        rowObject[columnNames[columnIndex]] = value;
-      });
-      rowObjects.push(rowObject);
-    }
+    chunk.appendToRowObjects(columnNames, rowObjects);
   }
   return rowObjects;
 }

--- a/api/src/getRowsFromChunks.ts
+++ b/api/src/getRowsFromChunks.ts
@@ -6,7 +6,7 @@ export function getRowsFromChunks(
 ): DuckDBValue[][] {
   const rows: DuckDBValue[][] = [];
   for (const chunk of chunks) {
-    chunk.visitRows((row) => rows.push(row));
+    chunk.appendToRows(rows);
   }
   return rows;
 }


### PR DESCRIPTION
Added getColumnsObject and getRowObjects to DuckDBDataChunk. These were incorrectly documented as existing, but didn't. The actual signatures differ somewhat from what was (incorrectly) documented - they need to take the list of column names, typically retrieved from result.deduplicatedColumnNames.

As part of this, factored out some related code into "append" methods that act on existing arrays or objects. This enabled some simplification of the functions that deal with arrays of chunks.
