### PR TITLE
Destroy N-API references for scalar functions on the JS thread

### DIFF
--- a/.github/workflows/DuckDBNodeBindingsAndAPI.yml
+++ b/.github/workflows/DuckDBNodeBindingsAndAPI.yml
@@ -141,6 +141,35 @@ jobs:
         working-directory: api
         run: pnpm test
 
+      # The steps below rebuild the addon with DUCKDB_NODE_INSTRUMENT_NAPI_REFS,
+      # which aborts if a Napi::ObjectReference is ever destroyed off the JS
+      # thread, and re-run the suites against it. See the comment on
+      # duckdb_node_instrument_napi_refs in bindings/binding.gyp.
+      #
+      # They come last because they leave an instrumented addon in bindings/pkgs
+      # which must never be published. Publishing only happens on
+      # workflow_dispatch, so the pull_request condition already keeps the two
+      # apart; keep it that way if these move.
+
+      - name: Bindings - Build (N-API reference instrumentation)
+        if: ${{ github.event_name == 'pull_request' }}
+        working-directory: bindings
+        run: |
+          pnpm exec node-gyp configure --nodedir=$NODE_DIR -- -Dduckdb_node_instrument_napi_refs=1
+          pnpm exec node-gyp build --nodedir=$NODE_DIR
+
+      - name: Bindings - Test (N-API reference instrumentation)
+        if: ${{ github.event_name == 'pull_request' }}
+        working-directory: bindings
+        run: |
+          pnpm test
+          pnpm run test:stress
+
+      - name: API - Test (N-API reference instrumentation)
+        if: ${{ github.event_name == 'pull_request' }}
+        working-directory: api
+        run: pnpm test
+
       # - name: Git Status
       #   if: ${{ inputs.publish }}
       #   run: git status

--- a/bindings/binding.gyp
+++ b/bindings/binding.gyp
@@ -14,6 +14,18 @@
         ],
       ],
     },
