### PR TITLE
remove npmrcs

### DIFF
--- a/api/pkgs/@duckdb/node-api/.npmrc
+++ b/api/pkgs/@duckdb/node-api/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/.npmrc
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-x64/.npmrc
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-x64/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/.npmrc
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/.npmrc
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/.npmrc
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}

--- a/bindings/pkgs/@duckdb/node-bindings/.npmrc
+++ b/bindings/pkgs/@duckdb/node-bindings/.npmrc
@@ -1,1 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_AUTH_TOKEN}


### PR DESCRIPTION
To use trusted publishing, we need to remove all uses of explicit tokens. I forgot about the reference in these `.npmrc` files. Removing them.