### PR TITLE
scalar function exception handling

### DIFF
--- a/bindings/binding.gyp
+++ b/bindings/binding.gyp
@@ -39,7 +39,7 @@
       'target_name': 'duckdb',
       'dependencies': [
         'fetch_libduckdb',
-        '<!(node -p "require(\'node-addon-api\').targets"):node_addon_api_except',
+        '<!(node -p "require(\'node-addon-api\').targets"):node_addon_api_except_all',
       ],
       'sources': ['src/duckdb_node_bindings.cpp'],
       'include_dirs': ['<(module_root_dir)/libduckdb'],

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -692,14 +692,18 @@ struct ScalarFunctionMainData {
 void ScalarFunctionMainCallback(Napi::Env env, Napi::Function callback, ScalarFunctionMainContext *context, ScalarFunctionMainData *data) {
   if (env != nullptr) {
     if (callback != nullptr) {
-      callback.Call(
-        env.Undefined(),
-        {
-          CreateExternalForFunctionInfoWithoutFinalizer(env, data->info),
-          CreateExternalForDataChunkWithoutFinalizer(env, data->input),
-          CreateExternalForVectorWithoutFinalizer(env, data->output)
-        }
-      );
+      try {
+        callback.Call(
+          env.Undefined(),
+          {
+            CreateExternalForFunctionInfoWithoutFinalizer(env, data->info),
+            CreateExternalForDataChunkWithoutFinalizer(env, data->input),
+            CreateExternalForVectorWithoutFinalizer(env, data->output)
+          }
+        );
+      } catch (const Napi::Error &err) {
+        duckdb_scalar_function_set_error(data->info, err.Message().c_str());
+      }
     }
   }
   {


### PR DESCRIPTION
When running a scalar function, wrap the call to the JS function in an exception handler, and transform any error into an error in the scalar function.

The change to use `node_addon_api_except_all` instead of `node_addon_api_except` isn't strictly needed, but seems like a good idea in general to avoid crashing. (It should cause C++ exceptions to be converted to JS exceptions in more cases.)