### PR TITLE
VARIANT append & bind support

### DIFF
--- a/api/src/DuckDBAppender.ts
+++ b/api/src/DuckDBAppender.ts
@@ -19,6 +19,7 @@ import {
   TIMESTAMPTZ,
   TIMETZ,
   UUID,
+  VARIANT,
 } from './DuckDBType';
 import { typeForValue } from './typeForValue';
 import {
@@ -41,6 +42,7 @@ import {
   DuckDBUnionValue,
   DuckDBUUIDValue,
   DuckDBValue,
+  DuckDBVariantValue,
   listValue,
   structValue,
 } from './values';
@@ -190,6 +192,9 @@ export class DuckDBAppender {
   }
   public appendBigNum(value: bigint) {
     this.appendValue(value, BIGNUM);
+  }
+  public appendVariant(value: DuckDBVariantValue) {
+    this.appendValue(value, VARIANT);
   }
   public appendNull() {
     duckdb.append_null(this.appender);

--- a/api/src/DuckDBAppender.ts
+++ b/api/src/DuckDBAppender.ts
@@ -193,7 +193,11 @@ export class DuckDBAppender {
   public appendBigNum(value: bigint) {
     this.appendValue(value, BIGNUM);
   }
-  public appendVariant(value: DuckDBVariantValue) {
+  public appendVariant(value: DuckDBVariantValue | null) {
+    if (value === null) {
+      this.appendNull();
+      return;
+    }
     this.appendValue(value, VARIANT);
   }
   public appendNull() {

--- a/api/src/DuckDBPreparedStatement.ts
+++ b/api/src/DuckDBPreparedStatement.ts
@@ -254,7 +254,14 @@ export class DuckDBPreparedStatement {
   public bindBit(parameterIndex: number, value: DuckDBBitValue) {
     this.bindValue(parameterIndex, value, BIT);
   }
-  public bindVariant(parameterIndex: number, value: DuckDBVariantValue) {
+  public bindVariant(
+    parameterIndex: number,
+    value: DuckDBVariantValue | null
+  ) {
+    if (value === null) {
+      this.bindNull(parameterIndex);
+      return;
+    }
     this.bindValue(parameterIndex, value, VARIANT);
   }
   public bindNull(parameterIndex: number) {

--- a/api/src/DuckDBPreparedStatement.ts
+++ b/api/src/DuckDBPreparedStatement.ts
@@ -21,6 +21,7 @@ import {
   TIMESTAMPTZ,
   TIMETZ,
   UUID,
+  VARIANT,
 } from './DuckDBType';
 import { DuckDBTypeId } from './DuckDBTypeId';
 import { StatementType } from './enums';
@@ -45,6 +46,7 @@ import {
   DuckDBUnionValue,
   DuckDBUUIDValue,
   DuckDBValue,
+  DuckDBVariantValue,
   listValue,
   structValue,
 } from './values';
@@ -251,6 +253,9 @@ export class DuckDBPreparedStatement {
   }
   public bindBit(parameterIndex: number, value: DuckDBBitValue) {
     this.bindValue(parameterIndex, value, BIT);
+  }
+  public bindVariant(parameterIndex: number, value: DuckDBVariantValue) {
+    this.bindValue(parameterIndex, value, VARIANT);
   }
   public bindNull(parameterIndex: number) {
     duckdb.bind_null(this.prepared_statement, parameterIndex);

--- a/api/src/DuckDBValueConverters.ts
+++ b/api/src/DuckDBValueConverters.ts
@@ -305,7 +305,7 @@ export function objectFromUnionValue<T>(
 /**
  * Converter for VARIANT values: unwraps the `DuckDBVariantValue` wrapper
  * and recursively walks the inner value, re-dispatching each scalar leaf
- * through the supplied converter with a freshly-derived `DuckDBType`.
+ * through the supplied converter.
  *
  * A walker is needed (rather than just dispatching through the converter)
  * because VARIANT containers are *heterogeneous* — items in a list or
@@ -313,8 +313,9 @@ export function objectFromUnionValue<T>(
  * `arrayFromListValue` / `objectFromStructValue` / `objectArrayFromMapValue`
  * assume a homogeneous element type pulled from the enclosing
  * `DuckDBListType` / `DuckDBStructType` / `DuckDBMapType`. The walker
- * emits the same output shape those converters do, but recovers each
- * child's type via `typeForValue`.
+ * emits the same output shape those converters do, and prefers the
+ * `DuckDBVariantValue.type` recorded by the decoder over `typeForValue`
+ * inference whenever a wrapper is encountered.
  */
 export function fromVariantValue<T>(
   value: DuckDBValue,
@@ -324,15 +325,21 @@ export function fromVariantValue<T>(
   if (!(value instanceof DuckDBVariantValue)) {
     throw new Error(`Expected DuckDBVariantValue`);
   }
-  return convertVariantInner(value.value, converter);
+  return convertVariantInner(value.value, converter, value.type);
 }
 
 function convertVariantInner<T>(
   value: DuckDBValue,
-  converter: DuckDBValueConverter<T>
+  converter: DuckDBValueConverter<T>,
+  typeHint?: DuckDBType
 ): T | null {
   if (value === null) {
     return null;
+  }
+  if (value instanceof DuckDBVariantValue) {
+    // Variant-of-variant (or a wrapped child inside a LIST(VARIANT)).
+    // Prefer the wrapper's exact type as the hint for further walking.
+    return convertVariantInner(value.value, converter, value.type ?? typeHint);
   }
   if (value instanceof DuckDBListValue || value instanceof DuckDBArrayValue) {
     return value.items.map((item) =>
@@ -358,13 +365,11 @@ function convertVariantInner<T>(
       value: convertVariantInner(value.value, converter),
     } as unknown as T;
   }
-  if (value instanceof DuckDBVariantValue) {
-    // Variant-of-variant: unwrap and continue.
-    return convertVariantInner(value.value, converter);
-  }
   // Scalar (or non-recursable rich value like DECIMAL, BLOB, DATE, etc.):
-  // dispatch through the regular converter with its own recovered type.
-  const inferredType = typeForValue(value);
+  // dispatch through the regular converter. Use `typeHint` (carried in
+  // from a wrapper) for type fidelity when available; fall back to
+  // `typeForValue` otherwise.
+  const inferredType = typeHint ?? typeForValue(value);
   // `typeForValue` infers BIGINT for any JS integer number outside INT32
   // range (e.g. a UINT32 VARIANT payload of 4_294_967_295). The BIGINT
   // converters expect a `bigint`, not a `number`, and would otherwise

--- a/api/src/DuckDBVector.ts
+++ b/api/src/DuckDBVector.ts
@@ -3,7 +3,14 @@ import os from 'os';
 import { varintDecode } from './conversion/varintDecode';
 import { DuckDBLogicalType } from './DuckDBLogicalType';
 import {
+  BIGINT,
+  BIGNUM,
+  BIT,
   BLOB,
+  BOOLEAN,
+  DATE,
+  DECIMAL,
+  DOUBLE,
   DuckDBArrayType,
   DuckDBBigIntType,
   DuckDBBigNumType,
@@ -42,11 +49,32 @@ import {
   DuckDBUnionType,
   DuckDBVarCharType,
   DuckDBVariantType,
+  FLOAT,
+  GEOMETRY,
+  HUGEINT,
+  INTEGER,
+  INTERVAL,
   LIST,
+  SMALLINT,
+  SQLNULL,
   STRUCT,
+  TIME,
+  TIME_NS,
+  TIMESTAMP,
+  TIMESTAMPTZ,
+  TIMESTAMP_MS,
+  TIMESTAMP_NS,
+  TIMESTAMP_S,
+  TIMETZ,
+  TINYINT,
+  UBIGINT,
+  UHUGEINT,
   UINTEGER,
+  USMALLINT,
   UTINYINT,
+  UUID,
   VARCHAR,
+  VARIANT,
 } from './DuckDBType';
 import { DuckDBTypeId } from './DuckDBTypeId';
 import {
@@ -3990,7 +4018,8 @@ export class DuckDBVariantVector extends DuckDBVector<DuckDBVariantValue> {
       keysOffset: this.keysList.getEntryOffset(itemIndex),
       keysLength: this.keysList.getEntryLength(itemIndex),
     };
-    return new DuckDBVariantValue(this.decodeNode(0, row));
+    const root = this.decodeNode(0, row);
+    return new DuckDBVariantValue(root.value, root.type);
   }
 
   public override setItem(
@@ -4022,10 +4051,17 @@ export class DuckDBVariantVector extends DuckDBVector<DuckDBVariantValue> {
    * absolute backing-array offsets they begin at. All recursive calls
    * share the same `row`; only `valueIndex` changes.
    *
+   * Returns both the decoded value and the `DuckDBType` corresponding to
+   * the node's on-disk tag, so the top-level caller can attach the type
+   * to the resulting `DuckDBVariantValue` for round-trip fidelity.
+   *
    * Throws if any index decoded from the blob falls outside its row-local
    * list slice — guards against malformed or hostile VARIANT payloads.
    */
-  private decodeNode(valueIndex: number, row: VariantRow): DuckDBValue {
+  private decodeNode(
+    valueIndex: number,
+    row: VariantRow
+  ): { value: DuckDBValue; type: DuckDBType } {
     if (valueIndex >= row.valuesLength) {
       throw new Error(
         `Malformed VARIANT: value_index ${valueIndex} out of bounds (row values length ${row.valuesLength})`
@@ -4037,82 +4073,134 @@ export class DuckDBVariantVector extends DuckDBVector<DuckDBVariantValue> {
     const { blob, view } = row;
     switch (tag as VariantLogicalType) {
       case VariantLogicalType.VARIANT_NULL:
-        return null;
+        return { value: null, type: SQLNULL };
       case VariantLogicalType.BOOL_TRUE:
-        return true;
+        return { value: true, type: BOOLEAN };
       case VariantLogicalType.BOOL_FALSE:
-        return false;
+        return { value: false, type: BOOLEAN };
       case VariantLogicalType.INT8:
-        return view.getInt8(byteOffset);
+        return { value: view.getInt8(byteOffset), type: TINYINT };
       case VariantLogicalType.INT16:
-        return getInt16(view, byteOffset);
+        return { value: getInt16(view, byteOffset), type: SMALLINT };
       case VariantLogicalType.INT32:
-        return getInt32(view, byteOffset);
+        return { value: getInt32(view, byteOffset), type: INTEGER };
       case VariantLogicalType.INT64:
-        return getInt64(view, byteOffset);
+        return { value: getInt64(view, byteOffset), type: BIGINT };
       case VariantLogicalType.INT128:
-        return getInt128(view, byteOffset);
+        return { value: getInt128(view, byteOffset), type: HUGEINT };
       case VariantLogicalType.UINT8:
-        return getUInt8(view, byteOffset);
+        return { value: getUInt8(view, byteOffset), type: UTINYINT };
       case VariantLogicalType.UINT16:
-        return getUInt16(view, byteOffset);
+        return { value: getUInt16(view, byteOffset), type: USMALLINT };
       case VariantLogicalType.UINT32:
-        return getUInt32(view, byteOffset);
+        return { value: getUInt32(view, byteOffset), type: UINTEGER };
       case VariantLogicalType.UINT64:
-        return getUInt64(view, byteOffset);
+        return { value: getUInt64(view, byteOffset), type: UBIGINT };
       case VariantLogicalType.UINT128:
-        return getUInt128(view, byteOffset);
+        return { value: getUInt128(view, byteOffset), type: UHUGEINT };
       case VariantLogicalType.FLOAT:
-        return view.getFloat32(byteOffset, littleEndian);
+        return {
+          value: view.getFloat32(byteOffset, littleEndian),
+          type: FLOAT,
+        };
       case VariantLogicalType.DOUBLE:
-        return view.getFloat64(byteOffset, littleEndian);
+        return {
+          value: view.getFloat64(byteOffset, littleEndian),
+          type: DOUBLE,
+        };
       case VariantLogicalType.UUID:
-        return DuckDBUUIDValue.fromStoredHugeInt(getInt128(view, byteOffset));
+        return {
+          value: DuckDBUUIDValue.fromStoredHugeInt(getInt128(view, byteOffset)),
+          type: UUID,
+        };
       case VariantLogicalType.DATE:
-        return new DuckDBDateValue(getInt32(view, byteOffset));
+        return {
+          value: new DuckDBDateValue(getInt32(view, byteOffset)),
+          type: DATE,
+        };
       case VariantLogicalType.TIME_MICROS:
-        return new DuckDBTimeValue(getInt64(view, byteOffset));
+        return {
+          value: new DuckDBTimeValue(getInt64(view, byteOffset)),
+          type: TIME,
+        };
       case VariantLogicalType.TIME_NANOS:
-        return new DuckDBTimeNSValue(getInt64(view, byteOffset));
+        return {
+          value: new DuckDBTimeNSValue(getInt64(view, byteOffset)),
+          type: TIME_NS,
+        };
       case VariantLogicalType.TIME_MICROS_TZ:
-        return DuckDBTimeTZValue.fromBits(getUInt64(view, byteOffset));
+        return {
+          value: DuckDBTimeTZValue.fromBits(getUInt64(view, byteOffset)),
+          type: TIMETZ,
+        };
       case VariantLogicalType.TIMESTAMP_SEC:
-        return new DuckDBTimestampSecondsValue(getInt64(view, byteOffset));
+        return {
+          value: new DuckDBTimestampSecondsValue(getInt64(view, byteOffset)),
+          type: TIMESTAMP_S,
+        };
       case VariantLogicalType.TIMESTAMP_MILIS:
-        return new DuckDBTimestampMillisecondsValue(getInt64(view, byteOffset));
+        return {
+          value: new DuckDBTimestampMillisecondsValue(
+            getInt64(view, byteOffset)
+          ),
+          type: TIMESTAMP_MS,
+        };
       case VariantLogicalType.TIMESTAMP_MICROS:
-        return new DuckDBTimestampValue(getInt64(view, byteOffset));
+        return {
+          value: new DuckDBTimestampValue(getInt64(view, byteOffset)),
+          type: TIMESTAMP,
+        };
       case VariantLogicalType.TIMESTAMP_NANOS:
-        return new DuckDBTimestampNanosecondsValue(getInt64(view, byteOffset));
+        return {
+          value: new DuckDBTimestampNanosecondsValue(
+            getInt64(view, byteOffset)
+          ),
+          type: TIMESTAMP_NS,
+        };
       case VariantLogicalType.TIMESTAMP_MICROS_TZ:
-        return new DuckDBTimestampTZValue(getInt64(view, byteOffset));
+        return {
+          value: new DuckDBTimestampTZValue(getInt64(view, byteOffset)),
+          type: TIMESTAMPTZ,
+        };
       case VariantLogicalType.INTERVAL:
-        return new DuckDBIntervalValue(
-          getInt32(view, byteOffset),
-          getInt32(view, byteOffset + 4),
-          getInt64(view, byteOffset + 8)
-        );
+        return {
+          value: new DuckDBIntervalValue(
+            getInt32(view, byteOffset),
+            getInt32(view, byteOffset + 4),
+            getInt64(view, byteOffset + 8)
+          ),
+          type: INTERVAL,
+        };
       case VariantLogicalType.VARCHAR: {
         const bytes = readVarintBytes(view, byteOffset, blob);
-        return textDecoder.decode(bytes);
+        return { value: textDecoder.decode(bytes), type: VARCHAR };
       }
       case VariantLogicalType.BLOB: {
         // Copy out — the bytes alias the underlying vector storage, which
         // we don't want to share through to user code.
         const bytes = readVarintBytes(view, byteOffset, blob);
-        return new DuckDBBlobValue(new Uint8Array(bytes));
+        return {
+          value: new DuckDBBlobValue(new Uint8Array(bytes)),
+          type: BLOB,
+        };
       }
       case VariantLogicalType.BITSTRING: {
         const bytes = readVarintBytes(view, byteOffset, blob);
-        return new DuckDBBitValue(new Uint8Array(bytes));
+        return {
+          value: new DuckDBBitValue(new Uint8Array(bytes)),
+          type: BIT,
+        };
       }
       case VariantLogicalType.BIGNUM: {
         const bytes = readVarintBytes(view, byteOffset, blob);
-        return getBigNumFromBytes(bytes);
+        return { value: getBigNumFromBytes(bytes), type: BIGNUM };
       }
       case VariantLogicalType.GEOMETRY: {
         const bytes = readVarintBytes(view, byteOffset, blob);
-        return new DuckDBGeometryValue(new Uint8Array(bytes));
+        return {
+          value: new DuckDBGeometryValue(new Uint8Array(bytes)),
+          type: GEOMETRY,
+        };
       }
       case VariantLogicalType.DECIMAL: {
         const wParse = varintDecode(view, byteOffset);
@@ -4132,12 +4220,16 @@ export class DuckDBVariantVector extends DuckDBVector<DuckDBVariantValue> {
         } else {
           throw new Error(`VARIANT DECIMAL width too large: ${width}`);
         }
-        return new DuckDBDecimalValue(intValue, width, scale);
+        return {
+          value: new DuckDBDecimalValue(intValue, width, scale),
+          type: DECIMAL(width, scale),
+        };
       }
       case VariantLogicalType.OBJECT: {
         const { childCount, childrenIdx } = readNestedHeader(view, byteOffset);
         this.checkChildrenSlice(childrenIdx, childCount, row);
         const entries: { [name: string]: DuckDBValue } = {};
+        const fields: { [name: string]: DuckDBType } = {};
         for (let k = 0; k < childCount; k++) {
           const entryAbs = row.childrenOffset + childrenIdx + k;
           const keyIdx = this.keysIdxVec.getItem(entryAbs) as number;
@@ -4150,22 +4242,44 @@ export class DuckDBVariantVector extends DuckDBVector<DuckDBVariantValue> {
             row.keysOffset + keyIdx
           ) as string;
           const valIdx = this.valuesIdxVec.getItem(entryAbs) as number;
-          entries[keyStr] = this.decodeNode(valIdx, row);
+          const child = this.decodeNode(valIdx, row);
+          entries[keyStr] = child.value;
+          fields[keyStr] = child.type;
         }
-        return new DuckDBStructValue(entries);
+        return {
+          value: new DuckDBStructValue(entries),
+          type: STRUCT(fields),
+        };
       }
       case VariantLogicalType.ARRAY: {
         const { childCount, childrenIdx } = readNestedHeader(view, byteOffset);
         this.checkChildrenSlice(childrenIdx, childCount, row);
-        const items: DuckDBValue[] = [];
+        // Decode all children first so we can decide whether their types
+        // are uniform. If they are, use `LIST(commonType)` with bare items
+        // — that's a Value the C API's create_list_value will accept, and
+        // it round-trips through bind/append cleanly. Otherwise fall back
+        // to `LIST(VARIANT)` with each item wrapped to preserve its type
+        // (heterogeneous case: round-trip via prepared bind is not
+        // supported by create_list_value).
+        const children: { value: DuckDBValue; type: DuckDBType }[] = [];
         for (let k = 0; k < childCount; k++) {
           const entryAbs = row.childrenOffset + childrenIdx + k;
           const valIdx = this.valuesIdxVec.getItem(entryAbs) as number;
-          items.push(
-            this.decodeNode(valIdx, row)
-          );
+          children.push(this.decodeNode(valIdx, row));
         }
-        return new DuckDBListValue(items);
+        const commonType = uniformVariantChildType(children);
+        if (commonType !== null) {
+          return {
+            value: new DuckDBListValue(children.map((c) => c.value)),
+            type: LIST(commonType),
+          };
+        }
+        return {
+          value: new DuckDBListValue(
+            children.map((c) => new DuckDBVariantValue(c.value, c.type)),
+          ),
+          type: LIST(VARIANT),
+        };
       }
       default:
         throw new Error(`Unknown VARIANT type id: ${tag}`);
@@ -4184,6 +4298,27 @@ export class DuckDBVariantVector extends DuckDBVector<DuckDBVariantValue> {
       );
     }
   }
+}
+
+/**
+ * Returns the shared DuckDBType if every child has the same canonical type
+ * (via `toString` equality), or `null` if any child differs. Used to pick
+ * between `LIST(commonType)` and `LIST(VARIANT)` for a decoded ARRAY.
+ */
+function uniformVariantChildType(
+  children: { value: DuckDBValue; type: DuckDBType }[]
+): DuckDBType | null {
+  if (children.length === 0) {
+    return null;
+  }
+  const first = children[0].type;
+  const firstString = first.toString();
+  for (let i = 1; i < children.length; i++) {
+    if (children[i].type.toString() !== firstString) {
+      return null;
+    }
+  }
+  return first;
 }
 
 /** Per-row state shared across recursive VARIANT decode calls. */

--- a/api/src/DuckDBVector.ts
+++ b/api/src/DuckDBVector.ts
@@ -4255,12 +4255,14 @@ export class DuckDBVariantVector extends DuckDBVector<DuckDBVariantValue> {
         const { childCount, childrenIdx } = readNestedHeader(view, byteOffset);
         this.checkChildrenSlice(childrenIdx, childCount, row);
         // Decode all children first so we can decide whether their types
-        // are uniform. If they are, use `LIST(commonType)` with bare items
-        // — that's a Value the C API's create_list_value will accept, and
-        // it round-trips through bind/append cleanly. Otherwise fall back
-        // to `LIST(VARIANT)` with each item wrapped to preserve its type
-        // (heterogeneous case: round-trip via prepared bind is not
-        // supported by create_list_value).
+        // are uniform. If they are (treating SQLNULL as compatible with
+        // any sibling, so e.g. [1, 2, null] reads as LIST(UBIGINT)), use
+        // `LIST(commonType)` with bare items — that's a Value the C API's
+        // create_list_value will accept, and it round-trips through
+        // bind/append cleanly. Otherwise fall back to `LIST(VARIANT)`
+        // with non-null items wrapped to preserve their type; null items
+        // remain bare to match how column-level LIST(VARIANT) decodes a
+        // null element.
         const children: { value: DuckDBValue; type: DuckDBType }[] = [];
         for (let k = 0; k < childCount; k++) {
           const entryAbs = row.childrenOffset + childrenIdx + k;
@@ -4276,7 +4278,11 @@ export class DuckDBVariantVector extends DuckDBVector<DuckDBVariantValue> {
         }
         return {
           value: new DuckDBListValue(
-            children.map((c) => new DuckDBVariantValue(c.value, c.type)),
+            children.map((c) =>
+              c.value === null
+                ? null
+                : new DuckDBVariantValue(c.value, c.type),
+            ),
           ),
           type: LIST(VARIANT),
         };
@@ -4301,24 +4307,47 @@ export class DuckDBVariantVector extends DuckDBVector<DuckDBVariantValue> {
 }
 
 /**
- * Returns the shared DuckDBType if every child has the same canonical type
- * (via `toString` equality), or `null` if any child differs. Used to pick
- * between `LIST(commonType)` and `LIST(VARIANT)` for a decoded ARRAY.
+ * Returns the shared DuckDBType if every non-null child has the same type,
+ * or `null` if non-null children differ. Used to pick between
+ * `LIST(commonType)` and `LIST(VARIANT)` for a decoded ARRAY.
+ *
+ * SQLNULL children are treated as compatible with any sibling — that way a
+ * very common JSON shape like `[1, 2, null]` decodes as `LIST(UBIGINT)`
+ * with a bare null element rather than `LIST(VARIANT)`. An array whose
+ * children are all SQLNULL (including the empty array) collapses to
+ * SQLNULL itself — DuckDB casts `LIST(SQLNULL)` to VARIANT for round-trip,
+ * but a `LIST(VARIANT)` of nulls or an empty `LIST(VARIANT)` doesn't
+ * survive `create_list_value`.
  */
 function uniformVariantChildType(
   children: { value: DuckDBValue; type: DuckDBType }[]
 ): DuckDBType | null {
-  if (children.length === 0) {
-    return null;
-  }
-  const first = children[0].type;
-  const firstString = first.toString();
-  for (let i = 1; i < children.length; i++) {
-    if (children[i].type.toString() !== firstString) {
+  let common: DuckDBType | null = null;
+  let commonKey: string | null = null;
+  for (const child of children) {
+    if (child.type.typeId === DuckDBTypeId.SQLNULL) {
+      continue;
+    }
+    const key = typeKey(child.type);
+    if (common === null) {
+      common = child.type;
+      commonKey = key;
+    } else if (key !== commonKey) {
       return null;
     }
   }
-  return first;
+  // All children (if any) are SQLNULL: collapse to SQLNULL.
+  return common ?? SQLNULL;
+}
+
+/**
+ * Returns a canonical string for a DuckDBType, suitable for equality
+ * comparison between types produced by the same decode pass. Uses the
+ * structured `toJson()` representation rather than the SQL-syntactic
+ * `toString()` so nested types compare structurally.
+ */
+function typeKey(type: DuckDBType): string {
+  return JSON.stringify(type.toJson());
 }
 
 /** Per-row state shared across recursive VARIANT decode calls. */

--- a/api/src/createValue.ts
+++ b/api/src/createValue.ts
@@ -1,6 +1,7 @@
 import duckdb, { Value } from '@duckdb/node-bindings';
 import { DuckDBType } from './DuckDBType';
 import { DuckDBTypeId } from './DuckDBTypeId';
+import { typeForValue } from './typeForValue';
 import {
   DuckDBArrayValue,
   DuckDBBitValue,
@@ -23,6 +24,7 @@ import {
   DuckDBUnionValue,
   DuckDBUUIDValue,
   DuckDBValue,
+  DuckDBVariantValue,
 } from './values';
 
 export function createValue(type: DuckDBType, input: DuckDBValue): Value {
@@ -279,13 +281,25 @@ export function createValue(type: DuckDBType, input: DuckDBValue): Value {
         // return duckdb.create_blob(input.bytes);
       }
       throw new Error(`input is not a DuckDBGeometryValue`);
-    case DuckDBTypeId.VARIANT:
-      // Surface the same actionable message regardless of input shape — a
-      // caller who first tries a raw value and then wraps it in
-      // `variantValue(...)` should not see two different errors. When write
-      // is implemented, reintroduce the `input instanceof DuckDBVariantValue`
-      // type-mismatch path.
-      throw new Error(`Creating values of type VARIANT is not yet supported.`);
+    case DuckDBTypeId.VARIANT: {
+      // VARIANT has no direct create primitive in the C API; DuckDB
+      // implicitly casts from any compatible type when the target column
+      // or parameter is VARIANT. Recurse on the input's natural type so
+      // we hand DuckDB a Value it can cast.
+      //
+      // If the input is a DuckDBVariantValue, prefer its embedded `.type`
+      // (set by the decoder from the on-disk variant tag) so heterogeneous
+      // content round-trips faithfully. Fall back to `typeForValue` when
+      // no type hint is attached.
+      if (input instanceof DuckDBVariantValue) {
+        const inner = input.value;
+        if (inner === null) {
+          return duckdb.create_null_value();
+        }
+        return createValue(input.type ?? typeForValue(inner), inner);
+      }
+      return createValue(typeForValue(input), input);
+    }
     default:
       throw new Error(`unrecognized type id ${typeId}`);
   }

--- a/api/src/createValue.ts
+++ b/api/src/createValue.ts
@@ -180,11 +180,20 @@ export function createValue(type: DuckDBType, input: DuckDBValue): Value {
             'Cannot create structs with an entry type of ANY. Specify a specific type.'
           );
         }
+        // Pair entries by name rather than positionally so that
+        // `structValue({b: 'x', a: 1})` against `STRUCT({a: INTEGER, b:
+        // VARCHAR})` doesn't silently mispair when the value's insertion
+        // order differs from the type's declared field order.
         return duckdb.create_struct_value(
           type.toLogicalType().logical_type,
-          Object.values(input.entries).map((value, i) =>
-            createValue(type.entryTypes[i], value)
-          )
+          type.entryNames.map((name, i) => {
+            if (!(name in input.entries)) {
+              throw new Error(
+                `STRUCT entry '${name}' is missing from input`
+              );
+            }
+            return createValue(type.entryTypes[i], input.entries[name]);
+          })
         );
       }
       throw new Error(`input is not a DuckDBStructValue`);
@@ -290,15 +299,25 @@ export function createValue(type: DuckDBType, input: DuckDBValue): Value {
       // If the input is a DuckDBVariantValue, prefer its embedded `.type`
       // (set by the decoder from the on-disk variant tag) so heterogeneous
       // content round-trips faithfully. Fall back to `typeForValue` when
-      // no type hint is attached.
-      if (input instanceof DuckDBVariantValue) {
-        const inner = input.value;
-        if (inner === null) {
-          return duckdb.create_null_value();
-        }
-        return createValue(input.type ?? typeForValue(inner), inner);
+      // no type hint is attached. The recursion is wrapped so a
+      // mismatched wrapper (e.g. `variantValue('hello', INTEGER)`)
+      // surfaces a VARIANT-flavored error rather than a confusing
+      // `input is not a number` from a sibling case.
+      const inner =
+        input instanceof DuckDBVariantValue ? input.value : input;
+      const innerType =
+        input instanceof DuckDBVariantValue && input.type
+          ? input.type
+          : typeForValue(inner);
+      try {
+        return createValue(innerType, inner);
+      } catch (err) {
+        throw new Error(
+          `Failed to create VARIANT value (inner type ${innerType}): ${
+            (err as Error).message
+          }`
+        );
       }
-      return createValue(typeForValue(input), input);
     }
     default:
       throw new Error(`unrecognized type id ${typeId}`);

--- a/api/src/values/DuckDBVariantValue.ts
+++ b/api/src/values/DuckDBVariantValue.ts
@@ -1,21 +1,34 @@
 import { displayStringForDuckDBValue } from '../conversion/displayStringForDuckDBValue';
+// Type-only import avoids a runtime cycle with ../DuckDBType, which itself
+// pulls in the values barrel.
+import type { DuckDBType } from '../DuckDBType';
 import { DuckDBValue } from './DuckDBValue';
 
 /**
  * Wraps a single decoded VARIANT row value. The wrapper distinguishes a
  * SQL-NULL row (returned as bare `null`) from an embedded `VARIANT_NULL`
  * tag (returned as `new DuckDBVariantValue(null)`).
+ *
+ * The optional `type` records the exact DuckDB type of the inner value
+ * (recovered from the on-disk variant tag at decode time). The append /
+ * bind paths use it so heterogeneous content round-trips faithfully —
+ * `typeForValue` is a best-effort fallback when `type` is not provided.
  */
 export class DuckDBVariantValue {
   public readonly value: DuckDBValue;
-  public constructor(value: DuckDBValue) {
+  public readonly type?: DuckDBType;
+  public constructor(value: DuckDBValue, type?: DuckDBType) {
     this.value = value;
+    this.type = type;
   }
   public toString(): string {
     return displayStringForDuckDBValue(this.value);
   }
 }
 
-export function variantValue(value: DuckDBValue): DuckDBVariantValue {
-  return new DuckDBVariantValue(value);
+export function variantValue(
+  value: DuckDBValue,
+  type?: DuckDBType,
+): DuckDBVariantValue {
+  return new DuckDBVariantValue(value, type);
 }

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -3022,9 +3022,10 @@ ORDER BY name
           `select '[1, "two", null, true]'::JSON::VARIANT as v`,
         );
         const chunk = await result.fetchChunk();
-        // ARRAY children carry their own tags; each is wrapped as a
-        // variantValue with its inner type. The outer list type is
-        // LIST(VARIANT).
+        // Non-null children carry differing tags so the list stays
+        // LIST(VARIANT) with each non-null item wrapped. A null child
+        // remains bare to match how a column-level LIST(VARIANT) decodes
+        // a NULL element.
         assertValues<DuckDBVariantValue, DuckDBVariantVector>(
           chunk!,
           0,
@@ -3034,7 +3035,7 @@ ORDER BY name
               listValue([
                 variantValue(1n, UBIGINT),
                 variantValue('two', VARCHAR),
-                variantValue(null, SQLNULL),
+                null,
                 variantValue(true, BOOLEAN),
               ]),
               LIST(VARIANT),
@@ -3050,6 +3051,9 @@ ORDER BY name
           `select '{"outer": [1, {"inner": "leaf"}, [null, true]]}'::JSON::VARIANT as v`,
         );
         const chunk = await result.fetchChunk();
+        // The innermost [null, true] homogenizes to LIST(BOOLEAN) — null
+        // is compatible with any sibling type. The outer array remains
+        // heterogeneous (number / struct / list) so it's LIST(VARIANT).
         assertValues<DuckDBVariantValue, DuckDBVariantVector>(
           chunk!,
           0,
@@ -3063,13 +3067,7 @@ ORDER BY name
                     structValue({ inner: 'leaf' }),
                     STRUCT({ inner: VARCHAR }),
                   ),
-                  variantValue(
-                    listValue([
-                      variantValue(null, SQLNULL),
-                      variantValue(true, BOOLEAN),
-                    ]),
-                    LIST(VARIANT),
-                  ),
+                  variantValue(listValue([null, true]), LIST(BOOLEAN)),
                 ]),
               }),
               STRUCT({ outer: LIST(VARIANT) }),
@@ -3307,18 +3305,21 @@ ORDER BY name
     // Regression tests for code-review fixes.
 
     test('UINTEGER max routes through the JS / JSON converters', async () => {
-      // typeForValue infers BIGINT for a number > INT32 max; the variant
-      // walker now coerces such numbers to bigint before dispatching, so
-      // bigintFromBigIntValue / stringFromValue both succeed.
+      // The decoder records the exact UINTEGER type on the wrapper, so the
+      // converter dispatches via UINTEGER → numberFromValue and the value
+      // stays a JS number. (Without the type hint, `typeForValue` would
+      // infer BIGINT for a number > INT32 max and the variant walker
+      // would coerce to bigint as a fallback — exercised separately for
+      // unwrapped numeric values.)
       await withConnection(async (connection) => {
         const reader = await connection.runAndReadAll(
           `select 4294967295::UINTEGER::VARIANT as u`,
         );
         assert.deepStrictEqual(reader.getRowObjectsJS(), [
-          { u: 4294967295n },
+          { u: 4294967295 },
         ]);
         assert.deepStrictEqual(reader.getRowObjectsJson(), [
-          { u: '4294967295' },
+          { u: 4294967295 },
         ]);
       });
     });
@@ -3516,9 +3517,11 @@ ORDER BY name
     test('heterogeneous LIST(VARIANT) cannot be bound directly', async () => {
       // The C API's create_list_value rejects a list of values with
       // heterogeneous physical types, so a decoded `LIST(VARIANT)` (which
-      // wraps each element to preserve mixed types) cannot be bound back
-      // through a prepared statement. Pin the failure so we notice if the
-      // surface changes.
+      // wraps each non-null element to preserve mixed types) cannot be
+      // bound back through a prepared statement. Pin the failure so we
+      // notice if the surface changes. The error wording originates in
+      // the native bindings — if it changes phrasing across DuckDB
+      // versions, update the regex.
       await withConnection(async (connection) => {
         const r1 = await connection.runAndReadAll(
           `select '[1, "two"]'::JSON::VARIANT as v`,
@@ -3529,7 +3532,110 @@ ORDER BY name
         const prepared = await connection.prepare(`select ?::VARIANT as v`);
         assert.throws(
           () => prepared.bindVariant(1, decoded),
-          /Failed to create list value/,
+          /Failed to create (?:VARIANT value.*?Failed to create )?list value/,
+        );
+      });
+    });
+
+    // Round-trip coverage for the SQLNULL-compatible homogenize logic.
+
+    test('[1, 2, null] homogenizes to LIST(UBIGINT) with a bare null', async () => {
+      await withConnection(async (connection) => {
+        const r1 = await connection.runAndReadAll(
+          `select '[1, 2, null]'::JSON::VARIANT as v`,
+        );
+        const decoded = r1.getRowObjects()[0].v as DuckDBVariantValue;
+        assert.deepStrictEqual(decoded, variantValue(
+          listValue([1n, 2n, null]),
+          LIST(UBIGINT),
+        ));
+        // And round-trips back through bindVariant.
+        const p = await connection.prepare(`select ?::VARIANT as v`);
+        p.bindVariant(1, decoded);
+        const r2 = await p.runAndReadAll();
+        assert.deepStrictEqual(r2.getRowObjects()[0].v, decoded);
+      });
+    });
+
+    test('[null, null] collapses to LIST(SQLNULL) and round-trips', async () => {
+      await withConnection(async (connection) => {
+        const r1 = await connection.runAndReadAll(
+          `select '[null, null]'::JSON::VARIANT as v`,
+        );
+        const decoded = r1.getRowObjects()[0].v as DuckDBVariantValue;
+        assert.deepStrictEqual(decoded, variantValue(
+          listValue([null, null]),
+          LIST(SQLNULL),
+        ));
+        const p = await connection.prepare(`select ?::VARIANT as v`);
+        p.bindVariant(1, decoded);
+        const r2 = await p.runAndReadAll();
+        assert.deepStrictEqual(r2.getRowObjects()[0].v, decoded);
+      });
+    });
+
+    test('empty [] decodes as LIST(SQLNULL) and round-trips', async () => {
+      await withConnection(async (connection) => {
+        const r1 = await connection.runAndReadAll(
+          `select '[]'::JSON::VARIANT as v`,
+        );
+        const decoded = r1.getRowObjects()[0].v as DuckDBVariantValue;
+        assert.deepStrictEqual(decoded, variantValue(listValue([]), LIST(SQLNULL)));
+        const p = await connection.prepare(`select ?::VARIANT as v`);
+        p.bindVariant(1, decoded);
+        const r2 = await p.runAndReadAll();
+        assert.deepStrictEqual(r2.getRowObjects()[0].v, decoded);
+      });
+    });
+
+    test('empty {} decodes as STRUCT() and round-trips', async () => {
+      await withConnection(async (connection) => {
+        const r1 = await connection.runAndReadAll(
+          `select '{}'::JSON::VARIANT as v`,
+        );
+        const decoded = r1.getRowObjects()[0].v as DuckDBVariantValue;
+        assert.deepStrictEqual(decoded, variantValue(structValue({}), STRUCT({})));
+        const p = await connection.prepare(`select ?::VARIANT as v`);
+        p.bindVariant(1, decoded);
+        const r2 = await p.runAndReadAll();
+        assert.deepStrictEqual(r2.getRowObjects()[0].v, decoded);
+      });
+    });
+
+    test('STRUCT VARIANT containing a SQLNULL-typed field round-trips', async () => {
+      // Covers the case where a struct field is JSON-null; the decoder
+      // captures the field type as SQLNULL and the bind path must accept
+      // it (top-level null shortcut in createValue handles the inner null).
+      await withConnection(async (connection) => {
+        const r1 = await connection.runAndReadAll(
+          `select '{"a": 1, "b": null}'::JSON::VARIANT as v`,
+        );
+        const decoded = r1.getRowObjects()[0].v as DuckDBVariantValue;
+        const p = await connection.prepare(`select ?::VARIANT as v`);
+        p.bindVariant(1, decoded);
+        const r2 = await p.runAndReadAll();
+        assert.deepStrictEqual(r2.getRowObjects()[0].v, decoded);
+      });
+    });
+
+    test('bindVariant accepts null (short-circuits to bindNull)', async () => {
+      await withConnection(async (connection) => {
+        const prepared = await connection.prepare(`select ?::VARIANT as v`);
+        prepared.bindVariant(1, null);
+        const reader = await prepared.runAndReadAll();
+        assert.deepStrictEqual(reader.getRowObjects(), [{ v: null }]);
+      });
+    });
+
+    test('mismatched DuckDBVariantValue wrapper produces a VARIANT-context error', async () => {
+      // `variantValue('hello', INTEGER)` claims the inner value is an
+      // integer but it's actually a string. The error message should
+      // surface the VARIANT context to aid debugging.
+      await withConnection(async (connection) => {
+        const prepared = await connection.prepare(`select ?::VARIANT as v`);
+        assert.throws(
+          () => prepared.bindVariant(1, variantValue('hello', INTEGER)),
+          /Failed to create VARIANT value.*input is not a number/,
         );
       });
     });

--- a/api/test/api.test.ts
+++ b/api/test/api.test.ts
@@ -70,6 +70,7 @@ import {
   DuckDBVector,
   ENUM,
   FLOAT,
+  GEOMETRY,
   HUGEINT,
   INTEGER,
   JSDuckDBValueConverter,
@@ -2949,43 +2950,45 @@ ORDER BY name
         if (!chunk) return;
 
         // 2024-01-02 = 1970-01-01 + 19724 days; ts is 1704164645 unix seconds.
-        const oneRow = (v: DuckDBValue) => [variantValue(v)];
         let i = 0;
-        const expect = (v: DuckDBValue) =>
+        const expect = (v: DuckDBValue, t: DuckDBType) =>
           assertValues<DuckDBVariantValue, DuckDBVariantVector>(
             chunk,
             i++,
             DuckDBVariantVector,
-            oneRow(v),
+            [variantValue(v, t)],
           );
 
-        expect(true);
-        expect(false);
-        expect(-128);
-        expect(32767);
-        expect(-2147483648);
-        expect(9223372036854775807n);
-        expect(170141183460469231731687303715884105727n);
-        expect(255);
-        expect(65535);
-        expect(4294967295);
-        expect(18446744073709551615n);
-        expect(340282366920938463463374607431768211455n);
-        expect(1.5);
-        expect(2.5);
-        expect('hello');
-        expect(blobValue(new Uint8Array([0x00, 0xff])));
-        expect(decimalValue(12345n, 5, 2));
-        expect(decimalValue(123456789012345n, 18, 1));
-        expect(decimalValue(12345678901234567890123456789n, 38, 4));
-        expect(dateValue(19724));
-        expect(timeValue(BigInt(((12 * 60 + 34) * 60 + 56) * 1_000_000 + 789_000)));
-        expect(timestampValue(1704164645678000n));
-        expect(timestampSecondsValue(1704164645n));
-        expect(timestampMillisValue(1704164645678n));
-        expect(timestampNanosValue(1704164645678901234n));
-        expect(intervalValue(3, 4, BigInt(5 * 60 * 1_000_000)));
-        expect(uuidValue(0x00112233_4455_6677_8899_aabbccddeeffn));
+        expect(true, BOOLEAN);
+        expect(false, BOOLEAN);
+        expect(-128, TINYINT);
+        expect(32767, SMALLINT);
+        expect(-2147483648, INTEGER);
+        expect(9223372036854775807n, BIGINT);
+        expect(170141183460469231731687303715884105727n, HUGEINT);
+        expect(255, UTINYINT);
+        expect(65535, USMALLINT);
+        expect(4294967295, UINTEGER);
+        expect(18446744073709551615n, UBIGINT);
+        expect(340282366920938463463374607431768211455n, UHUGEINT);
+        expect(1.5, FLOAT);
+        expect(2.5, DOUBLE);
+        expect('hello', VARCHAR);
+        expect(blobValue(new Uint8Array([0x00, 0xff])), BLOB);
+        expect(decimalValue(12345n, 5, 2), DECIMAL(5, 2));
+        expect(decimalValue(123456789012345n, 18, 1), DECIMAL(18, 1));
+        expect(decimalValue(12345678901234567890123456789n, 38, 4), DECIMAL(38, 4));
+        expect(dateValue(19724), DATE);
+        expect(
+          timeValue(BigInt(((12 * 60 + 34) * 60 + 56) * 1_000_000 + 789_000)),
+          TIME,
+        );
+        expect(timestampValue(1704164645678000n), TIMESTAMP);
+        expect(timestampSecondsValue(1704164645n), TIMESTAMP_S);
+        expect(timestampMillisValue(1704164645678n), TIMESTAMP_MS);
+        expect(timestampNanosValue(1704164645678901234n), TIMESTAMP_NS);
+        expect(intervalValue(3, 4, BigInt(5 * 60 * 1_000_000)), INTERVAL);
+        expect(uuidValue(0x00112233_4455_6677_8899_aabbccddeeffn), UUID);
       });
     });
 
@@ -2996,12 +2999,19 @@ ORDER BY name
         );
         assertColumns(result, [{ name: 'v', type: VARIANT }]);
         const chunk = await result.fetchChunk();
-        // JSON numbers parse to BIGINT; 1 becomes 1n.
+        // JSON integers decode as UINT64 (variant tag); 1 becomes 1n with
+        // UBIGINT type. The decoder reconstructs STRUCT field types from
+        // each child's tag.
         assertValues<DuckDBVariantValue, DuckDBVariantVector>(
           chunk!,
           0,
           DuckDBVariantVector,
-          [variantValue(structValue({ a: 1n, b: 'hi', c: null }))],
+          [
+            variantValue(
+              structValue({ a: 1n, b: 'hi', c: null }),
+              STRUCT({ a: UBIGINT, b: VARCHAR, c: SQLNULL }),
+            ),
+          ],
         );
       });
     });
@@ -3012,11 +3022,24 @@ ORDER BY name
           `select '[1, "two", null, true]'::JSON::VARIANT as v`,
         );
         const chunk = await result.fetchChunk();
+        // ARRAY children carry their own tags; each is wrapped as a
+        // variantValue with its inner type. The outer list type is
+        // LIST(VARIANT).
         assertValues<DuckDBVariantValue, DuckDBVariantVector>(
           chunk!,
           0,
           DuckDBVariantVector,
-          [variantValue(listValue([1n, 'two', null, true]))],
+          [
+            variantValue(
+              listValue([
+                variantValue(1n, UBIGINT),
+                variantValue('two', VARCHAR),
+                variantValue(null, SQLNULL),
+                variantValue(true, BOOLEAN),
+              ]),
+              LIST(VARIANT),
+            ),
+          ],
         );
       });
     });
@@ -3035,11 +3058,21 @@ ORDER BY name
             variantValue(
               structValue({
                 outer: listValue([
-                  1n,
-                  structValue({ inner: 'leaf' }),
-                  listValue([null, true]),
+                  variantValue(1n, UBIGINT),
+                  variantValue(
+                    structValue({ inner: 'leaf' }),
+                    STRUCT({ inner: VARCHAR }),
+                  ),
+                  variantValue(
+                    listValue([
+                      variantValue(null, SQLNULL),
+                      variantValue(true, BOOLEAN),
+                    ]),
+                    LIST(VARIANT),
+                  ),
                 ]),
               }),
+              STRUCT({ outer: LIST(VARIANT) }),
             ),
           ],
         );
@@ -3059,7 +3092,13 @@ ORDER BY name
           chunk!,
           0,
           DuckDBListVector,
-          [listValue([variantValue(1), variantValue('x'), null])],
+          [
+            listValue([
+              variantValue(1, INTEGER),
+              variantValue('x', VARCHAR),
+              null,
+            ]),
+          ],
         );
       });
     });
@@ -3078,7 +3117,12 @@ ORDER BY name
           chunk!,
           0,
           DuckDBStructVector,
-          [structValue({ x: variantValue(42), y: variantValue('hello') })],
+          [
+            structValue({
+              x: variantValue(42, INTEGER),
+              y: variantValue('hello', VARCHAR),
+            }),
+          ],
         );
       });
     });
