### PR TITLE
fix: raise a clear error for an empty map value instead of a cryptic TypeError

### DIFF
--- a/api/src/typeForValue.ts
+++ b/api/src/typeForValue.ts
@@ -89,6 +89,13 @@ export function typeForValue(value: DuckDBValue): DuckDBType {
         } else if (value instanceof DuckDBListValue) {
           return LIST(typeForValue(value.items[0]));
         } else if (value instanceof DuckDBMapValue) {
+          if (value.entries.length === 0) {
+            // An empty map carries no entries to infer key/value types from.
+            // Mirror the empty-list path (LIST(ANY)) so createValue raises the
+            // same "Cannot create maps with key type of ANY" error, instead of
+            // a cryptic "Cannot read properties of undefined (reading 'key')".
+            return MAP(ANY, ANY);
+          }
           return MAP(
             typeForValue(value.entries[0].key),
             typeForValue(value.entries[0].value)

--- a/api/test/prepared.test.ts
+++ b/api/test/prepared.test.ts
@@ -397,6 +397,22 @@ describe('prepared statements', () => {
       }
     });
   });
+  test('should fail gracefully when type cannot be inferred when binding maps to prepared statements', async () => {
+    await withConnection(async (connection) => {
+      const prepared = await connection.prepare('select ?');
+      try {
+        prepared.bind([mapValue([])]);
+        assert.fail('should throw');
+      } catch (err) {
+        assert.deepEqual(
+          err,
+          new Error(
+            'Cannot create maps with key type of ANY. Specify a specific type.',
+          ),
+        );
+      }
+    });
+  });
   test('should infer integer and floating-point values when binding to prepared statements', async () => {
     await withConnection(async (connection) => {
       const prepared = await connection.prepare('select ? as i1, ? as i2, ? as b1, ? as b2, ? as d');


### PR DESCRIPTION
`typeForValue` crashes on an empty `DuckDBMapValue`: it reads `value.entries[0].key` without a length check, so an empty map throws `TypeError: Cannot read properties of undefined (reading 'key')` — hard to diagnose, as reported in #451.

Empty lists and arrays already fail gracefully here: `typeForValue` returns `LIST(ANY)` / `ARRAY(ANY, 0)` and `createValue` raises a clear "Cannot create lists/arrays with item type of ANY. Specify a specific type." This brings maps in line — return `MAP(ANY, ANY)` for an empty map, so the existing `createValue` branch raises "Cannot create maps with key type of ANY. Specify a specific type."

Added a `prepared` test mirroring the existing empty-list / empty-array cases. The full `api` suite passes.

Fixes #451
