### PR TITLE
destroy prepared statements on connection close

### DIFF
--- a/api/src/DuckDBExtractedStatements.ts
+++ b/api/src/DuckDBExtractedStatements.ts
@@ -1,29 +1,37 @@
 import duckdb from '@duckdb/node-bindings';
 import { DuckDBPreparedStatement } from './DuckDBPreparedStatement';
+import { DuckDBPreparedStatementCollection } from './DuckDBPreparedStatementCollection';
 
 export class DuckDBExtractedStatements {
   private readonly connection: duckdb.Connection;
   private readonly extracted_statements: duckdb.ExtractedStatements;
   private readonly statement_count: number;
+  private readonly preparedStatements?: DuckDBPreparedStatementCollection;
   constructor(
     connection: duckdb.Connection,
     extracted_statements: duckdb.ExtractedStatements,
-    statement_count: number
+    statement_count: number,
+    preparedStatements?: DuckDBPreparedStatementCollection
   ) {
     this.connection = connection;
     this.extracted_statements = extracted_statements;
     this.statement_count = statement_count;
+    this.preparedStatements = preparedStatements;
   }
   public get count(): number {
     return this.statement_count;
   }
   public async prepare(index: number): Promise<DuckDBPreparedStatement> {
-    return new DuckDBPreparedStatement(
+    const prepared = new DuckDBPreparedStatement(
       await duckdb.prepare_extracted_statement(
         this.connection,
         this.extracted_statements,
         index
       )
     );
+    if (this.preparedStatements) {
+      this.preparedStatements.add(prepared);
+    }
+    return prepared;
   }
 }

--- a/api/src/DuckDBPreparedStatementCollection.ts
+++ b/api/src/DuckDBPreparedStatementCollection.ts
@@ -1,0 +1,5 @@
+import { DuckDBPreparedStatement } from './DuckDBPreparedStatement';
+
+export interface DuckDBPreparedStatementCollection {
+  add(prepared: DuckDBPreparedStatement): void;
+}

--- a/api/src/DuckDBPreparedStatementWeakRefCollection.ts
+++ b/api/src/DuckDBPreparedStatementWeakRefCollection.ts
@@ -1,0 +1,20 @@
+import { DuckDBPreparedStatement } from './DuckDBPreparedStatement';
+import { DuckDBPreparedStatementCollection } from './DuckDBPreparedStatementCollection';
+
+export class DuckDBPreparedStatementWeakRefCollection
+  implements DuckDBPreparedStatementCollection
+{
+  preparedStatements: WeakRef<DuckDBPreparedStatement>[] = [];
+  public add(prepared: DuckDBPreparedStatement) {
+    this.preparedStatements.push(new WeakRef(prepared));
+  }
+  public destroySync() {
+    for (const preparedRef of this.preparedStatements) {
+      const prepared = preparedRef.deref();
+      if (prepared) {
+        prepared.destroySync();
+      }
+    }
+    this.preparedStatements = [];
+  }
+}

--- a/api/src/DuckDBPreparedStatementWeakRefCollection.ts
+++ b/api/src/DuckDBPreparedStatementWeakRefCollection.ts
@@ -6,6 +6,7 @@ export class DuckDBPreparedStatementWeakRefCollection
 {
   preparedStatements: WeakRef<DuckDBPreparedStatement>[] = [];
   public add(prepared: DuckDBPreparedStatement) {
+    this.prune();
     this.preparedStatements.push(new WeakRef(prepared));
   }
   public destroySync() {
@@ -16,5 +17,10 @@ export class DuckDBPreparedStatementWeakRefCollection
       }
     }
     this.preparedStatements = [];
+  }
+  private prune() {
+    this.preparedStatements = this.preparedStatements.filter(
+      (ref) => !!ref.deref()
+    );
   }
 }

--- a/api/src/duckdb.ts
+++ b/api/src/duckdb.ts
@@ -15,6 +15,7 @@ export * from './DuckDBLogicalType';
 export * from './DuckDBMaterializedResult';
 export * from './DuckDBPendingResult';
 export * from './DuckDBPreparedStatement';
+export * from './DuckDBPreparedStatementCollection';
 export * from './DuckDBResult';
 export * from './DuckDBType';
 export * from './DuckDBTypeId';


### PR DESCRIPTION
Hold on to WeakRefs of any prepared statements created on a connection, and destroy them when the connection is closed (if they still exist). This provides a more convenient and robust way to solve #211.