### PR TITLE
core bindings for scalar functions

### DIFF
--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -1025,7 +1025,7 @@ export function validity_set_row_valid(validity: Uint8Array, row_index: number):
 export function create_scalar_function(): ScalarFunction;
 
 // DUCKDB_C_API void duckdb_destroy_scalar_function(duckdb_scalar_function *scalar_function);
-// not exposed: destroyed in finalizer
+export function destroy_scalar_function_sync(scalar_function: ScalarFunction): void;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_name(duckdb_scalar_function scalar_function, const char *name);
 export function scalar_function_set_name(scalar_function: ScalarFunction, name: string): void;

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -170,6 +170,10 @@ export interface TimestampParts {
   time: TimeParts;
 }
 
+export interface FunctionInfo {
+  __duckdb_type: 'duckdb_function_info';
+}
+
 export interface Vector {
   __duckdb_type: 'duckdb_vector';
 }
@@ -228,6 +232,10 @@ export interface Result {
   __duckdb_type: 'duckdb_result';
 }
 
+export interface ScalarFunction {
+  __duckdb_type: 'duckdb_scalar_function';
+}
+
 // export interface SelectionVector {
 //   __duckdb_type: 'duckdb_selection_vector';
 // }
@@ -248,6 +256,7 @@ export interface ExtractedStatementsAndCount {
   statement_count: number;
 }
 
+export type ScalarFunctionMainFunction = (info: FunctionInfo, input: DataChunk, output: Vector) => void;
 
 // Functions
 
@@ -1013,23 +1022,39 @@ export function validity_set_row_invalid(validity: Uint8Array, row_index: number
 export function validity_set_row_valid(validity: Uint8Array, row_index: number): void;
 
 // DUCKDB_C_API duckdb_scalar_function duckdb_create_scalar_function();
+export function create_scalar_function(): ScalarFunction;
+
 // DUCKDB_C_API void duckdb_destroy_scalar_function(duckdb_scalar_function *scalar_function);
+// not exposed: destroyed in finalizer
+
 // DUCKDB_C_API void duckdb_scalar_function_set_name(duckdb_scalar_function scalar_function, const char *name);
+export function scalar_function_set_name(scalar_function: ScalarFunction, name: string): void;
+
 // DUCKDB_C_API void duckdb_scalar_function_set_varargs(duckdb_scalar_function scalar_function, duckdb_logical_type type);
 // DUCKDB_C_API void duckdb_scalar_function_set_special_handling(duckdb_scalar_function scalar_function);
 // DUCKDB_C_API void duckdb_scalar_function_set_volatile(duckdb_scalar_function scalar_function);
 // DUCKDB_C_API void duckdb_scalar_function_add_parameter(duckdb_scalar_function scalar_function, duckdb_logical_type type);
+
 // DUCKDB_C_API void duckdb_scalar_function_set_return_type(duckdb_scalar_function scalar_function, duckdb_logical_type type);
+export function scalar_function_set_return_type(scalar_function: ScalarFunction, logical_type: LogicalType): void;
+
 // DUCKDB_C_API void duckdb_scalar_function_set_extra_info(duckdb_scalar_function scalar_function, void *extra_info, duckdb_delete_callback_t destroy);
 // DUCKDB_C_API void duckdb_scalar_function_set_bind(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind);
 // DUCKDB_C_API void duckdb_scalar_function_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
 // DUCKDB_C_API void duckdb_scalar_function_bind_set_error(duckdb_bind_info info, const char *error);
+
 // DUCKDB_C_API void duckdb_scalar_function_set_function(duckdb_scalar_function scalar_function, duckdb_scalar_function_t function);
+export function scalar_function_set_function(scalar_function: ScalarFunction, func: ScalarFunctionMainFunction): void;
+
 // DUCKDB_C_API duckdb_state duckdb_register_scalar_function(duckdb_connection con, duckdb_scalar_function scalar_function);
+export function register_scalar_function(connection: Connection, scalar_function: ScalarFunction): void;
+
 // DUCKDB_C_API void *duckdb_scalar_function_get_extra_info(duckdb_function_info info);
 // DUCKDB_C_API void *duckdb_scalar_function_get_bind_data(duckdb_function_info info);
 // DUCKDB_C_API void duckdb_scalar_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);
+
 // DUCKDB_C_API void duckdb_scalar_function_set_error(duckdb_function_info info, const char *error);
+export function scalar_function_set_error(function_info: FunctionInfo, error: string): void;
 
 // DUCKDB_C_API duckdb_scalar_function_set duckdb_create_scalar_function_set(const char *name);
 // DUCKDB_C_API void duckdb_destroy_scalar_function_set(duckdb_scalar_function_set *scalar_function_set);

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -493,7 +493,7 @@ static const napi_type_tag FunctionInfoTypeTag = {
   0xB0E6739D698048EA, 0x9E79734E3E137AC3
 };
 
-Napi::External<_duckdb_function_info> CreateExternalForFunctionInfo(Napi::Env env, duckdb_function_info function_info) {
+Napi::External<_duckdb_function_info> CreateExternalForFunctionInfoWithoutFinalizer(Napi::Env env, duckdb_function_info function_info) {
   // FunctionInfo objects are never explicitly created; they are passed in to function callbacks.
   return CreateExternalWithoutFinalizer<_duckdb_function_info>(env, FunctionInfoTypeTag, function_info);
 }
@@ -650,7 +650,7 @@ static const napi_type_tag VectorTypeTag = {
   0x9FE56DE8E3124D07, 0x9ABF31145EDE1C9E
 };
 
-Napi::External<_duckdb_vector> CreateExternalForVector(Napi::Env env, duckdb_vector vector) {
+Napi::External<_duckdb_vector> CreateExternalForVectorWithoutFinalizer(Napi::Env env, duckdb_vector vector) {
   // Vectors live as long as their containing data chunk; they cannot be explicitly destroyed.
   return CreateExternalWithoutFinalizer<_duckdb_vector>(env, VectorTypeTag, vector);
 }
@@ -676,9 +676,9 @@ void ScalarFunctionMainCallback(Napi::Env env, Napi::Function callback, ScalarFu
       callback.Call(
         env.Undefined(),
         {
-          CreateExternalForFunctionInfo(env, data->info),
+          CreateExternalForFunctionInfoWithoutFinalizer(env, data->info),
           CreateExternalForDataChunkWithoutFinalizer(env, data->input),
-          CreateExternalForVector(env, data->output)
+          CreateExternalForVectorWithoutFinalizer(env, data->output)
         }
       );
     }
@@ -3794,7 +3794,7 @@ private:
     auto chunk = GetDataChunkFromExternal(env, info[0]);
     auto column_index = info[1].As<Napi::Number>().Uint32Value();
     auto vector = duckdb_data_chunk_get_vector(chunk, column_index);
-    return CreateExternalForVector(env, vector);
+    return CreateExternalForVectorWithoutFinalizer(env, vector);
   }
 
   // DUCKDB_C_API idx_t duckdb_data_chunk_get_size(duckdb_data_chunk chunk);
@@ -3893,7 +3893,7 @@ private:
     auto env = info.Env();
     auto vector = GetVectorFromExternal(env, info[0]);
     auto child = duckdb_list_vector_get_child(vector);
-    return CreateExternalForVector(env, child);
+    return CreateExternalForVectorWithoutFinalizer(env, child);
   }
 
   // DUCKDB_C_API idx_t duckdb_list_vector_get_size(duckdb_vector vector);
@@ -3932,7 +3932,7 @@ private:
     auto vector = GetVectorFromExternal(env, info[0]);
     auto index = info[1].As<Napi::Number>().Uint32Value();
     auto child = duckdb_struct_vector_get_child(vector, index);
-    return CreateExternalForVector(env, child);
+    return CreateExternalForVectorWithoutFinalizer(env, child);
   }
 
   // DUCKDB_C_API duckdb_vector duckdb_array_vector_get_child(duckdb_vector vector);
