### PR TITLE
TIME_NS support

### DIFF
--- a/api/src/DuckDBLogicalType.ts
+++ b/api/src/DuckDBLogicalType.ts
@@ -13,13 +13,16 @@ import {
   DuckDBEnumType,
   DuckDBFloatType,
   DuckDBHugeIntType,
+  DuckDBIntegerLiteralType,
   DuckDBIntegerType,
   DuckDBIntervalType,
   DuckDBListType,
   DuckDBMapType,
   DuckDBSQLNullType,
   DuckDBSmallIntType,
+  DuckDBStringLiteralType,
   DuckDBStructType,
+  DuckDBTimeNSType,
   DuckDBTimeTZType,
   DuckDBTimeType,
   DuckDBTimestampMillisecondsType,
@@ -87,7 +90,7 @@ export class DuckDBLogicalType {
   }
   public static createStruct(
     entryNames: readonly string[],
-    entryLogicalTypes: readonly DuckDBLogicalType[],    
+    entryLogicalTypes: readonly DuckDBLogicalType[]
   ): DuckDBStructLogicalType {
     const length = entryNames.length;
     if (length !== entryLogicalTypes.length) {
@@ -122,7 +125,7 @@ export class DuckDBLogicalType {
   }
   public static createUnion(
     memberTags: readonly string[],
-    memberLogicalTypes: readonly DuckDBLogicalType[], 
+    memberLogicalTypes: readonly DuckDBLogicalType[]
   ): DuckDBUnionLogicalType {
     const length = memberTags.length;
     if (length !== memberLogicalTypes.length) {
@@ -152,7 +155,7 @@ export class DuckDBLogicalType {
     const alias = this.alias;
     switch (this.typeId) {
       case DuckDBTypeId.BOOLEAN:
-        return  DuckDBBooleanType.create(alias);
+        return DuckDBBooleanType.create(alias);
       case DuckDBTypeId.TINYINT:
         return DuckDBTinyIntType.create(alias);
       case DuckDBTypeId.SMALLINT:
@@ -223,6 +226,12 @@ export class DuckDBLogicalType {
         return DuckDBBigNumType.create(alias);
       case DuckDBTypeId.SQLNULL:
         return DuckDBSQLNullType.create(alias);
+      case DuckDBTypeId.STRING_LITERAL:
+        return DuckDBStringLiteralType.create(alias);
+      case DuckDBTypeId.INTEGER_LITERAL:
+        return DuckDBIntegerLiteralType.create(alias);
+      case DuckDBTypeId.TIME_NS:
+        return DuckDBTimeNSType.create(alias);
       default:
         throw new Error(`Unexpected type id: ${this.typeId}`);
     }
@@ -322,7 +331,11 @@ export class DuckDBStructLogicalType extends DuckDBLogicalType {
     return valueTypes;
   }
   public override asType(): DuckDBStructType {
-    return new DuckDBStructType(this.entryNames(), this.entryTypes(), this.alias);
+    return new DuckDBStructType(
+      this.entryNames(),
+      this.entryTypes(),
+      this.alias
+    );
   }
 }
 
@@ -338,7 +351,11 @@ export class DuckDBMapLogicalType extends DuckDBLogicalType {
     );
   }
   public override asType(): DuckDBMapType {
-    return new DuckDBMapType(this.keyType.asType(), this.valueType.asType(), this.alias);
+    return new DuckDBMapType(
+      this.keyType.asType(),
+      this.valueType.asType(),
+      this.alias
+    );
   }
 }
 
@@ -352,7 +369,11 @@ export class DuckDBArrayLogicalType extends DuckDBLogicalType {
     return duckdb.array_type_array_size(this.logical_type);
   }
   public override asType(): DuckDBArrayType {
-    return new DuckDBArrayType(this.valueType.asType(), this.length, this.alias);
+    return new DuckDBArrayType(
+      this.valueType.asType(),
+      this.length,
+      this.alias
+    );
   }
 }
 
@@ -396,6 +417,10 @@ export class DuckDBUnionLogicalType extends DuckDBLogicalType {
     return valueTypes;
   }
   public override asType(): DuckDBUnionType {
-    return new DuckDBUnionType(this.memberTags(), this.memberTypes(), this.alias);
+    return new DuckDBUnionType(
+      this.memberTags(),
+      this.memberTypes(),
+      this.alias
+    );
   }
 }

--- a/api/src/DuckDBType.ts
+++ b/api/src/DuckDBType.ts
@@ -959,6 +959,39 @@ export class DuckDBSQLNullType extends BaseDuckDBType<DuckDBTypeId.SQLNULL> {
 }
 export const SQLNULL = DuckDBSQLNullType.instance;
 
+export class DuckDBStringLiteralType extends BaseDuckDBType<DuckDBTypeId.STRING_LITERAL> {
+  public constructor(alias?: string) {
+    super(DuckDBTypeId.STRING_LITERAL, alias);
+  }
+  public static readonly instance = new DuckDBStringLiteralType();
+  public static create(alias?: string): DuckDBStringLiteralType {
+    return alias ? new DuckDBStringLiteralType(alias) : DuckDBStringLiteralType.instance;
+  }
+}
+export const STRING_LITERAL = DuckDBStringLiteralType.instance;
+
+export class DuckDBIntegerLiteralType extends BaseDuckDBType<DuckDBTypeId.INTEGER_LITERAL> {
+  public constructor(alias?: string) {
+    super(DuckDBTypeId.INTEGER_LITERAL, alias);
+  }
+  public static readonly instance = new DuckDBIntegerLiteralType();
+  public static create(alias?: string): DuckDBIntegerLiteralType {
+    return alias ? new DuckDBIntegerLiteralType(alias) : DuckDBIntegerLiteralType.instance;
+  }
+}
+export const INTEGER_LITERAL = DuckDBIntegerLiteralType.instance;
+
+export class DuckDBTimeNSType extends BaseDuckDBType<DuckDBTypeId.TIME_NS> {
+  public constructor(alias?: string) {
+    super(DuckDBTypeId.TIME_NS, alias);
+  }
+  public static readonly instance = new DuckDBTimeNSType();
+  public static create(alias?: string): DuckDBTimeNSType {
+    return alias ? new DuckDBTimeNSType(alias) : DuckDBTimeNSType.instance;
+  }
+}
+export const TIME_NS = DuckDBTimeNSType.instance;
+
 export type DuckDBType =
   | DuckDBBooleanType
   | DuckDBTinyIntType
@@ -995,4 +1028,7 @@ export type DuckDBType =
   | DuckDBTimestampTZType
   | DuckDBAnyType
   | DuckDBBigNumType
-  | DuckDBSQLNullType;
+  | DuckDBSQLNullType
+  | DuckDBStringLiteralType
+  | DuckDBIntegerLiteralType
+  | DuckDBTimeNSType;

--- a/api/src/DuckDBTypeId.ts
+++ b/api/src/DuckDBTypeId.ts
@@ -37,4 +37,7 @@ export enum DuckDBTypeId {
   ANY = 34,
   BIGNUM = 35,
   SQLNULL = 36,
+  STRING_LITERAL = 37,
+  INTEGER_LITERAL = 38,
+  TIME_NS = 39,
 }

--- a/api/src/JSDuckDBValueConverter.ts
+++ b/api/src/JSDuckDBValueConverter.ts
@@ -66,6 +66,9 @@ const JSConvertersByTypeId: Record<DuckDBTypeId, DuckDBValueConverter<JS>> = {
   [DuckDBTypeId.ANY]: unsupportedConverter,
   [DuckDBTypeId.BIGNUM]: bigintFromBigIntValue,
   [DuckDBTypeId.SQLNULL]: nullConverter,
+  [DuckDBTypeId.STRING_LITERAL]: unsupportedConverter,
+  [DuckDBTypeId.INTEGER_LITERAL]: unsupportedConverter,
+  [DuckDBTypeId.TIME_NS]: bigintFromTimeValue,
 };
 
 export const JSDuckDBValueConverter =

--- a/api/src/JsonDuckDBValueConverter.ts
+++ b/api/src/JsonDuckDBValueConverter.ts
@@ -58,6 +58,9 @@ const JsonConvertersByTypeId: Record<
   [DuckDBTypeId.ANY]: unsupportedConverter,
   [DuckDBTypeId.BIGNUM]: stringFromValue,
   [DuckDBTypeId.SQLNULL]: nullConverter,
+  [DuckDBTypeId.STRING_LITERAL]: unsupportedConverter,
+  [DuckDBTypeId.INTEGER_LITERAL]: unsupportedConverter,
+  [DuckDBTypeId.TIME_NS]: stringFromValue,
 };
 
 export const JsonDuckDBValueConverter = createDuckDBValueConverter(

--- a/api/src/createValue.ts
+++ b/api/src/createValue.ts
@@ -11,6 +11,7 @@ import {
   DuckDBListValue,
   DuckDBMapValue,
   DuckDBStructValue,
+  DuckDBTimeNSValue,
   DuckDBTimestampMillisecondsValue,
   DuckDBTimestampNanosecondsValue,
   DuckDBTimestampSecondsValue,
@@ -261,6 +262,15 @@ export function createValue(type: DuckDBType, input: DuckDBValue): Value {
       throw new Error(`input is not a bigint`);
     case DuckDBTypeId.SQLNULL:
       return duckdb.create_null_value();
+    case DuckDBTypeId.STRING_LITERAL:
+      throw new Error(`Cannot create values of type STRING_LITERAL.`);
+    case DuckDBTypeId.INTEGER_LITERAL:
+      throw new Error(`Cannot create values of type INTEGER_LITERAL.`);
+    case DuckDBTypeId.TIME_NS:
+      if (input instanceof DuckDBTimeNSValue) {
+        return duckdb.create_time_ns(input);
+      }
+      throw new Error(`input is not a DuckDBTimeNSValue`);
     default:
       throw new Error(`unrecognized type id ${typeId}`);
   }

--- a/api/src/values/DuckDBTimeNSValue.ts
+++ b/api/src/values/DuckDBTimeNSValue.ts
@@ -1,0 +1,23 @@
+import { TimeNS } from '@duckdb/node-bindings';
+import { getDuckDBTimeStringFromNanosecondsInDay } from '../conversion/dateTimeStringConversion';
+
+export class DuckDBTimeNSValue implements TimeNS {
+  public readonly nanos: bigint;
+
+  public constructor(nanos: bigint) {
+    this.nanos = nanos;
+  }
+
+  public toString(): string {
+    return getDuckDBTimeStringFromNanosecondsInDay(this.nanos);
+  }
+
+  public static readonly Max = new DuckDBTimeNSValue(
+    24n * 60n * 60n * 1000n * 1000n * 1000n
+  );
+  public static readonly Min = new DuckDBTimeNSValue(0n);
+}
+
+export function timeNSValue(nanos: bigint): DuckDBTimeNSValue {
+  return new DuckDBTimeNSValue(nanos);
+}

--- a/api/src/values/DuckDBValue.ts
+++ b/api/src/values/DuckDBValue.ts
@@ -7,6 +7,7 @@ import { DuckDBIntervalValue } from './DuckDBIntervalValue';
 import { DuckDBListValue } from './DuckDBListValue';
 import { DuckDBMapValue } from './DuckDBMapValue';
 import { DuckDBStructValue } from './DuckDBStructValue';
+import { DuckDBTimeNSValue } from './DuckDBTimeNSValue';
 import { DuckDBTimestampMillisecondsValue } from './DuckDBTimestampMillisecondsValue';
 import { DuckDBTimestampNanosecondsValue } from './DuckDBTimestampNanosecondsValue';
 import { DuckDBTimestampSecondsValue } from './DuckDBTimestampSecondsValue';
@@ -39,6 +40,6 @@ export type DuckDBValue =
   | DuckDBTimestampValue
   | DuckDBTimeTZValue
   | DuckDBTimeValue
+  | DuckDBTimeNSValue
   | DuckDBUnionValue
-  | DuckDBUUIDValue
-  ;
+  | DuckDBUUIDValue;

--- a/api/src/values/index.ts
+++ b/api/src/values/index.ts
@@ -7,6 +7,7 @@ export * from './DuckDBIntervalValue';
 export * from './DuckDBListValue';
 export * from './DuckDBMapValue';
 export * from './DuckDBStructValue';
+export * from './DuckDBTimeNSValue';
 export * from './DuckDBTimestampMillisecondsValue';
 export * from './DuckDBTimestampNanosecondsValue';
 export * from './DuckDBTimestampSecondsValue';

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -85,6 +85,9 @@ export enum Type {
   ANY = 34,
   BIGNUM = 35,
   SQLNULL = 36,
+  STRING_LITERAL = 37,
+  INTEGER_LITERAL = 38,
+  TIME_NS = 39,
 }
 
 
@@ -127,6 +130,11 @@ export interface TimeParts {
   min: number;
   sec: number;
   micros: number;
+}
+
+export interface TimeNS {
+  /** Nanoseconds since 00:00:00 */
+  nanos: bigint;
 }
 
 export interface TimeTZ {
@@ -717,6 +725,7 @@ export function create_date(input: Date_): Value;
 export function create_time(input: Time): Value;
 
 // DUCKDB_C_API duckdb_value duckdb_create_time_ns(duckdb_time_ns input);
+export function create_time_ns(input: TimeNS): Value;
 
 // DUCKDB_C_API duckdb_value duckdb_create_time_tz_value(duckdb_time_tz value);
 export function create_time_tz_value(input: TimeTZ): Value;
@@ -800,6 +809,7 @@ export function get_date(value: Value): Date_;
 export function get_time(value: Value): Time;
 
 // DUCKDB_C_API duckdb_time_ns duckdb_get_time_ns(duckdb_value val);
+export function get_time_ns(value: Value): TimeNS;
 
 // DUCKDB_C_API duckdb_time_tz duckdb_get_time_tz(duckdb_value val);
 export function get_time_tz(value: Value): TimeTZ;

--- a/bindings/test/query.test.ts
+++ b/bindings/test/query.test.ts
@@ -262,6 +262,22 @@ suite('query', () => {
       });
     });
   });
