### PR TITLE
upgrade to duckdb 1.4.3

### DIFF
--- a/api/pkgs/@duckdb/node-api/package.json
+++ b/api/pkgs/@duckdb/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-api",
-  "version": "1.4.2-r.1",
+  "version": "1.4.3-r.1",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -1538,13 +1538,13 @@ ORDER BY name
   });
   test('instance cache - same instance', async () => {
     const cache = new DuckDBInstanceCache();
-    const instance1 = await cache.getOrCreateInstance();
+    const instance1 = await cache.getOrCreateInstance(':memory:m1');
     const connection1 = await instance1.connect();
-    await connection1.run(`attach ':memory:' as mem1`);
+    await connection1.run(`create table t1 as select 1`);
 
-    const instance2 = await cache.getOrCreateInstance();
+    const instance2 = await cache.getOrCreateInstance(':memory:m1');
     const connection2 = await instance2.connect();
-    await connection2.run(`create table mem1.main.t1 as select 1`);
+    await connection2.run(`from t1`);
   });
   // Need to support explicitly destroying instance cache?
   test.skip('instance cache - different instances', async () => {
@@ -1584,11 +1584,13 @@ ORDER BY name
   });
   test('instance cache - different config', async () => {
     const cache = new DuckDBInstanceCache();
-    const instance1 = await cache.getOrCreateInstance();
+    const instance1 = await cache.getOrCreateInstance(':memory:m1');
     const connection1 = await instance1.connect();
-    await connection1.run(`attach ':memory:' as mem1`);
+    await connection1.run(`create table t1 as select 1`);
     try {
-      await cache.getOrCreateInstance(undefined, { accces_mode: 'READ_ONLY' });
+      await cache.getOrCreateInstance(':memory:m1', {
+        accces_mode: 'READ_ONLY',
+      });
       assert.fail('should throw');
     } catch (err) {
       assert.deepEqual(

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-arm64",
-  "version": "1.4.2-r.1",
+  "version": "1.4.3-r.1",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-x64",
-  "version": "1.4.2-r.1",
+  "version": "1.4.3-r.1",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-arm64",
-  "version": "1.4.2-r.1",
+  "version": "1.4.3-r.1",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-x64",
-  "version": "1.4.2-r.1",
+  "version": "1.4.3-r.1",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-x64",
-  "version": "1.4.2-r.1",
+  "version": "1.4.3-r.1",
   "license": "MIT",
   "os": [
     "win32"

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings",
-  "version": "1.4.2-r.1",
+  "version": "1.4.3-r.1",
   "license": "MIT",
   "main": "./duckdb.js",
   "types": "./duckdb.d.ts",

--- a/bindings/scripts/fetch_libduckdb_linux_amd64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_amd64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.2/libduckdb-linux-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.3/libduckdb-linux-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_linux_arm64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_arm64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.2/libduckdb-linux-arm64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.3/libduckdb-linux-arm64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_osx_universal.py
+++ b/bindings/scripts/fetch_libduckdb_osx_universal.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.2/libduckdb-osx-universal.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.3/libduckdb-osx-universal.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_windows_amd64.py
+++ b/bindings/scripts/fetch_libduckdb_windows_amd64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.2/libduckdb-windows-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.3/libduckdb-windows-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/test/config.test.ts
+++ b/bindings/test/config.test.ts
@@ -5,7 +5,7 @@ import { data } from './utils/expectedVectors';
 
 suite('config', () => {
   test('config_count', () => {
-    expect(duckdb.config_count()).toBe(199);
+    expect(duckdb.config_count()).toBe(201);
   });
   test('get_config_flag', () => {
     expect(duckdb.get_config_flag(0).name).toBe('access_mode');

--- a/bindings/test/constants.test.ts
+++ b/bindings/test/constants.test.ts
@@ -6,7 +6,7 @@ suite('constants', () => {
     expect(duckdb.sizeof_bool).toBe(1);
   });
   test('library_version', () => {
-    expect(duckdb.library_version()).toBe('v1.4.2');
+    expect(duckdb.library_version()).toBe('v1.4.3');
   });
   test('vector_size', () => {
     expect(duckdb.vector_size()).toBe(2048);


### PR DESCRIPTION
No other changes, just the new DuckDB version.

There was a behavior change of the instance cache with regard to memory instances, hence the test change. See https://github.com/duckdb/duckdb/pull/19841