### PR TITLE
no git status on linux

### DIFF
--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -117,9 +117,9 @@ jobs:
         working-directory: api
         run: pnpm test
 
-      - name: Git Status
-        if: ${{ inputs.publish }}
-        run: git status
+      # - name: Git Status
+      #   if: ${{ inputs.publish }}
+      #   run: git status
 
       - name: Publish - Bindings - Linux x64
         if: ${{ inputs.publish }}
@@ -176,9 +176,9 @@ jobs:
         working-directory: bindings
         run: pnpm test
 
-      - name: Git Status
-        if: ${{ inputs.publish }}
-        run: git status
+      # - name: Git Status
+      #   if: ${{ inputs.publish }}
+      #   run: git status
 
       - name: Publish - Bindings - Linux arm64
         if: ${{ inputs.publish }}


### PR DESCRIPTION
Don't run `git status` on Linux. It causes a permissions issue (presumably due to the use of the docker container) and isn't necessary.