### PR TITLE
data chunk: enforce max rows

### DIFF
--- a/api/src/DuckDBDataChunk.ts
+++ b/api/src/DuckDBDataChunk.ts
@@ -32,6 +32,10 @@ export class DuckDBDataChunk {
     return duckdb.data_chunk_get_size(this.chunk);
   }
   public set rowCount(count: number) {
+    const maxRowCount = duckdb.vector_size();
+    if (count > maxRowCount) {
+      throw new Error(`A data chunk cannot have more than ${maxRowCount} rows`);
+    }
     duckdb.data_chunk_set_size(this.chunk, count);
   }
   public getColumnVector(columnIndex: number): DuckDBVector {

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -1471,6 +1471,17 @@ describe('api', () => {
     const connection = await DuckDBConnection.create();
     await connection.run('select 1');
   });
+  test('data chunk max rows', () => {
+    try {
+      DuckDBDataChunk.create([INTEGER], 2049);
+      assert.fail('should throw');
+    } catch (err) {
+      assert.deepEqual(
+        err,
+        new Error('A data chunk cannot have more than 2048 rows')
+      );
+    }
+  });
   test('write integer vector', () => {
     const chunk = DuckDBDataChunk.create([INTEGER], 3);
     const vector = chunk.getColumnVector(0) as DuckDBIntegerVector;


### PR DESCRIPTION
Throw a friendly error if a data chunk's row count is set to larger than the max (2048).

See #205 