### PR TITLE
Reserve list child vector capacity before writing child elements

### DIFF
--- a/api/src/vectors/DuckDBListVector.ts
+++ b/api/src/vectors/DuckDBListVector.ts
@@ -153,6 +153,9 @@ export class DuckDBListVector extends DuckDBVector<DuckDBListValue> {
         }
       }
 
+      // grow child vector capacity (set_size does not allocate)
+      duckdb.list_vector_reserve(this.vector, totalLength);
+
       // set new child vector size
       duckdb.list_vector_set_size(this.vector, totalLength);
 

--- a/api/test/appender.test.ts
+++ b/api/test/appender.test.ts
@@ -49,6 +49,7 @@ import {
   DuckDBVarCharVector,
   INTEGER,
   LIST,
+  MAP,
   SMALLINT,
   STRUCT,
   TINYINT,
@@ -56,6 +57,7 @@ import {
   arrayValue,
   blobValue,
   listValue,
+  mapValue,
   structValue,
 } from '../src';
 import {
@@ -318,6 +320,159 @@ describe('appender', () => {
         assert.equal(resultChunk.columnCount, 1);
         assert.equal(resultChunk.rowCount, modifiedValues.length);
         assertValues(resultChunk, 0, DuckDBListVector, modifiedValues);
+      }
+    });
+  });
+  test('create and append data chunk with lists of integers exceeding child vector capacity', async () => {
+    await withConnection(async (connection) => {
+      // The child vector of a list starts with a capacity of only
+      // STANDARD_VECTOR_SIZE (2048), so lists totaling more child elements
+      // than that require growing its capacity before writing them.
+      const listLength = 1000;
+      const values = [
+        ...Array.from({ length: 4 }, (_, listIndex) =>
+          listValue(
+            Array.from(
+              { length: listLength },
+              (_, itemIndex) => listIndex * listLength + itemIndex,
+            ),
+          ),
+        ),
+        null,
+      ];
+
+      const chunk = DuckDBDataChunk.create([LIST(INTEGER)], values.length);
+      chunk.setColumnValues(0, values);
+
+      await connection.run('create table target(col0 integer[])');
+      const appender = await connection.createAppender('target');
+      appender.appendDataChunk(chunk);
+      appender.flushSync();
+
+      const result = await connection.run('from target');
+      const resultChunk = await result.fetchChunk();
+      assert.isDefined(resultChunk);
+      if (resultChunk) {
+        assert.equal(resultChunk.columnCount, 1);
+        assert.equal(resultChunk.rowCount, values.length);
+        assertValues(resultChunk, 0, DuckDBListVector, values);
+      }
+    });
+  });
+  test('create and append data chunk with lists of varchars exceeding child vector capacity', async () => {
+    await withConnection(async (connection) => {
+      const listLength = 1000;
+      const values = [
+        ...Array.from({ length: 4 }, (_, listIndex) =>
+          listValue(
+            Array.from(
+              { length: listLength },
+              // long enough to be stored out-of-line
+              (_, itemIndex) => `str_${listIndex * listLength + itemIndex}_xyz`,
+            ),
+          ),
+        ),
+        null,
+      ];
+
+      const chunk = DuckDBDataChunk.create([LIST(VARCHAR)], values.length);
+      chunk.setColumnValues(0, values);
+
+      await connection.run('create table target(col0 varchar[])');
+      const appender = await connection.createAppender('target');
+      appender.appendDataChunk(chunk);
+      appender.flushSync();
+
+      const result = await connection.run('from target');
+      const resultChunk = await result.fetchChunk();
+      assert.isDefined(resultChunk);
+      if (resultChunk) {
+        assert.equal(resultChunk.columnCount, 1);
+        assert.equal(resultChunk.rowCount, values.length);
+        assertValues(resultChunk, 0, DuckDBListVector, values);
+      }
+    });
+  });
+  test('create and append data chunk with nested lists exceeding child vector capacity', async () => {
+    await withConnection(async (connection) => {
+      // 4 * 50 = 200 inner lists (within the outer child vector's initial
+      // capacity), but 4 * 50 * 50 = 10000 integers (well beyond the inner
+      // child vector's initial capacity).
+      const outerListLength = 50;
+      const innerListLength = 50;
+      const values = [
+        ...Array.from({ length: 4 }, (_, outerIndex) =>
+          listValue(
+            Array.from({ length: outerListLength }, (_, innerIndex) =>
+              listValue(
+                Array.from(
+                  { length: innerListLength },
+                  (_, itemIndex) =>
+                    (outerIndex * outerListLength + innerIndex) *
+                      innerListLength +
+                    itemIndex,
+                ),
+              ),
+            ),
+          ),
+        ),
+        null,
+      ];
+
+      const chunk = DuckDBDataChunk.create(
+        [LIST(LIST(INTEGER))],
+        values.length,
+      );
+      chunk.setColumnValues(0, values);
+
+      await connection.run('create table target(col0 integer[][])');
+      const appender = await connection.createAppender('target');
+      appender.appendDataChunk(chunk);
+      appender.flushSync();
+
+      const result = await connection.run('from target');
+      const resultChunk = await result.fetchChunk();
+      assert.isDefined(resultChunk);
+      if (resultChunk) {
+        assert.equal(resultChunk.columnCount, 1);
+        assert.equal(resultChunk.rowCount, values.length);
+        assertValues(resultChunk, 0, DuckDBListVector, values);
+      }
+    });
+  });
+  test('create and append data chunk with maps exceeding child vector capacity', async () => {
+    await withConnection(async (connection) => {
+      const entryCount = 1000;
+      const values = [
+        ...Array.from({ length: 4 }, (_, mapIndex) =>
+          mapValue(
+            Array.from({ length: entryCount }, (_, entryIndex) => {
+              const n = mapIndex * entryCount + entryIndex;
+              return { key: `key_${n}_xyz`, value: n };
+            }),
+          ),
+        ),
+        null,
+      ];
+
+      const chunk = DuckDBDataChunk.create(
+        [MAP(VARCHAR, INTEGER)],
+        values.length,
+      );
+      chunk.setColumnValues(0, values);
+
+      await connection.run('create table target(col0 map(varchar, integer))');
+      const appender = await connection.createAppender('target');
+      appender.appendDataChunk(chunk);
+      appender.flushSync();
+
+      const result = await connection.run('from target');
+      const resultChunk = await result.fetchChunk();
+      assert.isDefined(resultChunk);
+      if (resultChunk) {
+        assert.equal(resultChunk.columnCount, 1);
+        assert.equal(resultChunk.rowCount, values.length);
+        assertValues(resultChunk, 0, DuckDBMapVector, values);
       }
     });
   });


