### PR TITLE
allow unsupported platform when duckdb.node present

### DIFF
--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.js
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.js
@@ -16,8 +16,12 @@ const getNativeNodeBinding = (runtimePlatformArch) => {
         case 'win32-x64':
             return require('@duckdb/node-bindings-win32-x64/duckdb.node');
         default:
-            const [platform, arch] = runtimePlatformArch.split('-')
-            throw new Error(`Error loading duckdb native binding: unsupported arch '${arch}' for platform '${platform}'`);
+            const [platform, arch] = runtimePlatformArch.split('-');
+            try {
+                return require(`@duckdb/node-bindings-${platform}-${arch}/duckdb.node`);
+            } catch (err) {
+                throw new Error(`Error loading duckdb native binding: unsupported arch '${arch}' for platform '${platform}'`);
+            }            
     }
 }
 


### PR DESCRIPTION
Right now, if you try to run duckdb-node-neo on an unsupported platform, it will always fail.

This PR changes that and will try to load a library with the name `@duckdb/node-bindings/${platform}-${arch}/duckdb.node` regardless if it is a supported platform.

This will allow third party authors to create libraries for platforms that are not officially supported. Users can then install these libraries using an alias which is supported by all major Node.js package managers:

```
npm install <alias>@npm:<name>
```

For example if someone publishes a library which provides a `duckdb.node` for FreeBSD, it could be installed like this:

```
npm install @duckdb/node-bindings-freebsd-x64@npm:<name>
```

And now it will be picked up by `getNativeNodeBinding` after this change.

If a library is not present, it will fail with the same error as before.