### PR TITLE
Fix quotedIdentifier and quotedString

### DIFF
--- a/api/src/sql.ts
+++ b/api/src/sql.ts
@@ -1,7 +1,7 @@
 export function quotedString(input: string): string {
-  return `'${input.replace(`'`, `''`)}'`;
+  return `'${input.replaceAll(`'`, `''`)}'`;
 }
 
 export function quotedIdentifier(input: string): string {
-  return `"${input.replace(`"`, `""`)}"`;
+  return `"${input.replaceAll(`"`, `""`)}"`;
 }

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -105,6 +105,8 @@ import {
   intervalValue,
   listValue,
   mapValue,
+  quotedIdentifier,
+  quotedString,
   structValue,
   timeTZValue,
   timeValue,
@@ -2400,6 +2402,47 @@ ORDER BY name
       assert.deepEqual(columns, {
         'my_func(NULL)': ['output_is_not_null'],
       });
+    });
+  });
+
+  describe('SQL utility functions', () => {
+    test('quotedString', async () => {
+      // Basic string
+      assert.equal(quotedString('hello'), "'hello'");
+
+      // String with single quotes
+      assert.equal(quotedString("it's"), "'it''s'");
+      assert.equal(quotedString("'quoted'"), "'''quoted'''");
+
+      // String with multiple single quotes
+      assert.equal(quotedString("it's 'really' good"), "'it''s ''really'' good'");
+
+      // Empty string
+      assert.equal(quotedString(''), "''");
+
+      // String with special characters
+      assert.equal(quotedString('hello\nworld'), "'hello\nworld'");
+      assert.equal(quotedString('tab\there'), "'tab\there'");
+    });
+
+    test('quotedIdentifier', async () => {
+      // Basic identifier
+      assert.equal(quotedIdentifier('table_name'), '"table_name"');
+
+      // Identifier with double quotes
+      assert.equal(quotedIdentifier('my"table'), '"my""table"');
+      assert.equal(quotedIdentifier('"column"'), '"""column"""');
+
+      // Identifier with multiple double quotes
+      assert.equal(quotedIdentifier('my"special"table'), '"my""special""table"');
+
+      // Empty identifier
+      assert.equal(quotedIdentifier(''), '""');
+
+      // Identifier with special characters
+      assert.equal(quotedIdentifier('table-name'), '"table-name"');
+      assert.equal(quotedIdentifier('table.name'), '"table.name"');
+      assert.equal(quotedIdentifier('table name'), '"table name"');
     });
   });
 });

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -2406,7 +2406,7 @@ ORDER BY name
   });
 
   describe('SQL utility functions', () => {
-    test('quotedString', async () => {
+    test('quotedString', () => {
       // Basic string
       assert.equal(quotedString('hello'), "'hello'");
 
@@ -2425,7 +2425,7 @@ ORDER BY name
       assert.equal(quotedString('tab\there'), "'tab\there'");
     });
 
-    test('quotedIdentifier', async () => {
+    test('quotedIdentifier', () => {
       // Basic identifier
       assert.equal(quotedIdentifier('table_name'), '"table_name"');
 


### PR DESCRIPTION
I discovered that the utility functions for quoting strings and identifiers only cover single instances of quotes. This PR adds tests and fixes the issue. Please let me know if you'd prefer any changes to this PR.