### PR TITLE
enable full TIME_NS supoort

### DIFF
--- a/api/src/DuckDBType.ts
+++ b/api/src/DuckDBType.ts
@@ -5,6 +5,7 @@ import { Json } from './Json';
 import { quotedIdentifier, quotedString } from './sql';
 import {
   DuckDBDateValue,
+  DuckDBTimeNSValue,
   DuckDBTimestampMillisecondsValue,
   DuckDBTimestampNanosecondsValue,
   DuckDBTimestampSecondsValue,
@@ -988,6 +989,12 @@ export class DuckDBTimeNSType extends BaseDuckDBType<DuckDBTypeId.TIME_NS> {
   public static readonly instance = new DuckDBTimeNSType();
   public static create(alias?: string): DuckDBTimeNSType {
     return alias ? new DuckDBTimeNSType(alias) : DuckDBTimeNSType.instance;
+  }
+  public get max() {
+    return DuckDBTimeNSValue.Max;
+  }
+  public get min() {
+    return DuckDBTimeNSValue.Min;
   }
 }
 export const TIME_NS = DuckDBTimeNSType.instance;

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -42,6 +42,7 @@ import {
   DuckDBResult,
   DuckDBSmallIntVector,
   DuckDBStructVector,
+  DuckDBTimeNSVector,
   DuckDBTimeTZValue,
   DuckDBTimeTZVector,
   DuckDBTimeValue,
@@ -935,14 +936,14 @@ ORDER BY name
   test('should support all data types', async () => {
     await withConnection(async (connection) => {
       const result = await connection.run(
-        'from test_all_types(use_large_enum=true) select * exclude (time_ns, geometry)',
+        'from test_all_types(use_large_enum=true) select * exclude (geometry)',
       );
       assertColumns(result, createTestAllTypesColumnNameAndTypeObjects());
 
       const chunk = await result.fetchChunk();
       assert.isDefined(chunk);
       if (chunk) {
-        assert.strictEqual(chunk.columnCount, 54);
+        assert.strictEqual(chunk.columnCount, 55);
         assert.strictEqual(chunk.rowCount, 3);
 
         const testAllTypesColumns = createTestAllTypesColumns();
@@ -1043,6 +1044,8 @@ ORDER BY name
         assertValues(chunk, 52, DuckDBArrayVector, testAllTypesColumns[52]);
         // list_of_fixed_int_array
         assertValues(chunk, 53, DuckDBListVector, testAllTypesColumns[53]);
+        // time_ns
+        assertValues(chunk, 54, DuckDBTimeNSVector, testAllTypesColumns[54]);
       }
     });
   });
@@ -1420,7 +1423,7 @@ ORDER BY name
   test('columns json', async () => {
     await withConnection(async (connection) => {
       const reader = await connection.runAndReadAll(
-        `from test_all_types() select * exclude (time_ns, geometry)`,
+        `from test_all_types() select * exclude (geometry)`,
       );
       const columnsJson = reader.getColumnsJson();
       assert.deepEqual(columnsJson, createTestAllTypesColumnsJson());
@@ -1429,7 +1432,7 @@ ORDER BY name
   test('columns object json', async () => {
     await withConnection(async (connection) => {
       const reader = await connection.runAndReadAll(
-        `from test_all_types() select * exclude (time_ns, geometry)`,
+        `from test_all_types() select * exclude (geometry)`,
       );
       const columnsJson = reader.getColumnsObjectJson();
       assert.deepEqual(columnsJson, createTestAllTypesColumnsObjectJson());
@@ -1438,7 +1441,7 @@ ORDER BY name
   test('rows json', async () => {
     await withConnection(async (connection) => {
       const reader = await connection.runAndReadAll(
-        `from test_all_types() select * exclude (time_ns, geometry)`,
+        `from test_all_types() select * exclude (geometry)`,
       );
       const rowsJson = reader.getRowsJson();
       assert.deepEqual(rowsJson, createTestAllTypesRowsJson());
@@ -1447,7 +1450,7 @@ ORDER BY name
   test('row objects json', async () => {
     await withConnection(async (connection) => {
       const reader = await connection.runAndReadAll(
-        `from test_all_types() select * exclude (time_ns, geometry)`,
+        `from test_all_types() select * exclude (geometry)`,
       );
       const rowObjectsJson = reader.getRowObjectsJson();
       assert.deepEqual(rowObjectsJson, createTestAllTypesRowObjectsJson());
@@ -1456,7 +1459,7 @@ ORDER BY name
   test('column names and types json', async () => {
     await withConnection(async (connection) => {
       const reader = await connection.runAndReadAll(
-        `from test_all_types(use_large_enum=true) select * exclude (time_ns, geometry)`,
+        `from test_all_types(use_large_enum=true) select * exclude (geometry)`,
       );
       const columnNamesAndTypesJson = reader.columnNamesAndTypesJson();
       assert.deepEqual(
@@ -1468,7 +1471,7 @@ ORDER BY name
   test('column name and type objects json', async () => {
     await withConnection(async (connection) => {
       const reader = await connection.runAndReadAll(
-        `from test_all_types(use_large_enum=true) select * exclude (time_ns, geometry)`,
+        `from test_all_types(use_large_enum=true) select * exclude (geometry)`,
       );
       const columnNameAndTypeObjectsJson =
         reader.columnNameAndTypeObjectsJson();
@@ -2730,7 +2733,7 @@ ORDER BY name
   test('iterate result stream rows json', async () => {
     await withConnection(async (connection) => {
       const result = await connection.stream(
-        `from test_all_types() select * exclude (time_ns, geometry)`,
+        `from test_all_types() select * exclude (geometry)`,
       );
       for await (const row of result.yieldRowsJson()) {
         assert.deepEqual(row, createTestAllTypesRowsJson());
@@ -2741,7 +2744,7 @@ ORDER BY name
   test('iterate result stream object json', async () => {
     await withConnection(async (connection) => {
       const result = await connection.stream(
-        `from test_all_types() select * exclude (time_ns, geometry)`,
+        `from test_all_types() select * exclude (geometry)`,
       );
       for await (const row of result.yieldRowObjectJson()) {
         assert.deepEqual(row, createTestAllTypesRowObjectsJson());

--- a/api/test/util/testAllTypes.ts
+++ b/api/test/util/testAllTypes.ts
@@ -32,6 +32,7 @@ import {
   STRUCT,
   structValue,
   TIME,
+  TIME_NS,
   TIMESTAMP,
   TIMESTAMP_MS,
   TIMESTAMP_NS,
@@ -778,6 +779,13 @@ export function createTestAllTypesData(): ColumnNameTypeAndValues[] {
         ],
         null,
       ]
+    ),
+    col(
+      'time_ns',
+      TIME_NS,
+      { typeId: 39 },
+      [TIME_NS.min, TIME_NS.max, null],
+      [String(TIME_NS.min), String(TIME_NS.max), null]
     ),
   ];
 }

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -1540,6 +1540,9 @@ Napi::Object CreateTypeEnum(Napi::Env env) {
   DefineEnumMember(typeEnum, "ANY", 34);
   DefineEnumMember(typeEnum, "BIGNUM", 35);
   DefineEnumMember(typeEnum, "SQLNULL", 36);
+  DefineEnumMember(typeEnum, "STRING_LITERAL", 37);
+  DefineEnumMember(typeEnum, "INTEGER_LITERAL", 38);
+  DefineEnumMember(typeEnum, "TIME_NS", 39);
   return typeEnum;
 }
 

--- a/bindings/test/query.test.ts
+++ b/bindings/test/query.test.ts
@@ -22,6 +22,7 @@ import {
   SMALLINT,
   STRUCT,
   TIME,
+  TIME_NS,
   TIME_TZ,
   TIMESTAMP,
   TIMESTAMP_MS,
@@ -68,7 +69,7 @@ suite('query', () => {
   test('test_all_types()', async () => {
     await withConnection(async (connection) => {
       const result = await duckdb.query(connection,
-        `from test_all_types(use_large_enum=${useLargeEnum}) select * exclude (time_ns, geometry)`);
+        `from test_all_types(use_large_enum=${useLargeEnum}) select * exclude (geometry)`);
       const validity = [true, true, false];
       await expectResult(result, {
         chunkCount: 1,
@@ -131,6 +132,7 @@ suite('query', () => {
           { name: 'struct_of_fixed_array', logicalType: STRUCT(ENTRY('a', ARRAY(INTEGER, 3)), ENTRY('b', ARRAY(VARCHAR, 3))) },
           { name: 'fixed_array_of_int_list', logicalType: ARRAY(LIST(INTEGER), 3) },
           { name: 'list_of_fixed_int_array', logicalType: LIST(ARRAY(INTEGER, 3)) },
+          { name: 'time_ns', logicalType: TIME_NS },
         ],
         chunks: [
           {
@@ -257,14 +259,14 @@ suite('query', () => {
                     [null, 2, 3, 4, 5, 6, null, 2, 3, 4, 5, 6, null, 2, 3, 4, 5, 6])
                 )
               ), // 53: list_of_fixed_int_array
+              data(8, validity, [0n, 86400000000000n, null]), // 54: time_ns
             ],
           },
         ],
       });
     });
   });
-  // TODO: Need DuckDB fix to LogicalTypeIdFromC and LogicalTypeIdToC
-  test.skip('time_ns', async () => {
+  test('time_ns', async () => {
     await withConnection(async (connection) => {
       const result = await duckdb.query(connection, `select '12:34:56.789123456'::time_ns as time_ns`);
       await expectResult(result, {
@@ -274,7 +276,7 @@ suite('query', () => {
           { name: 'time_ns', logicalType: { typeId: duckdb.Type.TIME_NS } },
         ],
         chunks: [
-          { rowCount: 1, vectors: [data(4, [true], [45296789123456n])]},
+          { rowCount: 1, vectors: [data(8, [true], [45296789123456n])]},
         ],
       });
     });

--- a/bindings/test/values.test.ts
+++ b/bindings/test/values.test.ts
@@ -34,6 +34,7 @@ import {
   SMALLINT,
   STRUCT,
   TIME,
+  TIME_NS,
   TIME_TZ,
   TIMESTAMP,
   TIMESTAMP_MS,
@@ -194,8 +195,7 @@ suite('values', () => {
   test('time_ns', () => {
     const input: TimeNS = { nanos: 86400000000000n };
     const time_ns_value = duckdb.create_time_ns(input);
-    // TODO: Need DuckDB fix to LogicalTypeIdFromC and LogicalTypeIdToC
-    // expectLogicalType(duckdb.get_value_type(time_ns_value), TIME_NS);
+    expectLogicalType(duckdb.get_value_type(time_ns_value), TIME_NS);
     expect(duckdb.get_time_ns(time_ns_value)).toStrictEqual(input);
   });
   test('time_tz', () => {


### PR DESCRIPTION
Enable tests for TIME_NS now that the C API supports it, and fix up a couple things (bindings enum value, api min/max values) to enable full support for this type.