### PR TITLE
Stop a registered scalar function from keeping its process alive

### DIFF
--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -3021,7 +3021,7 @@ private:
     auto env = info.Env();
     auto holder = GetScalarFunctionHolderFromExternal(env, info[0]);
     auto user_extra_info = info[1].As<Napi::Object>();
-    holder->EnsureInternalExtraInfo();
+    holder->EnsureInternalExtraInfo(ref_reaper);
     holder->internal_extra_info->SetUserExtraInfo(ref_reaper, user_extra_info);
     return env.Undefined();
   }
@@ -3032,7 +3032,7 @@ private:
     auto env = info.Env();
     auto holder = GetScalarFunctionHolderFromExternal(env, info[0]);
     auto func = info[1].As<Napi::Function>();
-    holder->EnsureInternalExtraInfo();
+    holder->EnsureInternalExtraInfo(ref_reaper);
     holder->internal_extra_info->SetBindFunction(env, func);
     duckdb_scalar_function_set_bind(holder->scalar_function, &ScalarFunctionBindFunction);
     return env.Undefined();
@@ -3070,7 +3070,7 @@ private:
     auto env = info.Env();
     auto holder = GetScalarFunctionHolderFromExternal(env, info[0]);
     auto func = info[1].As<Napi::Function>();
-    holder->EnsureInternalExtraInfo();
+    holder->EnsureInternalExtraInfo(ref_reaper);
     holder->internal_extra_info->SetMainFunction(env, func);
     duckdb_scalar_function_set_function(holder->scalar_function, &ScalarFunctionMainFunction);
     return env.Undefined();

