### PR TITLE
scalar func args

### DIFF
--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -1031,9 +1031,16 @@ export function destroy_scalar_function_sync(scalar_function: ScalarFunction): v
 export function scalar_function_set_name(scalar_function: ScalarFunction, name: string): void;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_varargs(duckdb_scalar_function scalar_function, duckdb_logical_type type);
+export function scalar_function_set_varargs(scalar_function: ScalarFunction, logical_type: LogicalType): void;
+
 // DUCKDB_C_API void duckdb_scalar_function_set_special_handling(duckdb_scalar_function scalar_function);
+export function scalar_function_set_special_handling(scalar_function: ScalarFunction): void;
+
 // DUCKDB_C_API void duckdb_scalar_function_set_volatile(duckdb_scalar_function scalar_function);
+export function scalar_function_set_volatile(scalar_function: ScalarFunction): void;
+
 // DUCKDB_C_API void duckdb_scalar_function_add_parameter(duckdb_scalar_function scalar_function, duckdb_logical_type type);
+export function scalar_function_add_parameter(scalar_function: ScalarFunction, logical_type: LogicalType): void;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_return_type(duckdb_scalar_function scalar_function, duckdb_logical_type type);
 export function scalar_function_set_return_type(scalar_function: ScalarFunction, logical_type: LogicalType): void;

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -1563,6 +1563,10 @@ public:
       InstanceMethod("create_scalar_function", &DuckDBNodeAddon::create_scalar_function),
       InstanceMethod("destroy_scalar_function_sync", &DuckDBNodeAddon::destroy_scalar_function_sync),
       InstanceMethod("scalar_function_set_name", &DuckDBNodeAddon::scalar_function_set_name),
+      InstanceMethod("scalar_function_set_varargs", &DuckDBNodeAddon::scalar_function_set_varargs),
+      InstanceMethod("scalar_function_set_special_handling", &DuckDBNodeAddon::scalar_function_set_special_handling),
+      InstanceMethod("scalar_function_set_volatile", &DuckDBNodeAddon::scalar_function_set_volatile),
+      InstanceMethod("scalar_function_add_parameter", &DuckDBNodeAddon::scalar_function_add_parameter),
       InstanceMethod("scalar_function_set_return_type", &DuckDBNodeAddon::scalar_function_set_return_type),
       InstanceMethod("scalar_function_set_function", &DuckDBNodeAddon::scalar_function_set_function),
       InstanceMethod("register_scalar_function", &DuckDBNodeAddon::register_scalar_function),
@@ -4054,9 +4058,42 @@ private:
   }
 
   // DUCKDB_C_API void duckdb_scalar_function_set_varargs(duckdb_scalar_function scalar_function, duckdb_logical_type type);
+  // function scalar_function_set_varargs(scalar_function: ScalarFunction, logical_type: LogicalType): void
+  Napi::Value scalar_function_set_varargs(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto scalar_function = GetScalarFunctionFromExternal(env, info[0]);
+    auto logical_type = GetLogicalTypeFromExternal(env, info[1]);
+    duckdb_scalar_function_set_varargs(scalar_function, logical_type);
+    return env.Undefined();
+  }
+
   // DUCKDB_C_API void duckdb_scalar_function_set_special_handling(duckdb_scalar_function scalar_function);
+  // function scalar_function_set_special_handling(scalar_function: ScalarFunction): void
+  Napi::Value scalar_function_set_special_handling(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto scalar_function = GetScalarFunctionFromExternal(env, info[0]);
+    duckdb_scalar_function_set_special_handling(scalar_function);
+    return env.Undefined();
+  }
+
   // DUCKDB_C_API void duckdb_scalar_function_set_volatile(duckdb_scalar_function scalar_function);
+  // function scalar_function_set_volatile(scalar_function: ScalarFunction): void
+  Napi::Value scalar_function_set_volatile(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto scalar_function = GetScalarFunctionFromExternal(env, info[0]);
+    duckdb_scalar_function_set_volatile(scalar_function);
+    return env.Undefined();
+  }
+
   // DUCKDB_C_API void duckdb_scalar_function_add_parameter(duckdb_scalar_function scalar_function, duckdb_logical_type type);
