### PR TITLE
add destroySync to DuckDBPreparedStatement

### DIFF
--- a/api/src/DuckDBPreparedStatement.ts
+++ b/api/src/DuckDBPreparedStatement.ts
@@ -47,6 +47,9 @@ export class DuckDBPreparedStatement {
   constructor(prepared_statement: duckdb.PreparedStatement) {
     this.prepared_statement = prepared_statement;
   }
+  public destroySync() {
+    return duckdb.destroy_prepare_sync(this.prepared_statement);
+  }
   public get statementType(): StatementType {
     return duckdb.prepared_statement_type(this.prepared_statement);
   }

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -398,6 +398,7 @@ describe('api', () => {
     const connection = await instance.connect();
     const prepared1 = await connection.prepare('select 1');
     assert.isDefined(prepared1);
+    prepared1.destroySync();
     connection.disconnectSync();
     try {
       await connection.prepare('select 2');

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -455,7 +455,7 @@ export function decimal_to_double(decimal: Decimal): number;
 export function prepare(connection: Connection, query: string): Promise<PreparedStatement>;
 
 // DUCKDB_API void duckdb_destroy_prepare(duckdb_prepared_statement *prepared_statement);
-// not exposed: destroyed in finalizer
+export function destroy_prepare_sync(prepared_statement: PreparedStatement): void;
 
 // DUCKDB_API const char *duckdb_prepare_error(duckdb_prepared_statement prepared_statement);
 // not exposed: prepare rejects promise with error

--- a/bindings/test/prepared_statements.test.ts
+++ b/bindings/test/prepared_statements.test.ts
@@ -448,4 +448,10 @@ suite('prepared statements', () => {
       }
     });
   });
+  test('destroy_prepare_sync', async () => {
+    await withConnection(async (connection) => {
+      const prepared = await duckdb.prepare(connection, 'select 1');
+      duckdb.destroy_prepare_sync(prepared);
+    });
+  });
 });


### PR DESCRIPTION
- Implement holder pattern for prepared statement external.
- Add `destroy_prepare_sync` to bindings.
- Add `destroySync` to `DuckDBPreparedStatement`.

Should provide a way to address #211.