+    # Off by default. When set to 1, aborts if a Napi::ObjectReference is ever
+    # destroyed off the JS thread (see napi_ref_reaper.h). This is a manual
+    # check, not part of any test suite; run it after touching reference
+    # ownership with:
+    #
+    #   node-gyp configure -- -Dduckdb_node_instrument_napi_refs=1
+    #   node-gyp build
+    #   pnpm test
+    #
+    # A clean run means every reference was destroyed on the JS thread.
+    # Reconfigure without the flag afterwards to get an uninstrumented build.
+    'duckdb_node_instrument_napi_refs%': 0,
     'conditions': [
       ['<(libc_musl) == 1', {
           'libc_pkg_suffix%': '-musl',
@@ -75,6 +87,9 @@
       'sources': ['src/duckdb_node_bindings.cpp'],
       'include_dirs': ['<(module_root_dir)/libduckdb'],
       'conditions': [
+        ['duckdb_node_instrument_napi_refs==1', {
+          'defines': ['DUCKDB_NODE_INSTRUMENT_NAPI_REFS'],
+        }],
         ['OS=="linux" and target_arch=="x64"', {
           'link_settings': {
             'libraries': [

--- a/bindings/binding.gyp
+++ b/bindings/binding.gyp
@@ -23,7 +23,10 @@
     #   node-gyp build
     #   pnpm test
     #
-    # A clean run means every reference was destroyed on the JS thread.
+    # A clean run means no reference was destroyed off the JS thread. Note that
+    # references still queued when the env tears down are leaked rather than
+    # destroyed, so a clean run is not by itself proof that every reference was
+    # reaped; the instrumented build reports those leaks separately on stderr.
     # Reconfigure without the flag afterwards to get an uninstrumented build.
     'duckdb_node_instrument_napi_refs%': 0,
     'conditions': [

--- a/bindings/package.json
+++ b/bindings/package.json
@@ -8,8 +8,9 @@
     "clean:gyp": "node-gyp clean",
     "clean:libduckdb": "rimraf libduckdb",
     "clean:package": "rimraf pkgs/@duckdb/**/*.node pkgs/@duckdb/**/*.so pkgs/@duckdb/**/*.dylib pkgs/@duckdb/**/*.dll",
-    "test": "vitest run",
-    "test:watch": "vitest"
+    "test": "vitest run --exclude 'test/stress/**'",
+    "test:stress": "vitest run test/stress",
+    "test:watch": "vitest --exclude 'test/stress/**'"
   },
   "devDependencies": {
     "@duckdb/node-bindings": "workspace:*",

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -23,7 +23,7 @@ class DuckDBNodeAddon : public Napi::Addon<DuckDBNodeAddon> {
 
 public:
 
-  DuckDBNodeAddon(Napi::Env env, Napi::Object exports) {
+  DuckDBNodeAddon(Napi::Env env, Napi::Object exports) : ref_reaper(std::make_shared<NapiRefReaper>(env)) {
     DefineAddon(exports, {
       InstanceValue("sizeof_bool", Napi::Number::New(env, sizeof(bool))),
 
@@ -330,7 +330,20 @@ public:
     });
   }
 
+  ~DuckDBNodeAddon() {
+    // Runs on the JS thread when the env is torn down, which is what matters for
+    // worker threads. Node may skip instance data finalizers for the main env at
+    // process exit; that is harmless, since the reaper's thread-safe function is
+    // unref'd and so never holds the process open. After shutdown, references
+    // still held by DuckDB can no longer be reaped and are leaked instead.
+    ref_reaper->Shutdown();
+  }
+
 private:
+
+  // Destroys user-object references on the JS thread, whatever thread DuckDB's
+  // delete callbacks run on. See napi_ref_reaper.h.
+  std::shared_ptr<NapiRefReaper> ref_reaper;
 
   // DUCKDB_C_API duckdb_instance_cache duckdb_create_instance_cache();
   // function create_instance_cache(): InstanceCache
@@ -3009,7 +3022,7 @@ private:
     auto holder = GetScalarFunctionHolderFromExternal(env, info[0]);
     auto user_extra_info = info[1].As<Napi::Object>();
     holder->EnsureInternalExtraInfo();
-    holder->internal_extra_info->SetUserExtraInfo(user_extra_info);
+    holder->internal_extra_info->SetUserExtraInfo(ref_reaper, user_extra_info);
     return env.Undefined();
   }
 
@@ -3032,7 +3045,7 @@ private:
     auto bind_info = GetBindInfoFromExternal(env, info[0]);
     auto user_bind_data = info[1].As<Napi::Object>();
     auto internal_bind_data = new ScalarFunctionInternalBindData();
-    internal_bind_data->SetUserBindData(user_bind_data);
+    internal_bind_data->SetUserBindData(ref_reaper, user_bind_data);
     duckdb_scalar_function_set_bind_data(bind_info, internal_bind_data, reinterpret_cast<duckdb_delete_callback_t>(DeleteScalarFunctionInternalBindData));
     duckdb_scalar_function_set_bind_data_copy(bind_info, reinterpret_cast<duckdb_copy_callback_t>(CopyScalarFunctionInternalBindData));
     return env.Undefined();
@@ -3081,10 +3094,10 @@ private:
     auto env = info.Env();
     auto function_info = GetFunctionInfoFromExternal(env, info[0]);
     auto internal_extra_info = GetScalarFunctionInternalExtraInfoFromFunctionInfo(function_info);
-    if (!internal_extra_info || !internal_extra_info->user_extra_info_ref || internal_extra_info->user_extra_info_ref->IsEmpty()) {
+    if (!internal_extra_info || !internal_extra_info->user_extra_info_ref) {
       return env.Undefined();
     }
-    return internal_extra_info->user_extra_info_ref->Value();
+    return internal_extra_info->user_extra_info_ref->ref.Value();
   }
 
   // DUCKDB_C_API void *duckdb_scalar_function_bind_get_extra_info(duckdb_bind_info info);
@@ -3093,10 +3106,10 @@ private:
     auto env = info.Env();
     auto bind_info = GetBindInfoFromExternal(env, info[0]);
     auto internal_extra_info = GetScalarFunctionInternalExtraInfoFromBindInfo(bind_info);
-    if (!internal_extra_info || !internal_extra_info->user_extra_info_ref || internal_extra_info->user_extra_info_ref->IsEmpty()) {
+    if (!internal_extra_info || !internal_extra_info->user_extra_info_ref) {
       return env.Undefined();
     }
-    return internal_extra_info->user_extra_info_ref->Value();
+    return internal_extra_info->user_extra_info_ref->ref.Value();
   }
 
   // DUCKDB_C_API void *duckdb_scalar_function_get_bind_data(duckdb_function_info info);
@@ -3105,10 +3118,10 @@ private:
     auto env = info.Env();
     auto function_info = GetFunctionInfoFromExternal(env, info[0]);
     auto internal_bind_data = reinterpret_cast<ScalarFunctionInternalBindData*>(duckdb_scalar_function_get_bind_data(function_info));
-    if (!internal_bind_data || !internal_bind_data->user_bind_data_ref || internal_bind_data->user_bind_data_ref->IsEmpty()) {
+    if (!internal_bind_data || !internal_bind_data->user_bind_data_ref) {
       return env.Undefined();
     }
-    return internal_bind_data->user_bind_data_ref->Value();
+    return internal_bind_data->user_bind_data_ref->ref.Value();
   }
 
   // DUCKDB_C_API void duckdb_scalar_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);

--- a/bindings/src/externals.h
+++ b/bindings/src/externals.h
@@ -2,6 +2,7 @@
 
 #include "napi_setup.h"
 #include "duckdb.h"
+#include "napi_ref_reaper.h"
 #include <cstddef>
 #include <memory>
 
@@ -342,7 +343,7 @@ using ScalarFunctionMainTSFN = Napi::TypedThreadSafeFunction<ScalarFunctionMainT
 struct ScalarFunctionInternalExtraInfo {
   std::unique_ptr<ScalarFunctionBindTSFN> bind_tsfn;
   std::unique_ptr<ScalarFunctionMainTSFN> main_tsfn;
-  std::unique_ptr<Napi::ObjectReference> user_extra_info_ref;
+  std::shared_ptr<ManagedObjectReference> user_extra_info_ref;
 
   ScalarFunctionInternalExtraInfo() {}
 
@@ -369,8 +370,8 @@ struct ScalarFunctionInternalExtraInfo {
     main_tsfn = std::make_unique<ScalarFunctionMainTSFN>(ScalarFunctionMainTSFN::New(env, func, "ScalarFunctionMain", 0, 1));
   }
 
-  void SetUserExtraInfo(Napi::Object user_extra_info) {
-    user_extra_info_ref = std::make_unique<Napi::ObjectReference>(user_extra_info.IsUndefined() ? Napi::ObjectReference() : Napi::Persistent(user_extra_info));
+  void SetUserExtraInfo(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object user_extra_info) {
+    user_extra_info_ref = user_extra_info.IsUndefined() ? nullptr : MakeManagedObjectReference(reaper, user_extra_info);
   }
 };
 

--- a/bindings/src/napi_ref_reaper.h
+++ b/bindings/src/napi_ref_reaper.h
@@ -78,6 +78,13 @@ public:
     );
     // Reaping references should not by itself keep the process alive.
     tsfn.Unref(env);
+    // Release the thread-safe function from an env cleanup hook rather than only
+    // from ~DuckDBNodeAddon. An unreleased thread-safe function keeps its env
+    // from finishing teardown, and the addon destructor runs as part of that
+    // teardown, so relying on it alone deadlocks: the env waits for a release
+    // that only happens once the env has torn down. A worker thread then never
+    // exits. Cleanup hooks run before that point, which breaks the cycle.
+    env.AddCleanupHook([this]() { Shutdown(); });
   }
 
   bool OnJSThread() const {

--- a/bindings/src/napi_ref_reaper.h
+++ b/bindings/src/napi_ref_reaper.h
@@ -1,0 +1,132 @@
+#pragma once
+
+#include "napi_setup.h"
+#include <memory>
+#include <mutex>
+#include <thread>
+
+#ifdef DUCKDB_NODE_INSTRUMENT_NAPI_REFS
+#include <cstdio>
+#include <cstdlib>
+#endif
+
+// N-API reference lifetime management
+//
+// User-supplied objects (scalar function extra info & bind data, and the
+// equivalents for other function families) are held across the boundary as
+// Napi::ObjectReferences, but the structs holding them are owned by DuckDB and
+// destroyed by DuckDB's delete callbacks. Those callbacks run on whatever thread
+// tears down the plan, which is routinely a DuckDB worker thread, not the JS
+// thread.
+//
+// Destroying a Napi::ObjectReference calls napi_delete_reference, which mutates
+// V8's global handle table. N-API requires every call except the thread-safe
+// function family to happen on the thread owning the napi_env, and Node does not
+// lock the isolate, so doing this from a worker thread is a data race.
+//
+// NapiRefReaper resolves that: references are always destroyed on the JS thread,
+// either inline (when the delete callback already runs there) or by handing them
+// to a thread-safe function that does the deletion on the JS thread.
+
+// A Napi::ObjectReference that must only ever be destroyed on the JS thread.
+//
+// Instances are always constructed on the JS thread, so under
+// DUCKDB_NODE_INSTRUMENT_NAPI_REFS the construction thread doubles as the
+// expected destruction thread, and any mismatch aborts with a usable stack.
+struct ManagedObjectReference {
+  Napi::ObjectReference ref;
+
+  explicit ManagedObjectReference(Napi::ObjectReference &&ref_in) : ref(std::move(ref_in)) {}
+
+  ~ManagedObjectReference() {
+#ifdef DUCKDB_NODE_INSTRUMENT_NAPI_REFS
+    if (std::this_thread::get_id() != created_on) {
+      fprintf(stderr, "FATAL: Napi::ObjectReference destroyed off the JS thread.\n");
+      fflush(stderr);
+      abort();
+    }
+#endif
+  }
+
+  ManagedObjectReference(const ManagedObjectReference &) = delete;
+  ManagedObjectReference &operator=(const ManagedObjectReference &) = delete;
+
+#ifdef DUCKDB_NODE_INSTRUMENT_NAPI_REFS
+private:
+  std::thread::id created_on = std::this_thread::get_id();
+#endif
+};
+
+// Destroys ManagedObjectReferences on the JS thread, from any calling thread.
+//
+// One instance is owned by the addon (and therefore scoped to a napi_env, which
+// matters under worker_threads, where the addon is instantiated per env). It is
+// held by shared_ptr, and every managed reference's deleter captures that
+// shared_ptr, so the reaper always outlives the references that depend on it.
+class NapiRefReaper {
+
+public:
+
+  explicit NapiRefReaper(Napi::Env env) : js_thread_id(std::this_thread::get_id()), alive(true) {
+    tsfn = Napi::ThreadSafeFunction::New(
+      env,
+      Napi::Function::New(env, [](const Napi::CallbackInfo&) {}), // never called; the work is in the call's own callback
+      "DuckDBNapiRefReaper",
+      0, // unlimited queue: releasing a reference must never block a DuckDB thread
+      1  // initial thread count
+    );
+    // Reaping references should not by itself keep the process alive.
+    tsfn.Unref(env);
+  }
+
+  bool OnJSThread() const {
+    return std::this_thread::get_id() == js_thread_id;
+  }
+
+  // Called on the JS thread when the addon is torn down.
+  void Shutdown() {
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!alive) {
+      return;
+    }
+    alive = false;
+    tsfn.Release();
+  }
+
+  // Takes ownership of the reference. Safe to call from any thread.
+  void Destroy(ManagedObjectReference *managed_ref) {
+    if (!managed_ref) {
+      return;
+    }
+    if (OnJSThread()) {
+      // Shutdown also runs on the JS thread, so it cannot be racing with this.
+      delete managed_ref;
+      return;
+    }
+    std::lock_guard<std::mutex> lock(mutex);
+    if (!alive || tsfn.NonBlockingCall([managed_ref](Napi::Env, Napi::Function) { delete managed_ref; }) != napi_ok) {
+      // The env is gone (or the queue rejected the call), so the reference can
+      // no longer be deleted safely from any thread. Leak it: this only happens
+      // during teardown, where the underlying JS object is already unreachable.
+      return;
+    }
+  }
+
+private:
+
+  std::thread::id js_thread_id;
+  Napi::ThreadSafeFunction tsfn;
+  std::mutex mutex;
+  bool alive;
+
+};
+
+// Creates a reference to the given object whose destruction is routed through
+// the reaper. The deleter holds the reaper alive for as long as any reference
+// created from it survives.
+inline std::shared_ptr<ManagedObjectReference> MakeManagedObjectReference(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object object) {
+  return std::shared_ptr<ManagedObjectReference>(
+    new ManagedObjectReference(Napi::Persistent(object)),
+    [reaper](ManagedObjectReference *managed_ref) { reaper->Destroy(managed_ref); }
+  );
+}

--- a/bindings/src/napi_ref_reaper.h
+++ b/bindings/src/napi_ref_reaper.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "napi_setup.h"
+#include <atomic>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -100,30 +101,62 @@ public:
     }
     if (OnJSThread()) {
       // Shutdown also runs on the JS thread, so it cannot be racing with this.
-      delete managed_ref;
+      // It can already have run, though, in which case the env is going away and
+      // the reference must be leaked rather than deleted.
+      if (alive) {
+        delete managed_ref;
+      } else {
+        LeakReference();
+      }
       return;
     }
+    // Holding the mutex across the check and the call is what stands in for the
+    // per-thread Acquire/Release that N-API's thread-safe function contract
+    // otherwise expects: it keeps Shutdown's Release from dropping the last
+    // thread count while a call is in flight. Callers must not move the call
+    // out of the lock.
     std::lock_guard<std::mutex> lock(mutex);
-    if (!alive || tsfn.NonBlockingCall([managed_ref](Napi::Env, Napi::Function) { delete managed_ref; }) != napi_ok) {
-      // The env is gone (or the queue rejected the call), so the reference can
-      // no longer be deleted safely from any thread. Leak it: this only happens
-      // during teardown, where the underlying JS object is already unreachable.
+    if (!alive) {
+      LeakReference();
       return;
+    }
+    auto status = tsfn.NonBlockingCall([managed_ref](Napi::Env, Napi::Function) { delete managed_ref; });
+    if (status != napi_ok) {
+      // A failed call means the thread-safe function is closing. Node closes it
+      // from its own env cleanup hook, independently of Shutdown, and N-API
+      // forbids using it afterwards because it may already have been freed.
+      // Mark the reaper dead so no other thread calls into it.
+      alive = false;
+      LeakReference();
     }
   }
 
 private:
 
+  // The reference can no longer be deleted safely from any thread, so leaking it
+  // is the only correct option. This happens only once the env is going away,
+  // where the underlying JS object is already unreachable.
+  static void LeakReference() {
+#ifdef DUCKDB_NODE_INSTRUMENT_NAPI_REFS
+    fprintf(stderr, "INFO: leaked a Napi::ObjectReference during teardown instead of destroying it.\n");
+    fflush(stderr);
+#endif
+  }
+
   std::thread::id js_thread_id;
   Napi::ThreadSafeFunction tsfn;
   std::mutex mutex;
-  bool alive;
+  // Written under the mutex, but read without it on the JS thread fast path.
+  std::atomic<bool> alive;
 
 };
 
 // Creates a reference to the given object whose destruction is routed through
 // the reaper. The deleter holds the reaper alive for as long as any reference
 // created from it survives.
+//
+// The resulting reference is never empty, so holders can treat a null
+// shared_ptr as "no user object" without also checking IsEmpty().
 inline std::shared_ptr<ManagedObjectReference> MakeManagedObjectReference(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object object) {
   return std::shared_ptr<ManagedObjectReference>(
     new ManagedObjectReference(Napi::Persistent(object)),

--- a/bindings/src/scalar_function_helpers.h
+++ b/bindings/src/scalar_function_helpers.h
@@ -8,25 +8,29 @@
 // Scalar functions
 
 struct ScalarFunctionInternalBindData {
-  std::unique_ptr<Napi::ObjectReference> user_bind_data_ref;
+  std::shared_ptr<ManagedObjectReference> user_bind_data_ref;
 
-  void SetUserBindData(Napi::Object user_bind_data) {
-    user_bind_data_ref = std::make_unique<Napi::ObjectReference>(user_bind_data.IsUndefined() ? Napi::ObjectReference() : Napi::Persistent(user_bind_data));
+  void SetUserBindData(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object user_bind_data) {
+    user_bind_data_ref = user_bind_data.IsUndefined() ? nullptr : MakeManagedObjectReference(reaper, user_bind_data);
   }
 };
 
+// Called by DuckDB when the bound expression is destroyed, on whatever thread
+// tears down the plan. Dropping the last reference hands it to the reaper, which
+// deletes it on the JS thread.
 inline void DeleteScalarFunctionInternalBindData(ScalarFunctionInternalBindData *internal_bind_data) {
   delete internal_bind_data;
 }
 
+// Called by DuckDB when the bound expression is copied, also on an arbitrary
+// thread. Sharing the reference makes this a refcount bump, so no N-API call is
+// made here.
 inline ScalarFunctionInternalBindData *CopyScalarFunctionInternalBindData(ScalarFunctionInternalBindData *internal_bind_data) {
   if (!internal_bind_data) {
     return nullptr;
   }
   auto new_internal_bind_data = new ScalarFunctionInternalBindData();
-  if (internal_bind_data->user_bind_data_ref && !internal_bind_data->user_bind_data_ref->IsEmpty()) {
-    new_internal_bind_data->SetUserBindData(internal_bind_data->user_bind_data_ref->Value());
-  }
+  new_internal_bind_data->user_bind_data_ref = internal_bind_data->user_bind_data_ref;
   return new_internal_bind_data;
 }
 

--- a/bindings/src/scalar_function_helpers.h
+++ b/bindings/src/scalar_function_helpers.h
@@ -25,6 +25,12 @@ inline void DeleteScalarFunctionInternalBindData(ScalarFunctionInternalBindData 
 // Called by DuckDB when the bound expression is copied, also on an arbitrary
 // thread. Sharing the reference makes this a refcount bump, so no N-API call is
 // made here.
+//
+// No test covers this: 18 query shapes were tried (common subexpressions, filter
+// pushdown, joins, set operations, windows, subqueries, CTAS, repeated execution
+// of a prepared statement) and DuckDB 1.5.5 did not copy the bind data for any of
+// them. Registering the copy callback is still correct, and sharing the reference
+// means the path is safe if it is ever reached.
 inline ScalarFunctionInternalBindData *CopyScalarFunctionInternalBindData(ScalarFunctionInternalBindData *internal_bind_data) {
   if (!internal_bind_data) {
     return nullptr;

--- a/bindings/test/scalar_functions.test.ts
+++ b/bindings/test/scalar_functions.test.ts
@@ -465,4 +465,170 @@ suite('scalar functions', () => {
       });
     });
   });
+  test('bind data identity is preserved across calls', async () => {
+    await withConnection(async (connection) => {
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_func');
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_volatile(scalar_function);
+      const bind_data_object = { 'my_bind_data_key': 'my_bind_data_value' };
+      duckdb.scalar_function_set_bind(scalar_function, (info) => {
+        duckdb.scalar_function_set_bind_data(info, bind_data_object);
+      });
+      const seen_bind_data: (object | undefined)[] = [];
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (info, input, output) => {
+          seen_bind_data.push(duckdb.scalar_function_get_bind_data(info));
+          const rowCount = duckdb.data_chunk_get_size(input);
+          for (let i = 0; i < rowCount; i++) {
+            duckdb.vector_assign_string_element(output, i, 'output');
+          }
+        },
+      );
+      duckdb.register_scalar_function(connection, scalar_function);
+      duckdb.destroy_scalar_function_sync(scalar_function);
+
+      // More than one vector's worth of rows, so the main function runs repeatedly.
+      await duckdb.query(connection, 'select my_func() from range(5000)');
+
+      expect(seen_bind_data.length).toBeGreaterThan(1);
+      for (const bind_data of seen_bind_data) {
+        // The very same JS object, not a copy: the binding holds a live reference to it.
+        expect(bind_data).toBe(bind_data_object);
+      }
+    });
+  });
+  test('bind data survives repeated execution of a prepared statement', async () => {
+    await withConnection(async (connection) => {
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_func');
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_bind(scalar_function, (info) => {
+        duckdb.scalar_function_set_bind_data(info, { 'suffix': 'bind_data' });
+      });
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (info, input, output) => {
+          const bind_data = duckdb.scalar_function_get_bind_data(info) as {
+            suffix: string;
+          };
+          const rowCount = duckdb.data_chunk_get_size(input);
+          for (let i = 0; i < rowCount; i++) {
+            duckdb.vector_assign_string_element(
+              output,
+              i,
+              `output_${i}_${bind_data.suffix}`,
+            );
+          }
+        },
+      );
+      duckdb.register_scalar_function(connection, scalar_function);
+      duckdb.destroy_scalar_function_sync(scalar_function);
+
+      const prepared = await duckdb.prepare(connection, 'select my_func()');
+      for (let i = 0; i < 3; i++) {
+        const result = await duckdb.execute_prepared(prepared);
+        await expectResult(result, {
+          chunkCount: 1,
+          rowCount: 1,
+          columns: [
+            { name: 'my_func()', logicalType: { typeId: duckdb.Type.VARCHAR } },
+          ],
+          chunks: [
+            {
+              rowCount: 1,
+              vectors: [data(16, [true], ['output_0_bind_data'])],
+            },
+          ],
+        });
+      }
+    });
+  });
+  test('bind data can hold values that would not survive serialization', async () => {
+    await withConnection(async (connection) => {
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_func');
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_bind(scalar_function, (info) => {
+        duckdb.scalar_function_set_bind_data(info, {
+          'lookup': new Map([[0, 'zero']]),
+          'describe': (i: number) => `row${i}`,
+        });
+      });
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (info, input, output) => {
+          const bind_data = duckdb.scalar_function_get_bind_data(info) as {
+            lookup: Map<number, string>;
+            describe: (i: number) => string;
+          };
+          const rowCount = duckdb.data_chunk_get_size(input);
+          for (let i = 0; i < rowCount; i++) {
+            duckdb.vector_assign_string_element(
+              output,
+              i,
+              `${bind_data.lookup.get(i)}_${bind_data.describe(i)}`,
+            );
+          }
+        },
+      );
+      duckdb.register_scalar_function(connection, scalar_function);
+      duckdb.destroy_scalar_function_sync(scalar_function);
+
+      const result = await duckdb.query(connection, 'select my_func()');
+      await expectResult(result, {
+        chunkCount: 1,
+        rowCount: 1,
+        columns: [
+          { name: 'my_func()', logicalType: { typeId: duckdb.Type.VARCHAR } },
+        ],
+        chunks: [{ rowCount: 1, vectors: [data(16, [true], ['zero_row0'])] }],
+      });
+    });
+  });
+  test('extra info can hold values that would not survive serialization', async () => {
+    await withConnection(async (connection) => {
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_func');
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_extra_info(scalar_function, {
+        'prefix': () => 'from_extra_info',
+      });
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (info, input, output) => {
+          const extra_info = duckdb.scalar_function_get_extra_info(info) as {
+            prefix: () => string;
+          };
+          const rowCount = duckdb.data_chunk_get_size(input);
+          for (let i = 0; i < rowCount; i++) {
+            duckdb.vector_assign_string_element(
+              output,
+              i,
+              `${extra_info.prefix()}_${i}`,
+            );
+          }
+        },
+      );
+      duckdb.register_scalar_function(connection, scalar_function);
+      duckdb.destroy_scalar_function_sync(scalar_function);
+
+      const result = await duckdb.query(connection, 'select my_func()');
+      await expectResult(result, {
+        chunkCount: 1,
+        rowCount: 1,
+        columns: [
+          { name: 'my_func()', logicalType: { typeId: duckdb.Type.VARCHAR } },
+        ],
+        chunks: [
+          { rowCount: 1, vectors: [data(16, [true], ['from_extra_info_0'])] },
+        ],
+      });
+    });
+  });
 });

--- a/bindings/test/stress/scalar_function_refs.test.ts
+++ b/bindings/test/stress/scalar_function_refs.test.ts
@@ -1,6 +1,8 @@
 import duckdb from '@duckdb/node-bindings';
+import { createRequire } from 'node:module';
 import v8 from 'node:v8';
 import vm from 'node:vm';
+import { Worker } from 'node:worker_threads';
 import { expect, suite, test } from 'vitest';
 import { withConnection } from '../utils/withConnection';
 import { withDatabase } from '../utils/withDatabase';
@@ -15,6 +17,15 @@ import { withDatabase } from '../utils/withDatabase';
 // any suite; see the comment on duckdb_node_instrument_napi_refs in binding.gyp.
 
 // Obtain gc() without requiring the process to be launched with --expose-gc.
+//
+// Vitest's default pool is 'forks', so this runs on the only JS thread of a
+// dedicated child process. If the pool is ever switched to 'threads', mutating
+// process-global V8 flags while sibling threads run JS is unsafe, and this
+// should move behind an --expose-gc launch flag instead.
+//
+// Note that gc() cannot collect the objects under test, because the bindings
+// hold them strongly. That is the point: these tests verify the reference is
+// strong rather than weak, and that reaping survives collection activity.
 v8.setFlagsFromString('--expose-gc');
 const forceGC = vm.runInNewContext('gc') as () => void;
 v8.setFlagsFromString('--no-expose-gc');
@@ -87,19 +98,23 @@ suite('scalar function reference lifetime', () => {
         gcInMainFunction: true,
       });
       for (let i = 0; i < 20; i++) {
+        // One chunk per query, so one call per query.
         await duckdb.query(connection, 'select my_func() from range(100)');
       }
-      expect(fn.callCount()).toBeGreaterThanOrEqual(20);
+      expect(fn.callCount()).toBe(20);
     });
   });
 
