### PR TITLE
bump pkgs to 1.2.1-alpha.17

### DIFF
--- a/api/pkgs/@duckdb/node-api/package.json
+++ b/api/pkgs/@duckdb/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-api",
-  "version": "1.2.1-alpha.16",
+  "version": "1.2.1-alpha.17",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-arm64",
-  "version": "1.2.1-alpha.16",
+  "version": "1.2.1-alpha.17",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-x64",
-  "version": "1.2.1-alpha.16",
+  "version": "1.2.1-alpha.17",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-arm64",
-  "version": "1.2.1-alpha.16",
+  "version": "1.2.1-alpha.17",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-x64",
-  "version": "1.2.1-alpha.16",
+  "version": "1.2.1-alpha.17",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-x64",
-  "version": "1.2.1-alpha.16",
+  "version": "1.2.1-alpha.17",
   "license": "MIT",
   "os": [
     "win32"

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings",
-  "version": "1.2.1-alpha.16",
+  "version": "1.2.1-alpha.17",
   "license": "MIT",
   "main": "./duckdb.js",
   "types": "./duckdb.d.ts",


### PR DESCRIPTION
Changes in this version:
- [instance cache in api](https://github.com/duckdb/duckdb-node-neo/commit/299e82e8301384876ade1dbb31876f71ac85b687)
- https://github.com/duckdb/duckdb-node-neo/pull/185
- https://github.com/duckdb/duckdb-node-neo/pull/186 (BREAKING: METHOD NAME CHANGES)
- https://github.com/duckdb/duckdb-node-neo/pull/187
- https://github.com/duckdb/duckdb-node-neo/pull/188 and https://github.com/duckdb/duckdb-node-neo/pull/194
- https://github.com/duckdb/duckdb-node-neo/pull/191
- https://github.com/duckdb/duckdb-node-neo/pull/192
- https://github.com/duckdb/duckdb-node-neo/pull/193