### PR TITLE
upgrade to duckdb 1.5.0

### DIFF
--- a/api/pkgs/@duckdb/node-api/package.json
+++ b/api/pkgs/@duckdb/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-api",
-  "version": "1.4.4-r.3",
+  "version": "1.5.0-r.1",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -935,7 +935,7 @@ ORDER BY name
   test('should support all data types', async () => {
     await withConnection(async (connection) => {
       const result = await connection.run(
-        'from test_all_types(use_large_enum=true)',
+        'from test_all_types(use_large_enum=true) select * exclude time_ns',
       );
       assertColumns(result, createTestAllTypesColumnNameAndTypeObjects());
 
@@ -1419,28 +1419,36 @@ ORDER BY name
   });
   test('columns json', async () => {
     await withConnection(async (connection) => {
-      const reader = await connection.runAndReadAll(`from test_all_types()`);
+      const reader = await connection.runAndReadAll(
+        `from test_all_types() select * exclude time_ns`,
+      );
       const columnsJson = reader.getColumnsJson();
       assert.deepEqual(columnsJson, createTestAllTypesColumnsJson());
     });
   });
   test('columns object json', async () => {
     await withConnection(async (connection) => {
-      const reader = await connection.runAndReadAll(`from test_all_types()`);
+      const reader = await connection.runAndReadAll(
+        `from test_all_types() select * exclude time_ns`,
+      );
       const columnsJson = reader.getColumnsObjectJson();
       assert.deepEqual(columnsJson, createTestAllTypesColumnsObjectJson());
     });
   });
   test('rows json', async () => {
     await withConnection(async (connection) => {
-      const reader = await connection.runAndReadAll(`from test_all_types()`);
+      const reader = await connection.runAndReadAll(
+        `from test_all_types() select * exclude time_ns`,
+      );
       const rowsJson = reader.getRowsJson();
       assert.deepEqual(rowsJson, createTestAllTypesRowsJson());
     });
   });
   test('row objects json', async () => {
     await withConnection(async (connection) => {
-      const reader = await connection.runAndReadAll(`from test_all_types()`);
+      const reader = await connection.runAndReadAll(
+        `from test_all_types() select * exclude time_ns`,
+      );
       const rowObjectsJson = reader.getRowObjectsJson();
       assert.deepEqual(rowObjectsJson, createTestAllTypesRowObjectsJson());
     });
@@ -1448,7 +1456,7 @@ ORDER BY name
   test('column names and types json', async () => {
     await withConnection(async (connection) => {
       const reader = await connection.runAndReadAll(
-        `from test_all_types(use_large_enum=true)`,
+        `from test_all_types(use_large_enum=true) select * exclude time_ns`,
       );
       const columnNamesAndTypesJson = reader.columnNamesAndTypesJson();
       assert.deepEqual(
@@ -1460,7 +1468,7 @@ ORDER BY name
   test('column name and type objects json', async () => {
     await withConnection(async (connection) => {
       const reader = await connection.runAndReadAll(
-        `from test_all_types(use_large_enum=true)`,
+        `from test_all_types(use_large_enum=true) select * exclude time_ns`,
       );
       const columnNameAndTypeObjectsJson =
         reader.columnNameAndTypeObjectsJson();
@@ -2721,7 +2729,9 @@ ORDER BY name
 
   test('iterate result stream rows json', async () => {
     await withConnection(async (connection) => {
-      const result = await connection.stream(`from test_all_types()`);
+      const result = await connection.stream(
+        `from test_all_types() select * exclude time_ns`,
+      );
       for await (const row of result.yieldRowsJson()) {
         assert.deepEqual(row, createTestAllTypesRowsJson());
       }
@@ -2730,7 +2740,9 @@ ORDER BY name
 
   test('iterate result stream object json', async () => {
     await withConnection(async (connection) => {
-      const result = await connection.stream(`from test_all_types()`);
+      const result = await connection.stream(
+        `from test_all_types() select * exclude time_ns`,
+      );
       for await (const row of result.yieldRowObjectJson()) {
         assert.deepEqual(row, createTestAllTypesRowObjectsJson());
       }

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-arm64",
-  "version": "1.4.4-r.3",
+  "version": "1.5.0-r.1",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-x64",
-  "version": "1.4.4-r.3",
+  "version": "1.5.0-r.1",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-arm64",
-  "version": "1.4.4-r.3",
+  "version": "1.5.0-r.1",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-x64",
-  "version": "1.4.4-r.3",
+  "version": "1.5.0-r.1",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-win32-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-arm64",
-  "version": "1.4.4-r.3",
+  "version": "1.5.0-r.1",
   "license": "MIT",
   "os": [
     "win32"

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-x64",
-  "version": "1.4.4-r.3",
+  "version": "1.5.0-r.1",
   "license": "MIT",
   "os": [
     "win32"

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings",
-  "version": "1.4.4-r.3",
+  "version": "1.5.0-r.1",
   "license": "MIT",
   "main": "./duckdb.js",
   "types": "./duckdb.d.ts",

--- a/bindings/scripts/fetch_libduckdb_linux_amd64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_amd64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.4/libduckdb-linux-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.5.0/libduckdb-linux-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_linux_arm64.py
+++ b/bindings/scripts/fetch_libduckdb_linux_arm64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.4/libduckdb-linux-arm64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.5.0/libduckdb-linux-arm64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_osx_universal.py
+++ b/bindings/scripts/fetch_libduckdb_osx_universal.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.4/libduckdb-osx-universal.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.5.0/libduckdb-osx-universal.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_windows_amd64.py
+++ b/bindings/scripts/fetch_libduckdb_windows_amd64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.4/libduckdb-windows-amd64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.5.0/libduckdb-windows-amd64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/scripts/fetch_libduckdb_windows_arm64.py
+++ b/bindings/scripts/fetch_libduckdb_windows_arm64.py
@@ -1,7 +1,7 @@
 import os
 from fetch_libduckdb import fetch_libduckdb
 
-zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.4.4/libduckdb-windows-arm64.zip"
+zip_url = "https://github.com/duckdb/duckdb/releases/download/v1.5.0/libduckdb-windows-arm64.zip"
 output_dir = os.path.join(os.path.dirname(__file__), "..", "libduckdb")
 files = [
   "duckdb.h",

--- a/bindings/test/config.test.ts
+++ b/bindings/test/config.test.ts
@@ -5,14 +5,18 @@ import { data } from './utils/expectedVectors';
 
 suite('config', () => {
   test('config_count', () => {
-    expect(duckdb.config_count()).toBe(202);
+    expect(duckdb.config_count()).toBe(227);
   });
   test('get_config_flag', () => {
     expect(duckdb.get_config_flag(0).name).toBe('access_mode');
-    expect(duckdb.get_config_flag(duckdb.config_count() - 1).name).toBe('variant_legacy_encoding');
+    expect(duckdb.get_config_flag(duckdb.config_count() - 1).name).toBe(
+      'unsafe_enable_version_guessing',
+    );
   });
   test('get_config_flag out of bounds', () => {
-    expect(() => duckdb.get_config_flag(-1)).toThrowError(/^Config option not found$/);
+    expect(() => duckdb.get_config_flag(-1)).toThrowError(
+      /^Config option not found$/,
+    );
   });
   test('create, set, and destroy', () => {
     const config = duckdb.create_config();
@@ -22,49 +26,58 @@ suite('config', () => {
   test('default duckdb_api without explicit config', async () => {
     const db = await duckdb.open();
     const connection = await duckdb.connect(db);
-    const result = await duckdb.query(connection, `select current_setting('duckdb_api') as duckdb_api`);
-      await expectResult(result, {
-        chunkCount: 1,
-        rowCount: 1,
-        columns: [
-          { name: 'duckdb_api', logicalType: { typeId: duckdb.Type.VARCHAR } },
-        ],
-        chunks: [
-          { rowCount: 1, vectors: [data(16, [true], ['node-neo-bindings'])]},
-        ],
-      });
+    const result = await duckdb.query(
+      connection,
+      `select current_setting('duckdb_api') as duckdb_api`,
+    );
+    await expectResult(result, {
+      chunkCount: 1,
+      rowCount: 1,
+      columns: [
+        { name: 'duckdb_api', logicalType: { typeId: duckdb.Type.VARCHAR } },
+      ],
+      chunks: [
+        { rowCount: 1, vectors: [data(16, [true], ['node-neo-bindings'])] },
+      ],
+    });
   });
   test('default duckdb_api with explicit config', async () => {
     const config = duckdb.create_config();
     const db = await duckdb.open(undefined, config);
     const connection = await duckdb.connect(db);
-    const result = await duckdb.query(connection, `select current_setting('duckdb_api') as duckdb_api`);
-      await expectResult(result, {
-        chunkCount: 1,
-        rowCount: 1,
-        columns: [
-          { name: 'duckdb_api', logicalType: { typeId: duckdb.Type.VARCHAR } },
-        ],
-        chunks: [
-          { rowCount: 1, vectors: [data(16, [true], ['node-neo-bindings'])]},
-        ],
-      });
+    const result = await duckdb.query(
+      connection,
+      `select current_setting('duckdb_api') as duckdb_api`,
+    );
+    await expectResult(result, {
+      chunkCount: 1,
+      rowCount: 1,
+      columns: [
+        { name: 'duckdb_api', logicalType: { typeId: duckdb.Type.VARCHAR } },
+      ],
+      chunks: [
+        { rowCount: 1, vectors: [data(16, [true], ['node-neo-bindings'])] },
+      ],
+    });
   });
   test('overriding duckdb_api', async () => {
     const config = duckdb.create_config();
     duckdb.set_config(config, 'duckdb_api', 'custom-duckdb-api');
     const db = await duckdb.open(undefined, config);
     const connection = await duckdb.connect(db);
-    const result = await duckdb.query(connection, `select current_setting('duckdb_api') as duckdb_api`);
-      await expectResult(result, {
-        chunkCount: 1,
-        rowCount: 1,
-        columns: [
-          { name: 'duckdb_api', logicalType: { typeId: duckdb.Type.VARCHAR } },
-        ],
-        chunks: [
-          { rowCount: 1, vectors: [data(16, [true], ['custom-duckdb-api'])]},
-        ],
-      });
+    const result = await duckdb.query(
+      connection,
+      `select current_setting('duckdb_api') as duckdb_api`,
+    );
+    await expectResult(result, {
+      chunkCount: 1,
+      rowCount: 1,
+      columns: [
+        { name: 'duckdb_api', logicalType: { typeId: duckdb.Type.VARCHAR } },
+      ],
+      chunks: [
+        { rowCount: 1, vectors: [data(16, [true], ['custom-duckdb-api'])] },
+      ],
+    });
   });
 });

--- a/bindings/test/constants.test.ts
+++ b/bindings/test/constants.test.ts
@@ -6,7 +6,7 @@ suite('constants', () => {
     expect(duckdb.sizeof_bool).toBe(1);
   });
   test('library_version', () => {
-    expect(duckdb.library_version()).toBe('v1.4.4');
+    expect(duckdb.library_version()).toBe('v1.5.0');
   });
   test('vector_size', () => {
     expect(duckdb.vector_size()).toBe(2048);

--- a/bindings/test/query.test.ts
+++ b/bindings/test/query.test.ts
@@ -67,7 +67,8 @@ suite('query', () => {
   });
   test('test_all_types()', async () => {
     await withConnection(async (connection) => {
-      const result = await duckdb.query(connection, `from test_all_types(use_large_enum=${useLargeEnum})`);
+      const result = await duckdb.query(connection,
+        `from test_all_types(use_large_enum=${useLargeEnum}) select * exclude time_ns`);
       const validity = [true, true, false];
       await expectResult(result, {
         chunkCount: 1,


### PR DESCRIPTION
In addition to the usual upgrade-related changes, I had to exclude the new TIME_NS type from queries to `test_all_types()`. Support for this new type is tracked by https://github.com/duckdb/duckdb-node-neo/issues/295.