--- a/bindings/src/externals.h
+++ b/bindings/src/externals.h
@@ -345,9 +345,20 @@ struct ScalarFunctionInternalExtraInfo {
   std::unique_ptr<ScalarFunctionMainTSFN> main_tsfn;
   std::shared_ptr<ManagedObjectReference> user_extra_info_ref;
 
-  ScalarFunctionInternalExtraInfo() {}
+  // Held to answer one question: is the env still alive? See the destructor.
+  std::shared_ptr<NapiRefReaper> env_state;
+
+  explicit ScalarFunctionInternalExtraInfo(std::shared_ptr<NapiRefReaper> env_state_in)
+    : env_state(std::move(env_state_in)) {}
 
   ~ScalarFunctionInternalExtraInfo() {
+    // Once the env has begun tearing down, Node has already destroyed these
+    // thread-safe functions, and releasing them again is a use-after-free. Node
+    // runs env cleanup hooks before finalizers, so this is accurate by the time
+    // this destructor runs from one.
+    if (!env_state || !env_state->EnvIsAlive()) {
+      return;
+    }
     if (bool(bind_tsfn)) {
       bind_tsfn->Release();
     }
@@ -356,11 +367,20 @@ struct ScalarFunctionInternalExtraInfo {
     }
   }
 
+  // Thread-safe functions are created referenced, which keeps the event loop
+  // alive for as long as they exist. These are only released when this extra
+  // info is destroyed, which needs the scalar function to be unregistered and
+  // its handle destroyed -- so a registered scalar function would otherwise stop
+  // its process (or its worker thread) from ever exiting. Unreferencing them is
+  // safe: a call in flight is always inside a query, and the async worker
+  // running that query keeps the loop alive on its own.
+
   void SetBindFunction(Napi::Env env, Napi::Function func) {
     if (bool(bind_tsfn)) {
       bind_tsfn->Release();
     }
     bind_tsfn = std::make_unique<ScalarFunctionBindTSFN>(ScalarFunctionBindTSFN::New(env, func, "ScalarFunctionBind", 0, 1));
+    bind_tsfn->Unref(env);
   }
 
   void SetMainFunction(Napi::Env env, Napi::Function func) {
@@ -368,6 +388,7 @@ struct ScalarFunctionInternalExtraInfo {
       main_tsfn->Release();
     }
     main_tsfn = std::make_unique<ScalarFunctionMainTSFN>(ScalarFunctionMainTSFN::New(env, func, "ScalarFunctionMain", 0, 1));
+    main_tsfn->Unref(env);
   }
 
   void SetUserExtraInfo(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object user_extra_info) {
@@ -390,9 +411,9 @@ struct ScalarFunctionHolder {
     duckdb_destroy_scalar_function(&scalar_function);
   }
 
-  ScalarFunctionInternalExtraInfo *EnsureInternalExtraInfo() {
+  ScalarFunctionInternalExtraInfo *EnsureInternalExtraInfo(const std::shared_ptr<NapiRefReaper> &env_state) {
     if (!internal_extra_info) {
-      internal_extra_info = new ScalarFunctionInternalExtraInfo();
+      internal_extra_info = new ScalarFunctionInternalExtraInfo(env_state);
       duckdb_scalar_function_set_extra_info(scalar_function, internal_extra_info, reinterpret_cast<duckdb_delete_callback_t>(DeleteScalarFunctionInternalExtraInfo));
     }
     return internal_extra_info;

--- a/bindings/src/napi_ref_reaper.h
+++ b/bindings/src/napi_ref_reaper.h
@@ -91,6 +91,15 @@ public:
     return std::this_thread::get_id() == js_thread_id;
   }
 
+  // Whether the env is still usable. Goes false from the env cleanup hook below,
+  // which Node runs before finalizers, so anything destroyed by a finalizer can
+  // consult this to find out whether the N-API objects it owns have already been
+  // torn down. Scalar function extra info uses it to avoid releasing thread-safe
+  // functions Node has already destroyed.
+  bool EnvIsAlive() const {
+    return alive;
+  }
+
   // Called on the JS thread when the addon is torn down.
   void Shutdown() {
     std::lock_guard<std::mutex> lock(mutex);

--- a/bindings/test/fixtures/scalarFunctionExit.cjs
+++ b/bindings/test/fixtures/scalarFunctionExit.cjs
@@ -1,0 +1,65 @@
+// Registers a scalar function and then lets the script end, so the parent test
+// can check whether the process exits on its own.
+//
+// Thread-safe functions are created referenced and hold the event loop open, so
+// unless they are unreferenced a registered scalar function keeps its process
+// alive indefinitely. The database is deliberately left open in most scenarios:
+// closing it destroys the extra info, which releases the thread-safe functions
+// and hides the problem.
+//
+// Run as: node scalarFunctionExit.cjs <scenario>, with the bindings package
+// resolvable from the working directory.
+
+const duckdb = require('@duckdb/node-bindings');
+
+const scenario = process.argv[2];
+
+async function main() {
+  const db = await duckdb.open();
+  const connection = await duckdb.connect(db);
+
+  const scalar_function = duckdb.create_scalar_function();
+  duckdb.scalar_function_set_name(scalar_function, 'my_func');
+  duckdb.scalar_function_set_return_type(
+    scalar_function,
+    duckdb.create_logical_type(duckdb.Type.VARCHAR),
+  );
+  duckdb.scalar_function_set_bind(scalar_function, (info) => {
+    duckdb.scalar_function_set_bind_data(info, { 'token': 'bind_data' });
+  });
+  duckdb.scalar_function_set_function(
+    scalar_function,
+    (_info, input, output) => {
+      const rowCount = duckdb.data_chunk_get_size(input);
+      for (let i = 0; i < rowCount; i++) {
+        duckdb.vector_assign_string_element(output, i, 'ok');
+      }
+    },
+  );
+  duckdb.register_scalar_function(connection, scalar_function);
+
+  if (scenario !== 'registered_handle_kept') {
+    duckdb.destroy_scalar_function_sync(scalar_function);
+  }
+
+  if (scenario !== 'registered_never_called') {
+    await duckdb.query(connection, 'select my_func() from range(10)');
+  }
+
+  if (scenario === 'closed') {
+    duckdb.disconnect_sync(connection);
+    duckdb.close_sync(db);
+  }
+
+  // Deliberately keep the database and connection reachable from module scope in
+  // the other scenarios, so nothing is collected and closed by a finalizer.
+  globalThis.__kept = { db, connection };
+}
+
+main().then(
+  () => process.stdout.write('done\n'),
+  (e) => {
+    process.stderr.write(`${(e && e.message) || e}\n`);
+    process.exitCode = 1;
+  },
+);

--- a/bindings/test/scalar_function_exit.test.ts
+++ b/bindings/test/scalar_function_exit.test.ts
@@ -1,0 +1,82 @@
+import { execFile } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { expect, suite, test } from 'vitest';
+
+// A registered scalar function must not keep its process alive. Its thread-safe
+// functions are created referenced, and they are only released when the scalar
+// function's extra info is destroyed -- which requires the database to be closed
+// or garbage collected. Without unreferencing them, a program that registers a
+// scalar function and keeps its database open never exits.
+//
+// These spawn a real process because that is the only way to observe it: within
+// a single process the condition is "the event loop never drains", which has no
+// in-process assertion.
+
+const fixturePath = fileURLToPath(
+  new URL('./fixtures/scalarFunctionExit.cjs', import.meta.url),
+);
+const bindingsRoot = fileURLToPath(new URL('..', import.meta.url));
+
+// The fixture exits in well under a second when the bug is absent, and hangs
+// forever when it is present. This only needs to outlast a slow process start.
+//
+// It must also stay below the per-test timeout below, so that execFile is what
+// kills a hung child: if vitest times the test out first, the child is left
+// running.
+const exitTimeoutMs = 8000;
+const testTimeoutMs = 30000;
+
+function runFixture(
+  scenario: string,
+): Promise<{ stdout: string; stderr: string; killed: boolean; code: number | null }> {
+  return new Promise((resolve, reject) => {
+    const child = execFile(
+      process.execPath,
+      [fixturePath, scenario],
+      { cwd: bindingsRoot, timeout: exitTimeoutMs },
+      (error, stdout, stderr) => {
+        if (error && !(error as { killed?: boolean }).killed) {
+          reject(
+            new Error(`fixture failed: ${error.message}\nstderr: ${stderr}`),
+          );
+          return;
+        }
+        resolve({
+          stdout,
+          stderr,
+          killed: Boolean((error as { killed?: boolean } | null)?.killed),
+          code: child.exitCode,
+        });
+      },
+    );
+  });
+}
+
+async function expectExits(scenario: string) {
+  const result = await runFixture(scenario);
+  expect(result.stderr).toBe('');
+  expect(result.stdout.trim()).toBe('done');
+  // killed means execFile's timeout fired, i.e. the process never exited.
+  expect(
+    result.killed,
+    `process did not exit within ${exitTimeoutMs}ms for scenario "${scenario}"`,
+  ).toBe(false);
+}
+
+suite('scalar function process exit', () => {
+  test('exits after closing the database', async () => {
+    // Control: this passed even before the thread-safe functions were
+    // unreferenced, because closing destroys the extra info and releases them.
+    await expectExits('closed');
+  }, testTimeoutMs);
+  test('exits with the database left open', async () => {
+    await expectExits('database_left_open');
+  }, testTimeoutMs);
+  test('exits when the function was never called', async () => {
+    // Registering alone creates the thread-safe functions, so this hangs too.
+    await expectExits('registered_never_called');
+  }, testTimeoutMs);
+  test('exits when the function handle was never destroyed', async () => {
+    await expectExits('registered_handle_kept');
+  }, testTimeoutMs);
+});


### PR DESCRIPTION
Thread-safe functions are created referenced, so they hold the event loop open for
as long as they exist. The bind and main thread-safe functions are only released
when a scalar function's extra info is destroyed, which needs the database closed
or garbage collected. So registering a scalar function and leaving the database
open meant **the process never exited**. Registering alone was enough — it did not
even need to be called.

Measured at the bindings layer, 10s cap:

| scenario | before |
|---|---|
| register, query, `disconnect_sync` + `close_sync` | exits in 8ms |
| register, query, leave the database open | **hangs forever** |
| register, never destroy the function handle | **hangs forever** |
| register, never even run a query | **hangs forever** |

Confirmed against a1c231f, so this predates the reaper work in #456.

Through the api layer the symptom is worse to diagnose, because it looks
intermittent rather than broken. The instance eventually becomes garbage and its
finalizer closes the database, so a small program does exit — after however long
GC takes to get to it, measured at **8.1 seconds** in one run, and never if the
instance stays reachable, which it does in any long-lived process.

## The fix

Unreference both thread-safe functions. Nothing is lost: a call in flight is
always inside a query, and the async worker running that query keeps the loop
alive on its own.

That alone turns the hang into an **abort**. Once the loop can drain, Node tears
the env down, destroying the thread-safe functions before it runs finalizers —
and the finalizer that destroys the extra info then released them again, which is
a use-after-free. Node runs env cleanup hooks before finalizers, so the reaper's
existing liveness flag is already accurate by then; consult it and skip the
release when the env is going away. Nothing leaks by skipping, because Node has
already destroyed them.

## Tests

Exit behaviour can only be observed from outside the process, so the tests spawn a
real one per scenario. Both halves of the fix are load bearing, and the tests fail
without either:

- remove the unreference → the three open-database scenarios hang, and fail with
  `process did not exit within 8000ms`
- remove the liveness check → they abort, and fail with a non-zero exit

The `execFile` timeout is deliberately below the per-test timeout, so a hung child
is killed by `execFile` rather than left running by a vitest timeout.

Verified on macOS and in a Linux container: bindings, stress, and api suites pass
under both the normal and instrumented builds.

## Note for table functions

Table functions add four more thread-safe functions per registered function, so
they inherit this trap directly. Doing this first means that work starts from the
right pattern rather than reproducing the bug four more times.

Separately, and not addressed here: the thread-safe functions are created with
`initialThreadCount = 1` and called from DuckDB threads that never `Acquire()`.
That deviation is safe today because `ScalarFunction` holds
`shared_ptr<ScalarFunctionInfo>` and every bound expression holds the function by
value, so the extra info cannot be destroyed while a call is in flight. It is an
invariant worth stating rather than a bug to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
