### PR TITLE
upgrade to duckdb 1.3.2

### DIFF
--- a/api/pkgs/@duckdb/node-api/package.json
+++ b/api/pkgs/@duckdb/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-api",
-  "version": "1.3.1-alpha.23",
+  "version": "1.3.2-alpha.24",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-arm64",
-  "version": "1.3.1-alpha.23",
+  "version": "1.3.2-alpha.24",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-x64",
-  "version": "1.3.1-alpha.23",
+  "version": "1.3.2-alpha.24",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-arm64",
-  "version": "1.3.1-alpha.23",
+  "version": "1.3.2-alpha.24",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-x64",
-  "version": "1.3.1-alpha.23",
+  "version": "1.3.2-alpha.24",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-x64",
-  "version": "1.3.1-alpha.23",
+  "version": "1.3.2-alpha.24",
   "license": "MIT",
   "os": [
     "win32"

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings",
-  "version": "1.3.1-alpha.23",
+  "version": "1.3.2-alpha.24",
   "license": "MIT",
   "main": "./duckdb.js",
   "types": "./duckdb.d.ts",

--- a/bindings/scripts/fetch_libduckdb_linux_amd64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_amd64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.1/libduckdb-linux-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.2/libduckdb-linux-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_linux_arm64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_arm64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.1/libduckdb-linux-arm64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.2/libduckdb-linux-arm64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_osx_universal.py
+++ b/bindings/scripts/fetch_libduckdb_osx_universal.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.1/libduckdb-osx-universal.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.2/libduckdb-osx-universal.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_windows_amd64.py
+++ b/bindings/scripts/fetch_libduckdb_windows_amd64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.1/libduckdb-windows-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.3.2/libduckdb-windows-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/test/config.test.ts
+++ b/bindings/test/config.test.ts
@@ -5,7 +5,7 @@ import { data } from './utils/expectedVectors';
 
 suite('config', () => {
   test('config_count', () => {
-    expect(duckdb.config_count()).toBe(181);
+    expect(duckdb.config_count()).toBe(184);
   });
   test('get_config_flag', () => {
     expect(duckdb.get_config_flag(0).name).toBe('access_mode');

--- a/bindings/test/constants.test.ts
+++ b/bindings/test/constants.test.ts
@@ -6,7 +6,7 @@ suite('constants', () => {
     expect(duckdb.sizeof_bool).toBe(1);
   });
   test('library_version', () => {
-    expect(duckdb.library_version()).toBe('v1.3.1');
+    expect(duckdb.library_version()).toBe('v1.3.2');
   });
   test('vector_size', () => {
     expect(duckdb.vector_size()).toBe(2048);


### PR DESCRIPTION
Just the DuckDB patch version bump; no other changes.