+  // function scalar_function_add_parameter(scalar_function: ScalarFunction, logical_type: LogicalType): void
+  Napi::Value scalar_function_add_parameter(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto scalar_function = GetScalarFunctionFromExternal(env, info[0]);
+    auto logical_type = GetLogicalTypeFromExternal(env, info[1]);
+    duckdb_scalar_function_add_parameter(scalar_function, logical_type);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_scalar_function_set_return_type(duckdb_scalar_function scalar_function, duckdb_logical_type type);
   // function scalar_function_set_return_type(scalar_function: ScalarFunction, logical_type: LogicalType): void
@@ -4719,14 +4756,14 @@ NODE_API_ADDON(DuckDBNodeAddon)
   ---
   431 total functions
 
-  253 instance methods
+  257 instance methods
     3 unimplemented client context functions
     1 unimplemented table names function
     1 unimplemented value to string function
     1 unimplemented logical type function
     2 unimplemented vector creation functions
     3 unimplemented vector manipulation functions
-   10 unimplemented scalar function functions
+    5 unimplemented scalar function functions
     4 unimplemented scalar function set functions
     3 unimplemented selection vector functions
    12 unimplemented aggregate function functions

--- a/bindings/test/scalar_functions.test.ts
+++ b/bindings/test/scalar_functions.test.ts
@@ -22,27 +22,28 @@ suite('scalar functions', () => {
     await withConnection(async (connection) => {
       const scalar_function = duckdb.create_scalar_function();
       duckdb.scalar_function_set_name(scalar_function, 'my_func');
-      const int_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
-      duckdb.scalar_function_set_return_type(scalar_function, int_type);
-      duckdb.scalar_function_set_function(scalar_function, (_info, input, output) => {
-        const inputSize = duckdb.data_chunk_get_size(input);
-        for (let i = 0; i < inputSize; i++) {
-          duckdb.vector_assign_string_element(output, i, `output_${i}`);
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (_info, input, output) => {
+          const rowCount = duckdb.data_chunk_get_size(input);
+          for (let i = 0; i < rowCount; i++) {
+            duckdb.vector_assign_string_element(output, i, `output_${i}`);
+          }
         }
-      });
+      );
       duckdb.register_scalar_function(connection, scalar_function);
       duckdb.destroy_scalar_function_sync(scalar_function);
 
-      const result = await duckdb.query(connection, "select my_func()");
+      const result = await duckdb.query(connection, 'select my_func()');
       await expectResult(result, {
         chunkCount: 1,
         rowCount: 1,
         columns: [
-          { name: 'my_func()', logicalType: { typeId: duckdb.Type.VARCHAR } }
+          { name: 'my_func()', logicalType: { typeId: duckdb.Type.VARCHAR } },
         ],
-        chunks: [
-          { rowCount: 1, vectors: [data(16, [true], ['output_0'])]}
-        ],
+        chunks: [{ rowCount: 1, vectors: [data(16, [true], ['output_0'])] }],
       });
     });
   });
@@ -50,27 +51,44 @@ suite('scalar functions', () => {
     await withConnection(async (connection) => {
       const scalar_function = duckdb.create_scalar_function();
       duckdb.scalar_function_set_name(scalar_function, 'my_func');
-      const int_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
-      duckdb.scalar_function_set_return_type(scalar_function, int_type);
-      duckdb.scalar_function_set_function(scalar_function, (info, input, output) => {
-        const extra_info = duckdb.scalar_function_get_extra_info(info);
-        const inputSize = duckdb.data_chunk_get_size(input);
-        for (let i = 0; i < inputSize; i++) {
-          duckdb.vector_assign_string_element(output, i, `output_${i}_${JSON.stringify(extra_info)}`);
-        }
-      }, { 'my_extra_info_key': 'my_extra_info_value' });
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (info, input, output) => {
+          const extra_info = duckdb.scalar_function_get_extra_info(info);
+          const rowCount = duckdb.data_chunk_get_size(input);
+          for (let i = 0; i < rowCount; i++) {
+            duckdb.vector_assign_string_element(
+              output,
+              i,
+              `output_${i}_${JSON.stringify(extra_info)}`
+            );
+          }
+        },
+        { 'my_extra_info_key': 'my_extra_info_value' }
+      );
       duckdb.register_scalar_function(connection, scalar_function);
       duckdb.destroy_scalar_function_sync(scalar_function);
 
-      const result = await duckdb.query(connection, "select my_func()");
+      const result = await duckdb.query(connection, 'select my_func()');
       await expectResult(result, {
         chunkCount: 1,
         rowCount: 1,
         columns: [
-          { name: 'my_func()', logicalType: { typeId: duckdb.Type.VARCHAR } }
+          { name: 'my_func()', logicalType: { typeId: duckdb.Type.VARCHAR } },
         ],
         chunks: [
-          { rowCount: 1, vectors: [data(16, [true], ['output_0_{"my_extra_info_key":"my_extra_info_value"}'])]}
+          {
+            rowCount: 1,
+            vectors: [
+              data(
+                16,
+                [true],
+                ['output_0_{"my_extra_info_key":"my_extra_info_value"}']
+              ),
+            ],
+          },
         ],
       });
     });
@@ -79,15 +97,187 @@ suite('scalar functions', () => {
     await withConnection(async (connection) => {
       const scalar_function = duckdb.create_scalar_function();
       duckdb.scalar_function_set_name(scalar_function, 'my_func');
-      const int_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
-      duckdb.scalar_function_set_return_type(scalar_function, int_type);
-      duckdb.scalar_function_set_function(scalar_function, (_info, _input, _output) => {
-        throw new Error('my_error');
-      });
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (_info, _input, _output) => {
+          throw new Error('my_error');
+        }
+      );
       duckdb.register_scalar_function(connection, scalar_function);
       duckdb.destroy_scalar_function_sync(scalar_function);
 
-      await expect(duckdb.query(connection, "select my_func()")).rejects.toThrow('Invalid Input Error: my_error');;
+      await expect(
+        duckdb.query(connection, 'select my_func()')
+      ).rejects.toThrow('Invalid Input Error: my_error');
+    });
+  });
+  test('parameters (fixed, volatile)', async () => {
+    await withConnection(async (connection) => {
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_func');
+      const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_add_parameter(scalar_function, int_type);
+      duckdb.scalar_function_add_parameter(scalar_function, varchar_type);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_volatile(scalar_function);
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (_info, input, output) => {
+          const rowCount = duckdb.data_chunk_get_size(input);
+          const vec0 = duckdb.data_chunk_get_vector(input, 0);
+          const data0 = duckdb.vector_get_data(vec0, rowCount * 4);
+          const dv0 = new DataView(data0.buffer);
+          const vec1 = duckdb.data_chunk_get_vector(input, 1);
+          const data1 = duckdb.vector_get_data(vec1, rowCount * 16);
+          const dv1 = new DataView(data1.buffer);
+          for (let i = 0; i < rowCount; i++) {
+            duckdb.vector_assign_string_element(
+              output,
+              i,
+              `output_${i}_${dv0.getInt32(i * 4, true)}_${dv1.getUint32(
+                i * 16,
+                true
+              )}`
+            );
+          }
+        }
+      );
+      duckdb.register_scalar_function(connection, scalar_function);
+      duckdb.destroy_scalar_function_sync(scalar_function);
+
+      const result = await duckdb.query(
+        connection,
+        "select my_func(42, 'duck') as my_func_result from range(3)"
+      );
+      await expectResult(result, {
+        chunkCount: 1,
+        rowCount: 3,
+        columns: [
+          {
+            name: 'my_func_result',
+            logicalType: { typeId: duckdb.Type.VARCHAR },
+          },
+        ],
+        chunks: [
+          {
+            rowCount: 3,
+            vectors: [
+              data(
+                16,
+                [true, true, true],
+                ['output_0_42_4', 'output_1_42_4', 'output_2_42_4']
+              ),
+            ],
+          },
+        ],
+      });
+    });
+  });
+  test('parameters (varargs, volatile)', async () => {
+    await withConnection(async (connection) => {
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_func');
+      const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_varargs(scalar_function, int_type);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_volatile(scalar_function);
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (_info, input, output) => {
+          const rowCount = duckdb.data_chunk_get_size(input);
+          const paramCount = duckdb.data_chunk_get_column_count(input);
+
+          for (let r = 0; r < rowCount; r++) {
+            const params: number[] = [];
+            for (let p = 0; p < paramCount; p++) {
+              const vec = duckdb.data_chunk_get_vector(input, p);
+              const data = duckdb.vector_get_data(vec, rowCount * 4);
+              const dv = new DataView(data.buffer);
+              params.push(dv.getInt32(r * 4, true));
+            }
+            duckdb.vector_assign_string_element(
+              output,
+              r,
+              `output_${r}_${params.join('_')}`
+            );
+          }
+        }
+      );
+      duckdb.register_scalar_function(connection, scalar_function);
+      duckdb.destroy_scalar_function_sync(scalar_function);
+
+      const result = await duckdb.query(
+        connection,
+        'select my_func(11, 13, 17) as my_func_result from range(3)'
+      );
+      await expectResult(result, {
+        chunkCount: 1,
+        rowCount: 3,
+        columns: [
+          {
+            name: 'my_func_result',
+            logicalType: { typeId: duckdb.Type.VARCHAR },
+          },
+        ],
+        chunks: [
+          {
+            rowCount: 3,
+            vectors: [
+              data(
+                16,
+                [true, true, true],
+                ['output_0_11_13_17', 'output_1_11_13_17', 'output_2_11_13_17']
+              ),
+            ],
+          },
+        ],
+      });
+    });
+  });
+  test('special handling', async () => {
+    await withConnection(async (connection) => {
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_func');
+      const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+      duckdb.scalar_function_add_parameter(scalar_function, int_type);
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_special_handling(scalar_function);
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (_info, input, output) => {
+          const rowCount = duckdb.data_chunk_get_size(input);
+          for (let i = 0; i < rowCount; i++) {
+            duckdb.vector_assign_string_element(
+              output,
+              i,
+              `output_is_not_null`
+            );
+          }
+        }
+      );
+      duckdb.register_scalar_function(connection, scalar_function);
+      duckdb.destroy_scalar_function_sync(scalar_function);
+
+      const result = await duckdb.query(connection, 'select my_func(NULL)');
+      await expectResult(result, {
+        chunkCount: 1,
+        rowCount: 1,
+        columns: [
+          {
+            name: 'my_func(NULL)',
+            logicalType: { typeId: duckdb.Type.VARCHAR },
+          },
+        ],
+        // Without special handling, this would be NULL
+        chunks: [
+          { rowCount: 1, vectors: [data(16, [true], ['output_is_not_null'])] },
+        ],
+      });
     });
   });
 });


### PR DESCRIPTION
Add support for scalar function parameters & varargs, as well as setting "volatile" and "special handling". Add tests.

Fix accounting comment; I missed updating it for a function I added earlier (`scalar_function_get_extra_info`).