### PR TITLE
prepared statement column info

### DIFF
--- a/api/src/DuckDBPreparedStatement.ts
+++ b/api/src/DuckDBPreparedStatement.ts
@@ -77,6 +77,29 @@ export class DuckDBPreparedStatement {
       duckdb.param_logical_type(this.prepared_statement, parameterIndex)
     ).asType();
   }
+  public get columnCount(): number {
+    return duckdb.prepared_statement_column_count(this.prepared_statement);
+  }
+  public columnName(columnIndex: number): string {
+    return duckdb.prepared_statement_column_name(
+      this.prepared_statement,
+      columnIndex
+    );
+  }
+  public columnTypeId(columnIndex: number): DuckDBTypeId {
+    return duckdb.prepared_statement_column_type(
+      this.prepared_statement,
+      columnIndex
+    ) as number as DuckDBTypeId;
+  }
+  public columnType(columnIndex: number): DuckDBType {
+    return DuckDBLogicalType.create(
+      duckdb.prepared_statement_column_logical_type(
+        this.prepared_statement,
+        columnIndex
+      )
+    ).asType();
+  }
   public clearBindings() {
     duckdb.clear_bindings(this.prepared_statement);
   }

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -1,10 +1,10 @@
 {
   "private": true,
   "scripts": {
-    "build": "npm run build:package && npm run build:test",
+    "build": "pnpm run build:package && pnpm run build:test",
     "build:package": "cross-replace node-gyp configure --verbose --nodedir=$NODE_DIR && node-gyp build --verbose --nodedir=$NODE_DIR",
     "build:test": "tsc -b test",
-    "clean": "npm run clean:gyp && npm run clean:libduckdb && npm run clean:package",
+    "clean": "pnpm run clean:gyp && pnpm run clean:libduckdb && pnpm run clean:package",
     "clean:gyp": "node-gyp clean",
     "clean:libduckdb": "rimraf libduckdb",
     "clean:package": "rimraf pkgs/@duckdb/**/*.node pkgs/@duckdb/**/*.so pkgs/@duckdb/**/*.dylib pkgs/@duckdb/**/*.dll",

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -520,9 +520,16 @@ export function clear_bindings(prepared_statement: PreparedStatement): void;
 export function prepared_statement_type(prepared_statement: PreparedStatement): StatementType;
 
 // DUCKDB_C_API idx_t duckdb_prepared_statement_column_count(duckdb_prepared_statement prepared_statement);
+export function prepared_statement_column_count(prepared_statement: PreparedStatement): number;
+
 // DUCKDB_C_API const char *duckdb_prepared_statement_column_name(duckdb_prepared_statement prepared_statement, idx_t col_idx);
+export function prepared_statement_column_name(prepared_statement: PreparedStatement, index: number): string;
+
 // DUCKDB_C_API duckdb_logical_type duckdb_prepared_statement_column_logical_type(duckdb_prepared_statement prepared_statement, idx_t col_idx);
+export function prepared_statement_column_logical_type(prepared_statement: PreparedStatement, index: number): LogicalType;
+
 // DUCKDB_C_API duckdb_type duckdb_prepared_statement_column_type(duckdb_prepared_statement prepared_statement, idx_t col_idx);
+export function prepared_statement_column_type(prepared_statement: PreparedStatement, index: number): Type;
 
 // DUCKDB_C_API duckdb_state duckdb_bind_value(duckdb_prepared_statement prepared_statement, idx_t param_idx, duckdb_value val);
 export function bind_value(prepared_statement: PreparedStatement, index: number, value: Value): void;


### PR DESCRIPTION
Implements https://github.com/duckdb/duckdb-node-neo/issues/297, in both bindings and api.

Also fixed a minor issue with the bindings package.json referring to `npm` instead of `pnpm`.