-  test('repeated register and destroy cycles under GC pressure', async () => {
+  // Note that only bind data is destroyed off the JS thread here. Extra info is
+  // owned by the catalog entry and released at disconnect/close, both of which
+  // run on the JS thread, so it always takes the reaper's inline path.
+  test('many registered functions under GC pressure', async () => {
     await withConnection(async (connection) => {
       for (let i = 0; i < 100; i++) {
         const name = `my_func_${i}`;
         const fn = registerCheckedFunction(connection, name);
         await duckdb.query(connection, `select ${name}() from range(100)`);
-        expect(fn.callCount()).toBeGreaterThan(0);
+        expect(fn.callCount()).toBe(1);
         if (i % 10 === 0) {
           forceGC();
         }
@@ -109,6 +124,7 @@ suite('scalar function reference lifetime', () => {
   });
 
   test('concurrent queries while the JS thread is busy', async () => {
+    const rounds = 25;
     await withDatabase({}, async (db) => {
       const registrar = await duckdb.connect(db);
       const connections: duckdb.Connection[] = [];
@@ -131,16 +147,33 @@ suite('scalar function reference lifetime', () => {
           }
         })();
 
-        await Promise.all(
-          connections.map((connection) =>
-            duckdb.query(connection, 'select my_func() from range(5000)'),
-          ),
-        );
+        try {
+          // Each round is 8 connections x 3 chunks of 5000 rows.
+          //
+          // allSettled rather than all, and a finally around the churn loop, are
+          // both load bearing on the failure path: Promise.all would reject on
+          // the first bad query and leave the other seven in flight, and the
+          // teardown below would then disconnect underneath them and hang. The
+          // point of this test is to fail loudly, not to wedge the run.
+          for (let round = 0; round < rounds; round++) {
+            const results = await Promise.allSettled(
+              connections.map((connection) =>
+                duckdb.query(connection, 'select my_func() from range(5000)'),
+              ),
+            );
+            const rejected = results.filter((r) => r.status === 'rejected');
+            if (rejected.length > 0) {
+              throw new Error(
+                `${rejected.length} of ${results.length} queries failed in round ${round}: ${rejected[0].reason}`,
+              );
+            }
+          }
+        } finally {
+          churning = false;
+          await churning_promise;
+        }
 
-        churning = false;
-        await churning_promise;
-
-        expect(fn.callCount()).toBeGreaterThan(8);
+        expect(fn.callCount()).toBe(connections.length * 3 * rounds);
       } finally {
         for (const connection of connections) {
           duckdb.disconnect_sync(connection);
@@ -149,5 +182,91 @@ suite('scalar function reference lifetime', () => {
       }
       forceGC();
     });
+  });
+
+  // The reaper is owned by the addon and therefore scoped to a napi_env. Under
+  // worker_threads the addon is instantiated per env, so this covers both that
+  // scoping and the env teardown path that runs NapiRefReaper::Shutdown -- which
+  // never runs for the main env, since Node skips instance data finalizers at
+  // process exit.
+  test('references are reaped per env under worker_threads', async () => {
+    const bindings_path = createRequire(import.meta.url).resolve(
+      '@duckdb/node-bindings',
+    );
+    const queries_per_worker = 25;
+    const chunks_per_query = 3; // range(5000) at a vector size of 2048
+
+    const worker_source = `
+      const { parentPort, workerData } = require('node:worker_threads');
+      const duckdb = require(workerData.bindings_path);
+      (async () => {
+        const db = await duckdb.open();
+        const connection = await duckdb.connect(db);
+        const fn = duckdb.create_scalar_function();
+        duckdb.scalar_function_set_name(fn, 'my_func');
+        duckdb.scalar_function_set_return_type(
+          fn,
+          duckdb.create_logical_type(duckdb.Type.VARCHAR),
+        );
+        duckdb.scalar_function_set_volatile(fn);
+        duckdb.scalar_function_set_extra_info(fn, { token: 'extra_info' });
+        duckdb.scalar_function_set_bind(fn, (info) => {
+          duckdb.scalar_function_set_bind_data(info, { token: 'bind_data' });
+        });
+        let calls = 0;
+        duckdb.scalar_function_set_function(fn, (info, input, output) => {
+          calls++;
+          const bind_data = duckdb.scalar_function_get_bind_data(info);
+          const extra_info = duckdb.scalar_function_get_extra_info(info);
+          if (bind_data.token !== 'bind_data' || extra_info.token !== 'extra_info') {
+            throw new Error('reference corrupted in worker');
+          }
+          const rowCount = duckdb.data_chunk_get_size(input);
+          for (let i = 0; i < rowCount; i++) {
+            duckdb.vector_assign_string_element(output, i, 'ok');
+          }
+        });
+        duckdb.register_scalar_function(connection, fn);
+        duckdb.destroy_scalar_function_sync(fn);
+        for (let i = 0; i < ${queries_per_worker}; i++) {
+          await duckdb.query(connection, 'select my_func() from range(5000)');
+        }
+        duckdb.disconnect_sync(connection);
+        duckdb.close_sync(db);
+        parentPort.postMessage({ calls });
+      })().catch((e) => {
+        parentPort.postMessage({ error: String((e && e.message) || e) });
+      });
+    `;
+
+    function runWorker(): Promise<{ calls?: number; error?: string }> {
+      return new Promise((resolve, reject) => {
+        const worker = new Worker(worker_source, {
+          eval: true,
+          workerData: { bindings_path },
+        });
+        let message: { calls?: number; error?: string } | undefined;
+        worker.on('message', (m) => {
+          message = m;
+        });
+        worker.on('error', reject);
+        worker.on('exit', (code) => {
+          if (code !== 0) {
+            reject(new Error(`worker exited with code ${code}`));
+          } else {
+            resolve(message ?? { error: 'worker sent no message' });
+          }
+        });
+      });
+    }
+
+    // Several envs concurrently, each with its own addon instance and reaper.
+    const results = await Promise.all(
+      Array.from({ length: 4 }, () => runWorker()),
+    );
+    for (const result of results) {
+      expect(result.error).toBeUndefined();
+      expect(result.calls).toBe(queries_per_worker * chunks_per_query);
+    }
   });
 });

--- a/bindings/test/stress/scalar_function_refs.test.ts
+++ b/bindings/test/stress/scalar_function_refs.test.ts
@@ -1,0 +1,153 @@
+import duckdb from '@duckdb/node-bindings';
+import v8 from 'node:v8';
+import vm from 'node:vm';
+import { expect, suite, test } from 'vitest';
+import { withConnection } from '../utils/withConnection';
+import { withDatabase } from '../utils/withDatabase';
+
+// These tests exercise the lifetime of the Napi::ObjectReferences held for
+// user-supplied extra info and bind data (see src/napi_ref_reaper.h). They are
+// slower and less deterministic than the main suite, so they are excluded from
+// `pnpm test` and run with `pnpm test:stress`.
+//
+// To check the invariant these tests are protecting -- that a reference is only
+// ever destroyed on the JS thread -- build with instrumentation enabled and run
+// any suite; see the comment on duckdb_node_instrument_napi_refs in binding.gyp.
+
+// Obtain gc() without requiring the process to be launched with --expose-gc.
+v8.setFlagsFromString('--expose-gc');
+const forceGC = vm.runInNewContext('gc') as () => void;
+v8.setFlagsFromString('--no-expose-gc');
+
+// Registers a scalar function that checks, on every invocation, that the objects
+// it was given at registration and bind time are still intact. A mismatch throws,
+// which the bindings surface as a query error, failing the awaiting test.
+//
+// Nothing on the JS side retains these objects: only the references taken by the
+// bindings keep them alive.
+function registerCheckedFunction(
+  connection: duckdb.Connection,
+  name: string,
+  { gcInMainFunction = false }: { gcInMainFunction?: boolean } = {},
+): { callCount: () => number } {
+  let calls = 0;
+  const scalar_function = duckdb.create_scalar_function();
+  duckdb.scalar_function_set_name(scalar_function, name);
+  const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+  duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+  duckdb.scalar_function_set_volatile(scalar_function);
+  duckdb.scalar_function_set_extra_info(scalar_function, {
+    'extra_info_token': `extra_info_${name}`,
+  });
+  duckdb.scalar_function_set_bind(scalar_function, (info) => {
+    const extra_info = duckdb.scalar_function_bind_get_extra_info(info) as {
+      extra_info_token: string;
+    };
+    if (extra_info?.extra_info_token !== `extra_info_${name}`) {
+      throw new Error(`extra info corrupted during bind of ${name}`);
+    }
+    duckdb.scalar_function_set_bind_data(info, {
+      'bind_data_token': `bind_data_${name}`,
+    });
+  });
+  duckdb.scalar_function_set_function(
+    scalar_function,
+    (info, input, output) => {
+      if (gcInMainFunction) {
+        forceGC();
+      }
+      calls++;
+      const bind_data = duckdb.scalar_function_get_bind_data(info) as {
+        bind_data_token: string;
+      };
+      const extra_info = duckdb.scalar_function_get_extra_info(info) as {
+        extra_info_token: string;
+      };
+      if (bind_data?.bind_data_token !== `bind_data_${name}`) {
+        throw new Error(`bind data corrupted in ${name}`);
+      }
+      if (extra_info?.extra_info_token !== `extra_info_${name}`) {
+        throw new Error(`extra info corrupted in ${name}`);
+      }
+      const rowCount = duckdb.data_chunk_get_size(input);
+      for (let i = 0; i < rowCount; i++) {
+        duckdb.vector_assign_string_element(output, i, 'ok');
+      }
+    },
+  );
+  duckdb.register_scalar_function(connection, scalar_function);
+  duckdb.destroy_scalar_function_sync(scalar_function);
+  return { callCount: () => calls };
+}
+
+suite('scalar function reference lifetime', () => {
+  test('bind data and extra info survive garbage collection', async () => {
+    await withConnection(async (connection) => {
+      const fn = registerCheckedFunction(connection, 'my_func', {
+        gcInMainFunction: true,
+      });
+      for (let i = 0; i < 20; i++) {
+        await duckdb.query(connection, 'select my_func() from range(100)');
+      }
+      expect(fn.callCount()).toBeGreaterThanOrEqual(20);
+    });
+  });
+
+  test('repeated register and destroy cycles under GC pressure', async () => {
+    await withConnection(async (connection) => {
+      for (let i = 0; i < 100; i++) {
+        const name = `my_func_${i}`;
+        const fn = registerCheckedFunction(connection, name);
+        await duckdb.query(connection, `select ${name}() from range(100)`);
+        expect(fn.callCount()).toBeGreaterThan(0);
+        if (i % 10 === 0) {
+          forceGC();
+        }
+      }
+      forceGC();
+    });
+  });
+
+  test('concurrent queries while the JS thread is busy', async () => {
+    await withDatabase({}, async (db) => {
+      const registrar = await duckdb.connect(db);
+      const connections: duckdb.Connection[] = [];
+      try {
+        const fn = registerCheckedFunction(registrar, 'my_func');
+        for (let i = 0; i < 8; i++) {
+          connections.push(await duckdb.connect(db));
+        }
+
+        // Keep the event loop busy so reference reaping has to contend with real
+        // JS activity rather than an idle main thread.
+        let churning = true;
+        const churning_promise = (async () => {
+          while (churning) {
+            const garbage: object[] = [];
+            for (let i = 0; i < 10000; i++) {
+              garbage.push({ i });
+            }
+            await new Promise((resolve) => setImmediate(resolve));
+          }
+        })();
+
+        await Promise.all(
+          connections.map((connection) =>
+            duckdb.query(connection, 'select my_func() from range(5000)'),
+          ),
+        );
+
+        churning = false;
+        await churning_promise;
+
+        expect(fn.callCount()).toBeGreaterThan(8);
+      } finally {
+        for (const connection of connections) {
+          duckdb.disconnect_sync(connection);
+        }
+        duckdb.disconnect_sync(registrar);
+      }
+      forceGC();
+    });
+  });
+});


### PR DESCRIPTION
Scalar function extra info and bind data hold user-supplied JS objects as
`Napi::ObjectReference`s, but the structs holding them are owned by DuckDB and
freed by DuckDB's delete callbacks, which run on whatever thread tears down the
plan.

Instrumenting those callbacks showed `DeleteScalarFunctionInternalBindData` runs
on a DuckDB worker thread **every time**, with a live reference. Its destructor
calls `napi_delete_reference`, which mutates V8's global handle table. N-API
requires that on the thread owning the `napi_env`, and Node does not lock the
isolate, so this was a data race. It went unnoticed because the main thread is
usually parked in the event loop while the worker deletes the reference; it needs
concurrent JS activity to bite.

`CopyScalarFunctionInternalBindData` had the same hazard and worse: it called
`Value()` and `Persistent()` — reference *reads and creation* — from an arbitrary
thread.

## The fix

`NapiRefReaper` (`bindings/src/napi_ref_reaper.h`), owned by the addon and
therefore scoped to a `napi_env` rather than a file-scope global, which matters
under `worker_threads` where the addon is instantiated per env. References are
destroyed on the JS thread, either inline when the delete callback already runs
there, or by handing them to an unref'd thread-safe function. Both paths are
exercised in practice — measured 5 deferred vs 3 inline across the scalar tests.

References are held by `shared_ptr`, which also makes the bind data copy callback
a refcount bump with no N-API call at all.

## Verification

`DUCKDB_NODE_INSTRUMENT_NAPI_REFS` is a gyp define, off by default, that aborts if
a reference is ever destroyed off the JS thread. It adds nothing to the exposed
API. Confirmed it can actually fail: temporarily bypassing the reaper makes the
existing scalar tests abort immediately with
`FATAL: Napi::ObjectReference destroyed off the JS thread`.

The Linux x64 glibc job now runs an instrumented build on PRs, measured at roughly
10–20 seconds since `libduckdb` and `node_modules` are already in place by that
point. Without it the documented manual procedure would be run once and forgotten,
right before four more callbacks start using this machinery for table functions.

## Tests

Four tests in the main suite covering bind data object identity across calls,
survival across repeated prepared-statement execution, and bind data and extra
info holding a `Map` and a closure.

**These would all have passed against the pre-fix code.** That is inherent — the
bug is a data race inside `napi_delete_reference`, which no black-box JS assertion
observes deterministically. What they guard is a different and still useful
invariant: that a live reference is held, so anyone "fixing" this later by
serializing would fail hard. The instrumented build is the real regression guard.

A stress suite in `bindings/test/stress/` covers GC pressure, concurrency, and
`worker_threads` — the last being the only path that runs `Shutdown()`, since Node
skips instance-data finalizers for the main env at process exit. It is excluded
from `pnpm test` and run with `pnpm test:stress`.

## Notes

- No query shape found so far copies scalar function bind data. 18 were tried
  (common subexpressions, filter pushdown, joins, set operations, windows,
  subqueries, CTAS, repeated prepared execution) and DuckDB 1.5.5 copies for none
  of them. The callback is still registered and is now safe if reached.
- The bind and main TSFNs are created with `initialThreadCount = 1` and called from
  DuckDB threads that never `Acquire()`. Pre-existing and untouched here, but worth
  being deliberate about when table functions copy this pattern across four
  callbacks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
