### PR TITLE
string from blob performance

### DIFF
--- a/api/src/conversion/stringFromBlob.ts
+++ b/api/src/conversion/stringFromBlob.ts
@@ -1,5 +1,15 @@
 /** Matches BLOB-to-VARCHAR conversion behavior of DuckDB. */
 export function stringFromBlob(bytes: Uint8Array): string {
+  // String concatenation appears to be faster for this function at smaller sizes.
+  // Threshold of (2^16) experimentally determined on a MacBook Pro (M2 Max).
+  // See stringFromBlob.bench.ts.
+  if (bytes.length <= 65536) {
+    return stringFromBlobStringConcat(bytes);
+  }
+  return stringFromBlobArrayJoin(bytes);
+}
+
+export function stringFromBlobStringConcat(bytes: Uint8Array): string {
   let byteString: string = '';
 
   for (const byte of bytes) {
@@ -15,4 +25,24 @@ export function stringFromBlob(bytes: Uint8Array): string {
     }
   }
   return byteString;
+}
+
+export function stringFromBlobArrayJoin(bytes: Uint8Array): string {
+  const byteStrings: string[] = [];
+
+  for (const byte of bytes) {
+    if (
+      byte <= 0x1f ||
+      byte === 0x22 /* double quote */ ||
+      byte === 0x27 /* single quote */ ||
+      byte >= 0x7f
+    ) {
+      byteStrings.push(
+        `\\x${byte.toString(16).toUpperCase().padStart(2, '0')}`
+      );
+    } else {
+      byteStrings.push(String.fromCharCode(byte));
+    }
+  }
+  return byteStrings.join('');
 }

--- a/api/test/bench/stringFromBlob.bench.ts
+++ b/api/test/bench/stringFromBlob.bench.ts
@@ -1,0 +1,30 @@
+import { bench, describe } from 'vitest';
+import {
+  stringFromBlob,
+  stringFromBlobArrayJoin,
+  stringFromBlobStringConcat,
+} from '../../src/conversion/stringFromBlob';
+
+function createBytes(length: number): Uint8Array {
+  const bytes = new Uint8Array(length);
+  for (let i = 0; i < length; i++) {
+    bytes[i] = i % 256;
+  }
+  return bytes;
+}
+
+for (let lenPow2 = 0; lenPow2 < 24; lenPow2++) {
+  const bytes = createBytes(2 ** lenPow2);
+
+  describe(`stringFromBlob ${lenPow2}`, () => {
+    bench('string concat', () => {
+      stringFromBlobStringConcat(bytes);
+    });
+    bench('array join', () => {
+      stringFromBlobArrayJoin(bytes);
+    });
+    bench('combined', () => {
+      stringFromBlob(bytes);
+    });
+  });
+}


### PR DESCRIPTION
Benchmarked performance of two implementation of `stringFromBlob`. Determined that string concatenation is faster for smaller sizes (less than 2^16 bytes), on a MacBook Pro (M2 Max). Changed implementation to select faster path based on this threshold. See https://github.com/duckdb/duckdb-node-neo/pull/188