### PR TITLE
scalar function bind (bindings)

### DIFF
--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -178,6 +178,10 @@ export interface TimestampParts {
   time: TimeParts;
 }
 
+export interface BindInfo {
+  __duckdb_type: 'duckdb_bind_info';
+}
+
 export interface FunctionInfo {
   __duckdb_type: 'duckdb_function_info';
 }
@@ -264,6 +268,7 @@ export interface ExtractedStatementsAndCount {
   statement_count: number;
 }
 
+export type ScalarFunctionBindFunction = (info: BindInfo) => void;
 export type ScalarFunctionMainFunction = (info: FunctionInfo, input: DataChunk, output: Vector) => void;
 
 // Functions
@@ -1093,9 +1098,16 @@ export function scalar_function_set_return_type(scalar_function: ScalarFunction,
 export function scalar_function_set_extra_info(scalar_function: ScalarFunction, extra_info: object): void;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_bind(duckdb_scalar_function scalar_function, duckdb_scalar_function_bind_t bind);
+export function scalar_function_set_bind(scalar_function: ScalarFunction, func: ScalarFunctionBindFunction): void;
+
 // DUCKDB_C_API void duckdb_scalar_function_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
+export function scalar_function_set_bind_data(info: BindInfo, bind_data: object): void;
+
 // DUCKDB_C_API void duckdb_scalar_function_set_bind_data_copy(duckdb_bind_info info, duckdb_copy_callback_t copy);
+// not exposed: handled by scalar_function_set_bind_data
+
 // DUCKDB_C_API void duckdb_scalar_function_bind_set_error(duckdb_bind_info info, const char *error);
+export function scalar_function_bind_set_error(bind_info: BindInfo, error: string): void;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_function(duckdb_scalar_function scalar_function, duckdb_scalar_function_t function);
 export function scalar_function_set_function(scalar_function: ScalarFunction, func: ScalarFunctionMainFunction): void;
@@ -1107,8 +1119,13 @@ export function register_scalar_function(connection: Connection, scalar_function
 export function scalar_function_get_extra_info(function_info: FunctionInfo): object | undefined;
 
 // DUCKDB_C_API void *duckdb_scalar_function_bind_get_extra_info(duckdb_bind_info info);
+export function scalar_function_bind_get_extra_info(bind_info: BindInfo): object | undefined;
+
 // DUCKDB_C_API void *duckdb_scalar_function_get_bind_data(duckdb_function_info info);
+export function scalar_function_get_bind_data(function_info: FunctionInfo): object | undefined;
+
 // DUCKDB_C_API void duckdb_scalar_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);
+export function scalar_function_get_client_context(bind_info: BindInfo): ClientContext;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_error(duckdb_function_info info, const char *error);
 export function scalar_function_set_error(function_info: FunctionInfo, error: string): void;


### PR DESCRIPTION
Support, in the bindings layer:
- scalar_function_set_bind
- scalar_function_set_bind_data
- scalar_function_bind_set_error
- scalar_function_bind_get_extra_info
- scalar_function_get_bind_data
- scalar_function_get_client_context

(duckdb_scalar_function_set_bind_data_copy is also handled internally)