+  // TODO: Need DuckDB fix to LogicalTypeIdFromC and LogicalTypeIdToC
+  test.skip('time_ns', async () => {
+    await withConnection(async (connection) => {
+      const result = await duckdb.query(connection, `select '12:34:56.789123456'::time_ns as time_ns`);
+      await expectResult(result, {
+        chunkCount: 1,
+        rowCount: 1,
+        columns: [
+          { name: 'time_ns', logicalType: { typeId: duckdb.Type.TIME_NS } },
+        ],
+        chunks: [
+          { rowCount: 1, vectors: [data(4, [true], [45296789123456n])]},
+        ],
+      });
+    });
+  });
   test('create and insert', async () => {
     await withConnection(async (connection) => {
       const createResult = await duckdb.query(connection, 'create table test_create_and_insert(i integer)');

--- a/bindings/test/utils/expectedLogicalTypes.ts
+++ b/bindings/test/utils/expectedLogicalTypes.ts
@@ -112,6 +112,17 @@ export const SQLNULL: ExpectedSimpleLogicalType = {
   typeId: duckdb.Type.SQLNULL,
 };
 
+export const STRING_LITERAL: ExpectedSimpleLogicalType = {
+  typeId: duckdb.Type.STRING_LITERAL,
+};
+export const INTEGER_LITERAL: ExpectedSimpleLogicalType = {
+  typeId: duckdb.Type.INTEGER_LITERAL,
+};
+
+export const TIME_NS: ExpectedSimpleLogicalType = {
+  typeId: duckdb.Type.TIME_NS,
+};
+
 export function ARRAY(
   valueType: ExpectedLogicalType,
   size: number

--- a/bindings/test/utils/getValue.ts
+++ b/bindings/test/utils/getValue.ts
@@ -194,6 +194,12 @@ export function getValue(logicalType: ExpectedLogicalType, validity: BigUint64Ar
     
     case duckdb.Type.SQLNULL:
       return null;
+
+    // STRING_LITERAL
+    // INTEGER_LITERAL
+
+    case duckdb.Type.TIME_NS:
+      return getInt64(dv, index * 8);
     
     default:
       throw new Error(`getValue not implemented for type: ${duckdb.Type[logicalType.typeId]}`);

--- a/bindings/test/values.test.ts
+++ b/bindings/test/values.test.ts
@@ -3,6 +3,7 @@ import duckdb, {
   Decimal,
   Interval,
   Time,
+  TimeNS,
   Timestamp,
   TimestampMilliseconds,
   TimestampNanoseconds,
@@ -47,7 +48,7 @@ import {
   USMALLINT,
   UTINYINT,
   UUID,
-  VARCHAR,
+  VARCHAR
 } from './utils/expectedLogicalTypes';
 
 suite('values', () => {
@@ -189,6 +190,13 @@ suite('values', () => {
     const time_value = duckdb.create_time(input);
     expectLogicalType(duckdb.get_value_type(time_value), TIME);
     expect(duckdb.get_time(time_value)).toStrictEqual(input);
+  });
+  test('time_ns', () => {
+    const input: TimeNS = { nanos: 86400000000000n };
+    const time_ns_value = duckdb.create_time_ns(input);
+    // TODO: Need DuckDB fix to LogicalTypeIdFromC and LogicalTypeIdToC
+    // expectLogicalType(duckdb.get_value_type(time_ns_value), TIME_NS);
+    expect(duckdb.get_time_ns(time_ns_value)).toStrictEqual(input);
   });
   test('time_tz', () => {
     const input: TimeTZ = { bits: 1449551462400115198n };


### PR DESCRIPTION
Add support for TIME_NS. This isn't entirely working due to some bugs in DuckDB; see https://github.com/duckdb/duckdb/pull/19613. Hence the skipped tests. But it's a step forward, so I'll merge it.