### PR TITLE
manylinux build

### DIFF
--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
 
       - uses: pnpm/action-setup@v3
         with:
@@ -159,7 +159,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 22
 
       - uses: pnpm/action-setup@v3
         with:


### PR DESCRIPTION
- Use manylinux container in Linux builds to avoid binding against newer versions of GLIBCXX, which can fail in environments with older standard libraries (e.g. AWS Lambdas, including Vercel).
- Use the actual Linux ARM runner (now that it's available) for the Linux ARM build, instead of using cross-compilation.
  - This means we can run tests in this job.
- Fix the images of the other builds, so upgrades can be done explicitly, avoiding surprises.