### PR TITLE
bump pkgs to 1.4.1-r.2

### DIFF
--- a/api/pkgs/@duckdb/node-api/package.json
+++ b/api/pkgs/@duckdb/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-api",
-  "version": "1.4.1-r.1",
+  "version": "1.4.1-r.2",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-arm64",
-  "version": "1.4.1-r.1",
+  "version": "1.4.1-r.2",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-x64",
-  "version": "1.4.1-r.1",
+  "version": "1.4.1-r.2",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-arm64",
-  "version": "1.4.1-r.1",
+  "version": "1.4.1-r.2",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-x64",
-  "version": "1.4.1-r.1",
+  "version": "1.4.1-r.2",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-x64",
-  "version": "1.4.1-r.1",
+  "version": "1.4.1-r.2",
   "license": "MIT",
   "os": [
     "win32"

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings",
-  "version": "1.4.1-r.1",
+  "version": "1.4.1-r.2",
   "license": "MIT",
   "main": "./duckdb.js",
   "types": "./duckdb.d.ts",


### PR DESCRIPTION
Only change in this version is downgrading the version of Ubuntu (from 24 to 22) to hopefully address the problem some users were having running Node Neo on older versions of Linux. (See https://github.com/duckdb/duckdb-node-neo/issues/302)
- https://github.com/duckdb/duckdb-node-neo/pull/311