### PR TITLE
scalar function refactors

### DIFF
--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -1046,14 +1046,14 @@ export function scalar_function_add_parameter(scalar_function: ScalarFunction, l
 export function scalar_function_set_return_type(scalar_function: ScalarFunction, logical_type: LogicalType): void;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_extra_info(duckdb_scalar_function scalar_function, void *extra_info, duckdb_delete_callback_t destroy);
-// not exposed: combined with scalar_function_set_function
+export function scalar_function_set_extra_info(scalar_function: ScalarFunction, extra_info: object): void;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_bind(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind);
 // DUCKDB_C_API void duckdb_scalar_function_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
 // DUCKDB_C_API void duckdb_scalar_function_bind_set_error(duckdb_bind_info info, const char *error);
 
 // DUCKDB_C_API void duckdb_scalar_function_set_function(duckdb_scalar_function scalar_function, duckdb_scalar_function_t function);
-export function scalar_function_set_function(scalar_function: ScalarFunction, func: ScalarFunctionMainFunction, extra_info?: object): void;
+export function scalar_function_set_function(scalar_function: ScalarFunction, func: ScalarFunctionMainFunction): void;
 
 // DUCKDB_C_API duckdb_state duckdb_register_scalar_function(duckdb_connection con, duckdb_scalar_function scalar_function);
 export function register_scalar_function(connection: Connection, scalar_function: ScalarFunction): void;

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -1592,6 +1592,7 @@ public:
       InstanceMethod("scalar_function_set_volatile", &DuckDBNodeAddon::scalar_function_set_volatile),
       InstanceMethod("scalar_function_add_parameter", &DuckDBNodeAddon::scalar_function_add_parameter),
       InstanceMethod("scalar_function_set_return_type", &DuckDBNodeAddon::scalar_function_set_return_type),
+      InstanceMethod("scalar_function_set_extra_info", &DuckDBNodeAddon::scalar_function_set_extra_info),
       InstanceMethod("scalar_function_set_function", &DuckDBNodeAddon::scalar_function_set_function),
       InstanceMethod("register_scalar_function", &DuckDBNodeAddon::register_scalar_function),
       InstanceMethod("scalar_function_get_extra_info", &DuckDBNodeAddon::scalar_function_get_extra_info),
@@ -4130,22 +4131,28 @@ private:
   }
 
   // DUCKDB_C_API void duckdb_scalar_function_set_extra_info(duckdb_scalar_function scalar_function, void *extra_info, duckdb_delete_callback_t destroy);
