### PR TITLE
upgrade to duckdb 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,8 @@ Change version in:
 ### Upgrade DuckDB Version
 
 Change version in:
-- `bindings/scripts/fetch_libduckdb_linux_aarch64.py`
 - `bindings/scripts/fetch_libduckdb_linux_amd64.py`
+- `bindings/scripts/fetch_libduckdb_linux_arm64.py`
 - `bindings/scripts/fetch_libduckdb_osx_universal.py`
 - `bindings/scripts/fetch_libduckdb_windows_amd64.py`
 - `bindings/test/constants.test.ts`

--- a/api/pkgs/@duckdb/node-api/package.json
+++ b/api/pkgs/@duckdb/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-api",
-  "version": "1.2.2-alpha.19",
+  "version": "1.3.0-alpha.20",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/bindings/binding.gyp
+++ b/bindings/binding.gyp
@@ -11,7 +11,7 @@
         }],
         ['OS=="linux" and target_arch=="arm64"', {
           'variables': {
-            'script_path': '<(module_root_dir)/scripts/fetch_libduckdb_linux_aarch64.py',
+            'script_path': '<(module_root_dir)/scripts/fetch_libduckdb_linux_arm64.py',
           },
         }],
         ['OS=="mac"', {

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-arm64",
-  "version": "1.2.2-alpha.19",
+  "version": "1.3.0-alpha.20",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-x64",
-  "version": "1.2.2-alpha.19",
+  "version": "1.3.0-alpha.20",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-arm64",
-  "version": "1.2.2-alpha.19",
+  "version": "1.3.0-alpha.20",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-x64",
-  "version": "1.2.2-alpha.19",
+  "version": "1.3.0-alpha.20",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-x64",
-  "version": "1.2.2-alpha.19",
+  "version": "1.3.0-alpha.20",
   "license": "MIT",
   "os": [
     "win32"

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings",
-  "version": "1.2.2-alpha.19",
+  "version": "1.3.0-alpha.20",
   "license": "MIT",
   "main": "./duckdb.js",
   "types": "./duckdb.d.ts",

--- a/bindings/scripts/checkFunctionSignatures.mjs
+++ b/bindings/scripts/checkFunctionSignatures.mjs
@@ -4,7 +4,7 @@ import path from 'path';
 function getFunctionSignaturesFromHeader(headerFilePath) {
   const sigs = [];
   const headerContents = fs.readFileSync(headerFilePath, { encoding: 'utf-8' });
-  const sigRegex = /^DUCKDB_API (?<sig>([^;]|[\r\n])*);$|^#ifndef (?<startif>DUCKDB_API_NO_DEPRECATED|DUCKDB_NO_EXTENSION_FUNCTIONS)$|^#endif$/gm;
+  const sigRegex = /^DUCKDB_C_API (?<sig>([^;]|[\r\n])*);$|^#ifndef (?<startif>DUCKDB_API_NO_DEPRECATED|DUCKDB_NO_EXTENSION_FUNCTIONS)$|^#endif$/gm;
   var ifndef = undefined;
   var match;
   while (match = sigRegex.exec(headerContents)) {

--- a/bindings/scripts/fetch_libduckdb_linux_aarch64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_aarch64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.2/libduckdb-linux-aarch64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.0/libduckdb-linux-aarch64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_linux_amd64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_amd64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.2/libduckdb-linux-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.0/libduckdb-linux-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_linux_arm64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_arm64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.0/libduckdb-linux-aarch64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.0/libduckdb-linux-arm64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_osx_universal.py
+++ b/bindings/scripts/fetch_libduckdb_osx_universal.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.2/libduckdb-osx-universal.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.0/libduckdb-osx-universal.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_windows_amd64.py
+++ b/bindings/scripts/fetch_libduckdb_windows_amd64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.2.2/libduckdb-windows-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.0/libduckdb-windows-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/test/appender.test.ts
+++ b/bindings/test/appender.test.ts
@@ -32,7 +32,7 @@ suite('appender', () => {
     await withConnection(async (connection) => {
       expect(() =>
         duckdb.appender_create_ext(connection, 'memory', 'main', 'bogus_table')
-      ).toThrowError(`Table "main.bogus_table" could not be found`);
+      ).toThrowError(`Table "memory.main.bogus_table" could not be found`);
     });
   });
   test('one column', async () => {

--- a/bindings/test/config.test.ts
+++ b/bindings/test/config.test.ts
@@ -5,11 +5,11 @@ import { data } from './utils/expectedVectors';
 
 suite('config', () => {
   test('config_count', () => {
-    expect(duckdb.config_count()).toBe(174);
+    expect(duckdb.config_count()).toBe(180);
   });
   test('get_config_flag', () => {
     expect(duckdb.get_config_flag(0).name).toBe('access_mode');
-    expect(duckdb.get_config_flag(173).name).toBe('unsafe_enable_version_guessing');
+    expect(duckdb.get_config_flag(duckdb.config_count() - 1).name).toBe('unsafe_enable_version_guessing');
   });
   test('get_config_flag out of bounds', () => {
     expect(() => duckdb.get_config_flag(-1)).toThrowError(/^Config option not found$/);

--- a/bindings/test/constants.test.ts
+++ b/bindings/test/constants.test.ts
@@ -6,7 +6,7 @@ suite('constants', () => {
     expect(duckdb.sizeof_bool).toBe(1);
   });
   test('library_version', () => {
-    expect(duckdb.library_version()).toBe('v1.2.2');
+    expect(duckdb.library_version()).toBe('v1.3.0');
   });
   test('vector_size', () => {
     expect(duckdb.vector_size()).toBe(2048);


### PR DESCRIPTION
- New version is 1.3.0-alpha.20
- A couple minor test updates needed.
- C function prefix changed from DUCKDB_API to DUCKDB_C_API, necessitating minor changes to checkFunctionSignatures script.
- Linux aarch64 was renamed to Linux arm64, necessitating some build script changes.