@@ -3161,20 +3205,25 @@ ORDER BY name
       });
     });
 
-    test('creating VARIANT values is not yet supported', async () => {
+    test('binding a VARIANT parameter (primitive)', async () => {
+      // Replaces the previous "not yet supported" test now that createValue
+      // routes the cast through DuckDB. Both wrapped and unwrapped inputs
+      // round-trip: the wrapper carries an exact `.type`; the unwrapped
+      // value falls back to `typeForValue` inference.
       await withConnection(async (connection) => {
-        const prepared = await connection.prepare('select ? as v');
-        // Same actionable message whether or not the input is wrapped —
-        // a caller shouldn't have to wrap first to learn writes aren't
-        // supported.
-        assert.throws(
-          () => prepared.bind([variantValue(1)], [VARIANT]),
-          /VARIANT is not yet supported/,
+        const prepared = await connection.prepare(
+          'select ?::VARIANT as v, ?::VARIANT as u',
         );
-        assert.throws(
-          () => prepared.bind([1], [VARIANT]),
-          /VARIANT is not yet supported/,
-        );
+        prepared.bind([variantValue(42, INTEGER), 'hello'], [VARIANT, VARIANT]);
+        const reader = await prepared.runAndReadAll();
+        assert.deepStrictEqual(reader.getRowObjects(), [
+          {
+            v: variantValue(42, INTEGER),
+            // INTEGER fits in JS number; typeForValue infers INTEGER for
+            // small numbers, but 'hello' is a string → VARCHAR.
+            u: variantValue('hello', VARCHAR),
+          },
+        ]);
       });
     });
 
@@ -3193,7 +3242,7 @@ ORDER BY name
           chunk!,
           0,
           DuckDBVariantVector,
-          [variantValue(bitValue('0101'))],
+          [variantValue(bitValue('0101'), BIT)],
         );
       });
     });
