### PR TITLE
v1.4 bump pkgs to 1.4.4-r.4

### DIFF
--- a/api/pkgs/@duckdb/node-api/package.json
+++ b/api/pkgs/@duckdb/node-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-api",
-  "version": "1.4.4-r.3",
+  "version": "1.4.4-r.4",
   "license": "MIT",
   "main": "./lib/index.js",
   "types": "./lib/index.d.ts",

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-arm64",
-  "version": "1.4.4-r.3",
+  "version": "1.4.4-r.4",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-darwin-x64",
-  "version": "1.4.4-r.3",
+  "version": "1.4.4-r.4",
   "license": "MIT",
   "os": [
     "darwin"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-arm64",
-  "version": "1.4.4-r.3",
+  "version": "1.4.4-r.4",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-linux-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-linux-x64",
-  "version": "1.4.4-r.3",
+  "version": "1.4.4-r.4",
   "license": "MIT",
   "os": [
     "linux"

--- a/bindings/pkgs/@duckdb/node-bindings-win32-arm64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-arm64",
-  "version": "1.4.4-r.3",
+  "version": "1.4.4-r.4",
   "license": "MIT",
   "os": [
     "win32"

--- a/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings-win32-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings-win32-x64",
-  "version": "1.4.4-r.3",
+  "version": "1.4.4-r.4",
   "license": "MIT",
   "os": [
     "win32"

--- a/bindings/pkgs/@duckdb/node-bindings/package.json
+++ b/bindings/pkgs/@duckdb/node-bindings/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@duckdb/node-bindings",
-  "version": "1.4.4-r.3",
+  "version": "1.4.4-r.4",
   "license": "MIT",
   "main": "./duckdb.js",
   "types": "./duckdb.d.ts",


### PR DESCRIPTION
This version contains some fixes from `main` ported to the (new) `v1.4` branch:
- https://github.com/duckdb/duckdb-node-neo/pull/418
- https://github.com/duckdb/duckdb-node-neo/pull/419
- https://github.com/duckdb/duckdb-node-neo/pull/423
- https://github.com/duckdb/duckdb-node-neo/pull/425

Along with some tests & tooling improvements & updates:
- https://github.com/duckdb/duckdb-node-neo/pull/417
- https://github.com/duckdb/duckdb-node-neo/pull/420
- https://github.com/duckdb/duckdb-node-neo/pull/421
- https://github.com/duckdb/duckdb-node-neo/pull/422
- https://github.com/duckdb/duckdb-node-neo/pull/424