-  // not exposed: combined with scalar_function_set_function
+  // function scalar_function_set_extra_info(scalar_function: ScalarFunction, extra_info: object): void
+  Napi::Value scalar_function_set_extra_info(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto holder = GetScalarFunctionHolderFromExternal(env, info[0]);
+    auto user_extra_info = info[1].As<Napi::Object>();
+    holder->EnsureInternalExtraInfo();
+    holder->internal_extra_info->SetUserExtraInfo(user_extra_info);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_scalar_function_set_bind(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind);
   // DUCKDB_C_API void duckdb_scalar_function_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
   // DUCKDB_C_API void duckdb_scalar_function_bind_set_error(duckdb_bind_info info, const char *error);
 
   // DUCKDB_C_API void duckdb_scalar_function_set_function(duckdb_scalar_function scalar_function, duckdb_scalar_function_t function);
-  // function scalar_function_set_function(scalar_function: ScalarFunction, func: ScalarFunctionMainFunction, extra_info?: object): void
+  // function scalar_function_set_function(scalar_function: ScalarFunction, func: ScalarFunctionMainFunction): void
   Napi::Value scalar_function_set_function(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto holder = GetScalarFunctionHolderFromExternal(env, info[0]);
     auto func = info[1].As<Napi::Function>();
-    auto user_extra_info = info[2].As<Napi::Object>();
     holder->EnsureInternalExtraInfo();
     holder->internal_extra_info->SetMainFunction(env, func);
-    holder->internal_extra_info->SetUserExtraInfo(user_extra_info);
     duckdb_scalar_function_set_function(holder->scalar_function, &ScalarFunctionMainFunction);
     return env.Undefined();
   }
@@ -4781,7 +4788,7 @@ NODE_API_ADDON(DuckDBNodeAddon)
   ---
   431 total functions
 
-  257 instance methods
+  258 instance methods
     3 unimplemented client context functions
     1 unimplemented table names function
     1 unimplemented value to string function
@@ -4803,7 +4810,7 @@ NODE_API_ADDON(DuckDBNodeAddon)
     6 unimplemented table description functions
     8 unimplemented tasks functions
    12 unimplemented cast function functions
-   24 functions not exposed
+   23 functions not exposed
 +  41 unimplemented deprecated functions (of 47)
   ---
   431 functions accounted for

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -680,8 +680,8 @@ duckdb_vector GetVectorFromExternal(Napi::Env env, Napi::Value value) {
 
 // Scalar functions
 
-using ScalarFunctionMainContext = std::nullptr_t;
-struct ScalarFunctionMainData {
+using ScalarFunctionMainTSFNContext = std::nullptr_t;
+struct ScalarFunctionMainTSFNData {
   duckdb_function_info info;
   duckdb_data_chunk input;
   duckdb_vector output;
@@ -689,7 +689,7 @@ struct ScalarFunctionMainData {
   std::mutex *cv_mutex;
   bool done;
 };
-void ScalarFunctionMainCallback(Napi::Env env, Napi::Function callback, ScalarFunctionMainContext *context, ScalarFunctionMainData *data) {
+void ScalarFunctionMainTSFNCallback(Napi::Env env, Napi::Function callback, ScalarFunctionMainTSFNContext *context, ScalarFunctionMainTSFNData *data) {
   if (env != nullptr) {
     if (callback != nullptr) {
       try {
@@ -712,7 +712,7 @@ void ScalarFunctionMainCallback(Napi::Env env, Napi::Function callback, ScalarFu
   }
   data->cv->notify_one();
 }
-using ScalarFunctionMainTSFN = Napi::TypedThreadSafeFunction<ScalarFunctionMainContext, ScalarFunctionMainData, ScalarFunctionMainCallback>;
+using ScalarFunctionMainTSFN = Napi::TypedThreadSafeFunction<ScalarFunctionMainTSFNContext, ScalarFunctionMainTSFNData, ScalarFunctionMainTSFNCallback>;
 
 struct ScalarFunctionMainExtraInfo {
   ScalarFunctionMainTSFN tsfn;
@@ -741,7 +741,7 @@ void DeleteScalarFunctionMainExtraInfo(ScalarFunctionMainExtraInfo *extra_info) 
 
 void ScalarFunctionMainFunction(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
   auto extra_info = GetScalarFunctionMainExtraInfo(info);
-  auto data = reinterpret_cast<ScalarFunctionMainData*>(duckdb_malloc(sizeof(ScalarFunctionMainData)));
+  auto data = reinterpret_cast<ScalarFunctionMainTSFNData*>(duckdb_malloc(sizeof(ScalarFunctionMainTSFNData)));
   data->info = info;
   data->input = input;
   data->output = output;

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -631,13 +631,13 @@ struct ScalarFunctionInternalExtraInfo {
   ScalarFunctionInternalExtraInfo() {}
 
   ~ScalarFunctionInternalExtraInfo() {
-    if (main_tsfn) {
+    if (bool(main_tsfn)) {
       main_tsfn->Release();
     }
   }
 
   void SetMainFunction(Napi::Env env, Napi::Function func) {
-    if (main_tsfn) {
+    if (bool(main_tsfn)) {
       main_tsfn->Release();
     }
     main_tsfn = std::make_unique<ScalarFunctionMainTSFN>(ScalarFunctionMainTSFN::New(env, func, "ScalarFunctionMain", 0, 1));
@@ -656,7 +656,7 @@ struct ScalarFunctionHolder {
   duckdb_scalar_function scalar_function;
   ScalarFunctionInternalExtraInfo *internal_extra_info;
 
-  ScalarFunctionHolder(duckdb_scalar_function scalar_function_in): scalar_function(scalar_function_in) {}
+  ScalarFunctionHolder(duckdb_scalar_function scalar_function_in): scalar_function(scalar_function_in), internal_extra_info(nullptr) {}
 
   ~ScalarFunctionHolder() {
     // duckdb_destroy_scalar_function is a no-op if already destroyed

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -720,11 +720,11 @@ using ScalarFunctionMainTSFN = Napi::TypedThreadSafeFunction<ScalarFunctionMainT
 
 struct ScalarFunctionMainExtraInfo {
   std::unique_ptr<ScalarFunctionMainTSFN> tsfn;
-  Napi::ObjectReference user_extra_info_ref;
+  std::unique_ptr<Napi::ObjectReference> user_extra_info_ref;
 
-  ScalarFunctionMainExtraInfo(Napi::Env env, Napi::Function func, Napi::Object user_extra_info) :
-    user_extra_info_ref(user_extra_info.IsUndefined() ? Napi::ObjectReference() : Napi::Persistent(user_extra_info)) {
+  ScalarFunctionMainExtraInfo(Napi::Env env, Napi::Function func, Napi::Object user_extra_info) {
     tsfn = std::make_unique<ScalarFunctionMainTSFN>(ScalarFunctionMainTSFN::New(env, func, "ScalarFunctionMain", 0, 1));
+    user_extra_info_ref = std::make_unique<Napi::ObjectReference>(user_extra_info.IsUndefined() ? Napi::ObjectReference() : Napi::Persistent(user_extra_info));
   }
 
   ~ScalarFunctionMainExtraInfo() {
@@ -4150,10 +4150,10 @@ private:
     auto env = info.Env();
     auto function_info = GetFunctionInfoFromExternal(env, info[0]);
     auto extra_info = GetScalarFunctionMainExtraInfo(function_info);
-    if (extra_info->user_extra_info_ref.IsEmpty()) {
+    if (!extra_info->user_extra_info_ref || extra_info->user_extra_info_ref->IsEmpty()) {
       return env.Undefined();
     }
-    return extra_info->user_extra_info_ref.Value();
+    return extra_info->user_extra_info_ref->Value();
   }
 
   // DUCKDB_C_API void *duckdb_scalar_function_get_bind_data(duckdb_function_info info);

--- a/bindings/test/scalar_functions.test.ts
+++ b/bindings/test/scalar_functions.test.ts
@@ -65,9 +65,9 @@ suite('scalar functions', () => {
               `output_${i}_${JSON.stringify(extra_info)}`
             );
           }
-        },
-        { 'my_extra_info_key': 'my_extra_info_value' }
+        }
       );
+      duckdb.scalar_function_set_extra_info(scalar_function, { 'my_extra_info_key': 'my_extra_info_value' });
       duckdb.register_scalar_function(connection, scalar_function);
       duckdb.destroy_scalar_function_sync(scalar_function);
 


### PR DESCRIPTION
Refactor how scalar functions are implemented to support a separate `set_extra_info` function and set the stage for supporting the bind function & data.

Now, a reference to the internal extra info is stored by the holder, so the user extra info and function can be set in any order. Also, C++ objects are used to manage these internal data structures (instead of C memory management), simplifying things and avoiding some initialization pitfalls with the latter approach.