@@ -3208,7 +3257,7 @@ ORDER BY name
           chunk!,
           0,
           DuckDBVariantVector,
-          [variantValue(1234567890123456789012345n)],
+          [variantValue(1234567890123456789012345n, BIGNUM)],
         );
       });
     });
@@ -3223,7 +3272,12 @@ ORDER BY name
           chunk!,
           0,
           DuckDBVariantVector,
-          [variantValue(timeTZValue(45296789000n, 5 * 3600 + 30 * 60))],
+          [
+            variantValue(
+              timeTZValue(45296789000n, 5 * 3600 + 30 * 60),
+              TIMETZ,
+            ),
+          ],
         );
       });
     });
@@ -3245,7 +3299,7 @@ ORDER BY name
           chunk!,
           0,
           DuckDBVariantVector,
-          [variantValue(geometryValue(pointWkb))],
+          [variantValue(geometryValue(pointWkb), GEOMETRY)],
         );
       });
     });
@@ -3298,6 +3352,185 @@ ORDER BY name
         assert.deepStrictEqual(reader.getRowObjectsJS(), [
           { s: { x: 42, y: 7 } },
         ]);
+      });
+    });
+
+    // Binding / appending VARIANTs. DuckDB has no `duckdb_create_variant`
+    // primitive; instead the variant target type triggers an implicit cast
+    // from whatever Value we hand it. Four routes get exercised below:
+    //   1. Wrapper round-trip via `bindVariant` / `appendVariant`.
+    //   2. Generic `bindValue` / `appendValue` with target=VARIANT.
+    //   3. Generic `bindValue` / `appendValue` with a *non-VARIANT* target
+    //      (DuckDB performs the cast on its side).
+    //   4. Type-specific append methods (`appendInteger`, `appendVarchar`)
+    //      that bypass `createValue` entirely.
+
+    test('bindVariant round-trips a primitive VARIANT (path 1)', async () => {
+      await withConnection(async (connection) => {
+        const r1 = await connection.runAndReadAll(
+          `select 42::INTEGER::VARIANT as v`,
+        );
+        const decoded = r1.getRowObjects()[0].v as DuckDBVariantValue;
+        const prepared = await connection.prepare(`select ?::VARIANT as v`);
+        prepared.bindVariant(1, decoded);
+        const r2 = await prepared.runAndReadAll();
+        assert.deepStrictEqual(r2.getRowObjects(), [
+          { v: variantValue(42, INTEGER) },
+        ]);
+      });
+    });
+
+    test('bindVariant round-trips a STRUCT VARIANT (path 1)', async () => {
+      await withConnection(async (connection) => {
+        const r1 = await connection.runAndReadAll(
+          `select '{"a": 1, "b": "hi"}'::JSON::VARIANT as v`,
+        );
+        const decoded = r1.getRowObjects()[0].v as DuckDBVariantValue;
+        const prepared = await connection.prepare(`select ?::VARIANT as v`);
+        prepared.bindVariant(1, decoded);
+        const r2 = await prepared.runAndReadAll();
+        assert.deepStrictEqual(r2.getRowObjects(), [
+          {
+            v: variantValue(
+              structValue({ a: 1n, b: 'hi' }),
+              STRUCT({ a: UBIGINT, b: VARCHAR }),
+            ),
+          },
+        ]);
+      });
+    });
+
+    test('bindVariant round-trips a homogeneous ARRAY VARIANT (path 1)', async () => {
+      // A JSON array whose elements all share a tag becomes
+      // LIST(commonType) with bare items, which round-trips cleanly.
+      // (Heterogeneous arrays decode as LIST(VARIANT) with wrapped items
+      // and currently cannot be re-bound — see the limitation note.)
+      await withConnection(async (connection) => {
+        const r1 = await connection.runAndReadAll(
+          `select '[1, 2, 3]'::JSON::VARIANT as v`,
+        );
+        const decoded = r1.getRowObjects()[0].v as DuckDBVariantValue;
+        const prepared = await connection.prepare(`select ?::VARIANT as v`);
+        prepared.bindVariant(1, decoded);
+        const r2 = await prepared.runAndReadAll();
+        assert.deepStrictEqual(r2.getRowObjects(), [
+          {
+            v: variantValue(
+              listValue([1n, 2n, 3n]),
+              LIST(UBIGINT),
+            ),
+          },
+        ]);
+      });
+    });
+
+    test('bindValue with explicit VARIANT target (path 2)', async () => {
+      await withConnection(async (connection) => {
+        const prepared = await connection.prepare(
+          `select ?::VARIANT as v, ?::VARIANT as u`,
+        );
+        // Mixed: a raw number (typeForValue → INTEGER) and a raw string
+        // (typeForValue → VARCHAR).
+        prepared.bindValue(1, 42, VARIANT);
+        prepared.bindValue(2, 'hello', VARIANT);
+        const reader = await prepared.runAndReadAll();
+        assert.deepStrictEqual(reader.getRowObjects(), [
+          {
+            v: variantValue(42, INTEGER),
+            u: variantValue('hello', VARCHAR),
+          },
+        ]);
+      });
+    });
+
+    test('bindValue with explicit VARIANT target accepts null (path 2)', async () => {
+      await withConnection(async (connection) => {
+        const prepared = await connection.prepare(`select ?::VARIANT as v`);
+        prepared.bindValue(1, null, VARIANT);
+        const reader = await prepared.runAndReadAll();
+        assert.deepStrictEqual(reader.getRowObjects(), [{ v: null }]);
+      });
+    });
+
+    test('bindValue with non-VARIANT target casts on DuckDB side (path 3)', async () => {
+      // The target column is VARIANT (via the `?::VARIANT` cast) but the
+      // bound Value is INTEGER / VARCHAR / STRUCT. DuckDB performs the
+      // cast.
+      await withConnection(async (connection) => {
+        const prepared = await connection.prepare(
+          `select ?::VARIANT as i, ?::VARIANT as s, ?::VARIANT as o`,
+        );
+        prepared.bindValue(1, 42, INTEGER);
+        prepared.bindValue(2, 'hello', VARCHAR);
+        prepared.bindValue(
+          3,
+          structValue({ a: 1, b: 'x' }),
+          STRUCT({ a: INTEGER, b: VARCHAR }),
+        );
+        const reader = await prepared.runAndReadAll();
+        assert.deepStrictEqual(reader.getRowObjects(), [
+          {
+            i: variantValue(42, INTEGER),
+            s: variantValue('hello', VARCHAR),
+            o: variantValue(
+              structValue({ a: 1, b: 'x' }),
+              STRUCT({ a: INTEGER, b: VARCHAR }),
+            ),
+          },
+        ]);
+      });
+    });
+
+    test('appendVariant + appendValue + type-specific append (paths 1, 2, 3, 4)', async () => {
+      await withConnection(async (connection) => {
+        await connection.run(`CREATE TABLE t (v VARIANT)`);
+        const appender = await connection.createAppender('t');
+        // Path 1: appendVariant with a wrapped value carrying its exact type.
+        appender.appendVariant(variantValue(1, INTEGER));
+        appender.endRow();
+        // Path 2: appendValue with target=VARIANT, raw input.
+        appender.appendValue('hello', VARIANT);
+        appender.endRow();
+        // Path 3: appendValue with target=INTEGER against a VARIANT column.
+        appender.appendValue(3, INTEGER);
+        appender.endRow();
+        // Path 4: type-specific append bypasses createValue.
+        appender.appendInteger(4);
+        appender.endRow();
+        // Null.
+        appender.appendNull();
+        appender.endRow();
+        appender.closeSync();
+
+        const reader = await connection.runAndReadAll(`select v from t`);
+        assert.deepStrictEqual(reader.getRowObjects(), [
+          { v: variantValue(1, INTEGER) },
+          { v: variantValue('hello', VARCHAR) },
+          { v: variantValue(3, INTEGER) },
+          { v: variantValue(4, INTEGER) },
+          { v: null },
+        ]);
+      });
+    });
+
+    test('heterogeneous LIST(VARIANT) cannot be bound directly', async () => {
+      // The C API's create_list_value rejects a list of values with
+      // heterogeneous physical types, so a decoded `LIST(VARIANT)` (which
+      // wraps each element to preserve mixed types) cannot be bound back
+      // through a prepared statement. Pin the failure so we notice if the
+      // surface changes.
+      await withConnection(async (connection) => {
+        const r1 = await connection.runAndReadAll(
+          `select '[1, "two"]'::JSON::VARIANT as v`,
+        );
+        const decoded = r1.getRowObjects()[0].v as DuckDBVariantValue;
+        // Confirm the decoder produced the heterogeneous shape.
+        assert.deepStrictEqual(decoded.type, LIST(VARIANT));
+        const prepared = await connection.prepare(`select ?::VARIANT as v`);
+        assert.throws(
+          () => prepared.bindVariant(1, decoded),
+          /Failed to create list value/,
+        );
       });
     });
   });


### PR DESCRIPTION
Turns out append & bind support for VARIANT can be implemented without any C API additions, because DuckDB casts to VARIANT as needed. To make this work nicely in more cases, I added a `type` field to `DuckDBVariantValue`; this is possible because VARIANT values carry their type.