### PR TITLE
fix run with params

### DIFF
--- a/api/src/DuckDBConnection.ts
+++ b/api/src/DuckDBConnection.ts
@@ -28,11 +28,11 @@ export class DuckDBConnection {
   }
   /** Same as disconnectSync. */
   public closeSync() {
-    return this.disconnectSync();
+    this.disconnectSync();
   }
   public disconnectSync() {
     this.preparedStatements.destroySync();
-    return duckdb.disconnect_sync(this.connection);
+    duckdb.disconnect_sync(this.connection);
   }
   public interrupt() {
     duckdb.interrupt(this.connection);
@@ -49,7 +49,8 @@ export class DuckDBConnection {
       const prepared = await this.createPrepared(sql);
       try {
         prepared.bind(values, types);
-        return prepared.run();
+        const result = await prepared.run();
+        return result;
       } finally {
         prepared.destroySync();
       }
@@ -95,7 +96,8 @@ export class DuckDBConnection {
       if (values) {
         prepared.bind(values, types);
       }
-      return prepared.stream();
+      const result = await prepared.stream();
+      return result;
     } finally {
       prepared.destroySync();
     }

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -785,6 +785,13 @@ describe('api', () => {
       );
     });
   });
+  test('runAndReadAll with params', async () => {
+    await withConnection(async (connection) => {
+      const reader = await connection.runAndReadAll('select ? as n', [17]);
+      const rows = reader.getRowObjects();
+      assert.deepEqual(rows, [{ n: 17 }]);
+    });
+  });
   test('should support all data types', async () => {
     await withConnection(async (connection) => {
       const result = await connection.run(


### PR DESCRIPTION
Fix https://github.com/duckdb/duckdb-node-neo/issues/223, and probably https://github.com/duckdb/duckdb-node-neo/issues/220 as well.

The problem was `connection.run` (and `connection.stream`), when given params, would return the promise for `prepared.run()` without awaiting, and then destroy the prepared statement when returning. The run occurs on a different thread, so it often would not complete before the destroy.

The fix is simply to await the run, so that it completes before we destroy the prepared statement. (The result's lifetime is separate from the prepared statement, so it's okay to return that and destroy the statement.)

Added a simple test which reproduces the issue before the fix, and passes with the fix.