### PR TITLE
fix scalar fn race

### DIFF
--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -832,8 +832,8 @@ void ScalarFunctionBindTSFNCallback(Napi::Env env, Napi::Function callback, Scal
   {
     std::lock_guard lk(*data->cv_mutex);
     data->done = true;
-  }
-  data->cv->notify_one();
+    data->cv->notify_one();
+  } 
 }
 
 ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromBindInfo(duckdb_bind_info bind_info) {
@@ -891,8 +891,8 @@ void ScalarFunctionMainTSFNCallback(Napi::Env env, Napi::Function callback, Scal
   {
     std::lock_guard lk(*data->cv_mutex);
     data->done = true;
+    data->cv->notify_one();
   }
-  data->cv->notify_one();
 }
 
 ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromFunctionInfo(duckdb_function_info function_info) {


### PR DESCRIPTION
Uses of scalar functions would sometimes (rarely) result in memory corruption. Investigation revealed that this was due to calling `notify_one` from the callback after releasing the mutex. The main function deletes the cv and mutex when it wakes up, and this could happen before the `notify_one` call returned. To fix this, `notify_one` is now called while the lock is held. See these [notes on notify_one](https://en.cppreference.com/w/cpp/thread/condition_variable/notify_one.html) for some details one how this works.