### PR TITLE
throttle prepared pruning

### DIFF
--- a/api/src/DuckDBPreparedStatementWeakRefCollection.ts
+++ b/api/src/DuckDBPreparedStatementWeakRefCollection.ts
@@ -5,8 +5,13 @@ export class DuckDBPreparedStatementWeakRefCollection
   implements DuckDBPreparedStatementCollection
 {
   preparedStatements: WeakRef<DuckDBPreparedStatement>[] = [];
+  lastPruneTime: number = 0;
   public add(prepared: DuckDBPreparedStatement) {
-    this.prune();
+    const now = performance.now();
+    if (now - this.lastPruneTime > 1000) {
+      this.lastPruneTime = now;
+      this.prune();
+    }
     this.preparedStatements.push(new WeakRef(prepared));
   }
   public destroySync() {

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -2153,7 +2153,7 @@ ORDER BY name
     });
   });
 
-    test('should not segfault with concurrent prepared statement creation and execution', async () => {
+  test('should not segfault with concurrent prepared statement creation and execution', async () => {
     await withConnection(async (connection) => {
       // Create test table with some data
       await connection.run(`


### PR DESCRIPTION
Since the list of prepare statements weakrefs can get long when a process is create prepared statements at a high rate, only attempt to prune the list at most once a second. This should reduce the number of times we attempt to prune and fail to find any collected weakrefs.