### PR TITLE
add api helpers for using pending results

### DIFF
--- a/api/src/DuckDBPendingResult.ts
+++ b/api/src/DuckDBPendingResult.ts
@@ -2,6 +2,7 @@ import duckdb from '@duckdb/node-bindings';
 import { createResult } from './createResult';
 import { DuckDBResult } from './DuckDBResult';
 import { DuckDBResultReader } from './DuckDBResultReader';
+import { sleep } from './sleep';
 
 // Values match similar enum in C API.
 export enum DuckDBPendingResultState {
@@ -32,6 +33,11 @@ export class DuckDBPendingResult {
         return DuckDBPendingResultState.NO_TASKS_AVAILABLE;
       default:
         throw new Error(`Unexpected pending state: ${pending_state}`);
+    }
+  }
+  public async runAllTasks(): Promise<void> {
+    while (this.runTask() !== DuckDBPendingResultState.RESULT_READY) {
+      await sleep(1);
     }
   }
   public async getResult(): Promise<DuckDBResult> {

--- a/api/src/sleep.ts
+++ b/api/src/sleep.ts
@@ -1,0 +1,5 @@
+export async function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}


### PR DESCRIPTION
Add some helpers to make it easier to run SQL using pending results. Using these, especially the `startStreamThenRead` variants, should enable cooperative multithreading when handling many requests at the same time, some of which may take a while. See https://github.com/duckdb/duckdb-node-neo/issues/325 for a more information about this problem.