@@ -3941,7 +3941,7 @@ private:
     auto env = info.Env();
     auto vector = GetVectorFromExternal(env, info[0]);
     auto child = duckdb_array_vector_get_child(vector);
-    return CreateExternalForVector(env, child);
+    return CreateExternalForVectorWithoutFinalizer(env, child);
   }
 
   // DUCKDB_C_API void duckdb_slice_vector(duckdb_vector vector, duckdb_selection_vector selection, idx_t len);

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -3,6 +3,10 @@
 #define NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
 #include "napi.h"
 
+#include <cstddef>
+#include <condition_variable>
+#include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -4691,7 +4691,7 @@ NODE_API_ADDON(DuckDBNodeAddon)
   ---
   431 total functions
 
-  253 instance methods
+  252 instance methods
     3 unimplemented client context functions
     1 unimplemented table names function
     1 unimplemented value to string function

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -3,8 +3,8 @@
 #define NODE_API_NO_EXTERNAL_BUFFERS_ALLOWED
 #include "napi.h"
 
-#include <cstddef>
 #include <condition_variable>
+#include <cstddef>
 #include <memory>
 #include <mutex>
 #include <optional>

--- a/bindings/test/scalar_functions.test.ts
+++ b/bindings/test/scalar_functions.test.ts
@@ -1,0 +1,48 @@
+import duckdb from '@duckdb/node-bindings';
+import { expect, suite, test } from 'vitest';
+import { data } from './utils/expectedVectors';
+import { expectResult } from './utils/expectResult';
+import { withConnection } from './utils/withConnection';
+
+suite('scalar functions', () => {
+  test('create', () => {
+    const scalar_function = duckdb.create_scalar_function();
+    expect(scalar_function).toBeTruthy();
+  });
+  test('set name', () => {
+    const scalar_function = duckdb.create_scalar_function();
+    duckdb.scalar_function_set_name(scalar_function, 'my_func');
+  });
+  test('set return type', () => {
+    const scalar_function = duckdb.create_scalar_function();
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    duckdb.scalar_function_set_return_type(scalar_function, int_type);
+  });
+  test('register & run', async () => {
+    await withConnection(async (connection) => {
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_func');
+      const int_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_return_type(scalar_function, int_type);
+      duckdb.scalar_function_set_function(scalar_function, (_info, input, output) => {
+        const inputSize = duckdb.data_chunk_get_size(input);
+        for (let i = 0; i < inputSize; i++) {
+          duckdb.vector_assign_string_element(output, i, `output_${i}`);
+        }
+      });
+      duckdb.register_scalar_function(connection, scalar_function);
+
+      const result = await duckdb.query(connection, "select my_func()");
+      await expectResult(result, {
+        chunkCount: 1,
+        rowCount: 1,
+        columns: [
+          { name: 'my_func()', logicalType: { typeId: duckdb.Type.VARCHAR } }
+        ],
+        chunks: [
+          { rowCount: 1, vectors: [data(16, [true], ['output_0'])]}
+        ],
+      });
+    });
+  });
+});

--- a/bindings/test/scalar_functions.test.ts
+++ b/bindings/test/scalar_functions.test.ts
@@ -43,6 +43,7 @@ suite('scalar functions', () => {
           { rowCount: 1, vectors: [data(16, [true], ['output_0'])]}
         ],
       });
+      duckdb.destroy_scalar_function_sync(scalar_function);
     });
   });
 });


### PR DESCRIPTION
Add bindings for the minimal subset of C API functions for using scalar functions.