### PR DESCRIPTION
Fixes #446.

## Problem

`DuckDBListVector.flush()` called `duckdb_list_vector_set_size`, which sets the child vector's *logical size* but explicitly does **not** allocate memory for it:

> Sets the size of the underlying child-vector of a list vector. Note that this does NOT reserve the memory in the child buffer, and that it is possible to set a size exceeding the capacity. To set the capacity, use `duckdb_list_vector_reserve`.

A list's child vector starts with a capacity of `STANDARD_VECTOR_SIZE` (2048). Since `flush()` then maps a JS view over the child's data pointer sized to the *logical* size and writes every child element through it (or, for VARCHAR, calls `vector_assign_string_element` per element), any chunk whose lists total more than 2048 child elements wrote past the end of the child's data and validity buffers, corrupting the heap.

Depending on what happened to be adjacent in the heap, this showed up as silently wrong data, a thrown error from `flushSync`, or a hard crash (SIGSEGV / SIGBUS / malloc abort) — often at a later, unrelated point, which is what made it look like a hang in the issue report.

Because MAP is represented as `LIST(STRUCT(key, value))`, and nested lists recurse through the same flush path, both were affected as well. ARRAY is not: its child is allocated with capacity `STANDARD_VECTOR_SIZE * array_size`.

## Fix

Call `duckdb_list_vector_reserve(vector, totalLength)` before `list_vector_set_size` — and therefore before `list_vector_get_child`, since reserving can reallocate (and thus move) the child's backing storage.

Thanks to @pmaciolek for the precise diagnosis and suggested fix.

## Tests

Four regression tests added to `appender.test.ts`, each appending a chunk whose child elements exceed the initial child capacity and verifying the full round trip:

- lists of integers (4 x 1000 children)
- lists of varchars (4 x 1000 children, long enough to be stored out-of-line)
- nested lists (200 inner lists, 10000 leaf integers — only the inner child vector overflows)
- maps (4 x 1000 entries)

Verified that all four fail on `main` without the fix: the integer-list and map cases crash the test worker, while the varchar-list and nested-list cases return corrupted data. All pass with the fix, along with the rest of the suite (144 passed, 1 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)