### PR TITLE
Extract a helper for JS callbacks invoked from DuckDB threads

### DIFF
--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -13,6 +13,7 @@
 #include "bindings_config.h"
 #include "conversion_helpers.h"
 #include "externals.h"
+#include "napi_ref_reaper.h"
 #include "scalar_function_helpers.h"
 #include "promise_workers.h"
 #include "enums.h"

--- a/bindings/src/duckdb_thread_callback.h
+++ b/bindings/src/duckdb_thread_callback.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "napi_setup.h"
+#include "duckdb.h"
 #include "napi_ref_reaper.h"
 #include <condition_variable>
 #include <memory>
@@ -35,14 +36,14 @@
 //   static void Call(Napi::Env, Napi::Function, const Payload &);
 //   static void SetError(const Payload &, const char *message);
 
-// One in-flight call. Lives on the calling DuckDB thread's stack: Invoke does not
-// return until the dispatch below has signalled, including when it is draining.
+// One in-flight call, allocated by the calling DuckDB thread and freed by it once
+// the dispatch below has signalled.
 template <typename Traits>
 struct DuckDBThreadCallbackCall {
   typename Traits::Payload payload;
-  std::condition_variable cv;
-  std::mutex mutex;
-  bool done = false;
+  std::condition_variable *cv;
+  std::mutex *mutex;
+  bool done;
 };
 
 template <typename Traits>
@@ -59,10 +60,13 @@ void DuckDBThreadCallbackDispatch(Napi::Env env, Napi::Function callback, std::n
     }
   }
   {
-    std::lock_guard<std::mutex> lock(call->mutex);
+    // Signal while still holding the lock. The waiting thread frees this call
+    // once it wakes, so notifying after releasing the lock would let it destroy
+    // the condition variable before notify_one touches it.
+    std::lock_guard<std::mutex> lock(*call->mutex);
     call->done = true;
+    call->cv->notify_one();
   }
-  call->cv.notify_one();
 }
 
 template <typename Traits>
@@ -99,17 +103,23 @@ public:
     if (!tsfn) {
       return;
     }
-    DuckDBThreadCallbackCall<Traits> call;
-    call.payload = payload;
+    auto call = reinterpret_cast<DuckDBThreadCallbackCall<Traits>*>(duckdb_malloc(sizeof(DuckDBThreadCallbackCall<Traits>)));
+    call->payload = payload;
+    call->cv = new std::condition_variable;
+    call->mutex = new std::mutex;
+    call->done = false;
     // The "blocking" part of BlockingCall only waits for queue space, and the
     // queue is unlimited, so it never actually blocks. Waiting for the JS
     // function to run is the wait below.
-    if (tsfn->BlockingCall(&call) != napi_ok) {
+    if (tsfn->BlockingCall(call) == napi_ok) {
+      std::unique_lock<std::mutex> lock(*call->mutex);
+      call->cv->wait(lock, [call] { return call->done; });
+    } else {
       Traits::SetError(payload, "BlockingCall returned not ok");
-      return;
     }
-    std::unique_lock<std::mutex> lock(call.mutex);
-    call.cv.wait(lock, [&call] { return call.done; });
+    delete call->cv;
+    delete call->mutex;
+    duckdb_free(call);
   }
 
 private:

--- a/bindings/src/duckdb_thread_callback.h
+++ b/bindings/src/duckdb_thread_callback.h
@@ -1,0 +1,129 @@
+#pragma once
+
+#include "napi_setup.h"
+#include "napi_ref_reaper.h"
+#include <condition_variable>
+#include <memory>
+#include <mutex>
+
+// A JS function that DuckDB invokes from its own threads.
+//
+// DuckDB calls the bind and main callbacks of a scalar function -- and, for other
+// function families, init and local init as well -- on worker threads. JS can
+// only run on the JS thread, so each call is handed to a thread-safe function and
+// the calling DuckDB thread blocks until it has run.
+//
+// Three lifetime rules are encoded here. Each of them was a bug before it was a
+// rule, and each fails silently until it doesn't, so new function families should
+// use this rather than hand-rolling the same sequence:
+//
+//  1. Thread-safe functions are created referenced, and a referenced one holds the
+//     event loop open. One that outlives a query would keep the process alive, so
+//     it is unreferenced immediately. Nothing is lost by doing so: a call in
+//     flight is always inside a query, and that query's async worker holds the
+//     loop open on its own.
+//  2. Node destroys thread-safe functions during env teardown, before it runs
+//     finalizers. Releasing one from a finalizer after that point is a
+//     use-after-free, so the release is skipped once the env is gone. Nothing
+//     leaks by skipping it, since Node has already destroyed them.
+//  3. Replacing a callback releases the one it replaces, so repeatedly setting a
+//     callback does not accumulate thread-safe functions.
+//
+// Traits supplies the per-callback details:
+//   using Payload = ...;                  // arguments for one call; copyable
+//   static const char *ResourceName();
+//   static void Call(Napi::Env, Napi::Function, const Payload &);
+//   static void SetError(const Payload &, const char *message);
+
+// One in-flight call. Lives on the calling DuckDB thread's stack: Invoke does not
+// return until the dispatch below has signalled, including when it is draining.
+template <typename Traits>
+struct DuckDBThreadCallbackCall {
+  typename Traits::Payload payload;
+  std::condition_variable cv;
+  std::mutex mutex;
+  bool done = false;
+};
+
+template <typename Traits>
+void DuckDBThreadCallbackDispatch(Napi::Env env, Napi::Function callback, std::nullptr_t *,
+                                  DuckDBThreadCallbackCall<Traits> *call) {
+  // env is null when the thread-safe function is draining during teardown. The
+  // JS function cannot run then, but the waiting DuckDB thread must still be
+  // released, so the signalling below is unconditional.
+  if (env != nullptr && callback != nullptr) {
+    try {
+      Traits::Call(env, callback, call->payload);
+    } catch (const Napi::Error &error) {
+      Traits::SetError(call->payload, error.Message().c_str());
+    }
+  }
+  {
+    std::lock_guard<std::mutex> lock(call->mutex);
+    call->done = true;
+  }
+  call->cv.notify_one();
+}
+
+template <typename Traits>
+class DuckDBThreadCallback {
+
+public:
+
+  using TSFN = Napi::TypedThreadSafeFunction<std::nullptr_t, DuckDBThreadCallbackCall<Traits>,
+                                             DuckDBThreadCallbackDispatch<Traits>>;
+
+  explicit DuckDBThreadCallback(std::shared_ptr<NapiRefReaper> env_state_in)
+    : env_state(std::move(env_state_in)) {}
+
+  ~DuckDBThreadCallback() {
+    Release();
+  }
+
+  DuckDBThreadCallback(const DuckDBThreadCallback &) = delete;
+  DuckDBThreadCallback &operator=(const DuckDBThreadCallback &) = delete;
+
+  bool IsSet() const {
+    return bool(tsfn);
+  }
+
+  // Called on the JS thread.
+  void Set(Napi::Env env, Napi::Function func) {
+    Release();
+    tsfn = std::make_unique<TSFN>(TSFN::New(env, func, Traits::ResourceName(), 0, 1));
+    tsfn->Unref(env); // Rule 1.
+  }
+
+  // Called on a DuckDB thread. Blocks until the JS function has run.
+  void Invoke(typename Traits::Payload payload) {
+    if (!tsfn) {
+      return;
+    }
+    DuckDBThreadCallbackCall<Traits> call;
+    call.payload = payload;
+    // The "blocking" part of BlockingCall only waits for queue space, and the
+    // queue is unlimited, so it never actually blocks. Waiting for the JS
+    // function to run is the wait below.
+    if (tsfn->BlockingCall(&call) != napi_ok) {
+      Traits::SetError(payload, "BlockingCall returned not ok");
+      return;
+    }
+    std::unique_lock<std::mutex> lock(call.mutex);
+    call.cv.wait(lock, [&call] { return call.done; });
+  }
+
+private:
+
+  void Release() {
+    // Rule 2: after the env has begun tearing down, Node has already destroyed
+    // this thread-safe function.
+    if (tsfn && env_state && env_state->EnvIsAlive()) {
+      tsfn->Release();
+    }
+    tsfn.reset();
+  }
+
+  std::shared_ptr<NapiRefReaper> env_state;
+  std::unique_ptr<TSFN> tsfn;
+
+};

--- a/bindings/src/externals.h
+++ b/bindings/src/externals.h
@@ -2,10 +2,6 @@
 
 #include "napi_setup.h"
 #include "duckdb.h"
-#include "napi_ref_reaper.h"
-#include "duckdb_thread_callback.h"
-#include <cstddef>
-#include <memory>
 
 // Externals
 
@@ -325,97 +321,6 @@ inline Napi::External<duckdb_result> CreateExternalForResult(Napi::Env env, duck
 
 inline duckdb_result *GetResultFromExternal(Napi::Env env, Napi::Value value) {
   return GetDataFromExternal<duckdb_result>(env, ResultTypeTag, value, "Invalid result argument");
-}
-
-static const napi_type_tag ScalarFunctionTypeTag = {
-  0x95D48B7051D14994, 0x9F883D7DF5DEA86D
-};
-
-// Per-callback details for DuckDBThreadCallback. Defined in
-// scalar_function_helpers.h, which is included after the CreateExternalFor*
-// helpers these need.
-
-struct ScalarFunctionBindCallbackTraits {
-  using Payload = duckdb_bind_info;
-  static const char *ResourceName();
-  static void Call(Napi::Env env, Napi::Function callback, const Payload &payload);
-  static void SetError(const Payload &payload, const char *message);
-};
-
-struct ScalarFunctionMainCallbackTraits {
-  struct Payload {
-    duckdb_function_info info;
-    duckdb_data_chunk input;
-    duckdb_vector output;
-  };
-  static const char *ResourceName();
-  static void Call(Napi::Env env, Napi::Function callback, const Payload &payload);
-  static void SetError(const Payload &payload, const char *message);
-};
-
-struct ScalarFunctionInternalExtraInfo {
-  DuckDBThreadCallback<ScalarFunctionBindCallbackTraits> bind_callback;
-  DuckDBThreadCallback<ScalarFunctionMainCallbackTraits> main_callback;
-  std::shared_ptr<ManagedObjectReference> user_extra_info_ref;
-
-  explicit ScalarFunctionInternalExtraInfo(const std::shared_ptr<NapiRefReaper> &env_state)
-    : bind_callback(env_state), main_callback(env_state) {}
-
-  void SetBindFunction(Napi::Env env, Napi::Function func) {
-    bind_callback.Set(env, func);
-  }
-
-  void SetMainFunction(Napi::Env env, Napi::Function func) {
-    main_callback.Set(env, func);
-  }
-
-  void SetUserExtraInfo(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object user_extra_info) {
-    user_extra_info_ref = user_extra_info.IsUndefined() ? nullptr : MakeManagedObjectReference(reaper, user_extra_info);
-  }
-};
-
-inline void DeleteScalarFunctionInternalExtraInfo(ScalarFunctionInternalExtraInfo *internal_extra_info) {
-  delete internal_extra_info;
-}
-
-struct ScalarFunctionHolder {
-  duckdb_scalar_function scalar_function;
-  ScalarFunctionInternalExtraInfo *internal_extra_info;
-
-  ScalarFunctionHolder(duckdb_scalar_function scalar_function_in): scalar_function(scalar_function_in), internal_extra_info(nullptr) {}
-
-  ~ScalarFunctionHolder() {
-    // duckdb_destroy_scalar_function is a no-op if already destroyed
-    duckdb_destroy_scalar_function(&scalar_function);
-  }
-
-  ScalarFunctionInternalExtraInfo *EnsureInternalExtraInfo(const std::shared_ptr<NapiRefReaper> &env_state) {
-    if (!internal_extra_info) {
-      internal_extra_info = new ScalarFunctionInternalExtraInfo(env_state);
-      duckdb_scalar_function_set_extra_info(scalar_function, internal_extra_info, reinterpret_cast<duckdb_delete_callback_t>(DeleteScalarFunctionInternalExtraInfo));
-    }
-    return internal_extra_info;
-  }
-};
-
-inline ScalarFunctionHolder *CreateScalarFunctionHolder(duckdb_scalar_function scalar_function) {
-  return new ScalarFunctionHolder(scalar_function);
-}
-
-inline void FinalizeScalarFunctionHolder(Napi::BasicEnv, ScalarFunctionHolder *holder) {
-  delete holder;
-}
-
-inline Napi::External<ScalarFunctionHolder> CreateExternalForScalarFunction(Napi::Env env, duckdb_scalar_function scalar_function) {
-  return CreateExternal<ScalarFunctionHolder>(env, ScalarFunctionTypeTag, CreateScalarFunctionHolder(scalar_function), FinalizeScalarFunctionHolder);
-}
-
-inline ScalarFunctionHolder *GetScalarFunctionHolderFromExternal(Napi::Env env, Napi::Value value) {
-  return GetDataFromExternal<ScalarFunctionHolder>(env, ScalarFunctionTypeTag, value, "Invalid scalar function argument");
-}
-
-inline duckdb_scalar_function GetScalarFunctionFromExternal(Napi::Env env, Napi::Value value) {
-  return GetScalarFunctionHolderFromExternal(env, value)->scalar_function;
 }
 
 static const napi_type_tag ValueTypeTag = {

--- a/bindings/src/externals.h
+++ b/bindings/src/externals.h
@@ -3,6 +3,7 @@
 #include "napi_setup.h"
 #include "duckdb.h"
 #include "napi_ref_reaper.h"
+#include "duckdb_thread_callback.h"
 #include <cstddef>
 #include <memory>
 
@@ -330,65 +331,42 @@ static const napi_type_tag ScalarFunctionTypeTag = {
   0x95D48B7051D14994, 0x9F883D7DF5DEA86D
 };
 
-using ScalarFunctionBindTSFNContext = std::nullptr_t;
-struct ScalarFunctionBindTSFNData;
-void ScalarFunctionBindTSFNCallback(Napi::Env env, Napi::Function callback, ScalarFunctionBindTSFNContext *context, ScalarFunctionBindTSFNData *data);
-using ScalarFunctionBindTSFN = Napi::TypedThreadSafeFunction<ScalarFunctionBindTSFNContext, ScalarFunctionBindTSFNData, ScalarFunctionBindTSFNCallback>;
+// Per-callback details for DuckDBThreadCallback. Defined in
+// scalar_function_helpers.h, which is included after the CreateExternalFor*
+// helpers these need.
 
-using ScalarFunctionMainTSFNContext = std::nullptr_t;
-struct ScalarFunctionMainTSFNData;
-void ScalarFunctionMainTSFNCallback(Napi::Env env, Napi::Function callback, ScalarFunctionMainTSFNContext *context, ScalarFunctionMainTSFNData *data);
-using ScalarFunctionMainTSFN = Napi::TypedThreadSafeFunction<ScalarFunctionMainTSFNContext, ScalarFunctionMainTSFNData, ScalarFunctionMainTSFNCallback>;
+struct ScalarFunctionBindCallbackTraits {
+  using Payload = duckdb_bind_info;
+  static const char *ResourceName();
+  static void Call(Napi::Env env, Napi::Function callback, const Payload &payload);
+  static void SetError(const Payload &payload, const char *message);
+};
+
+struct ScalarFunctionMainCallbackTraits {
+  struct Payload {
+    duckdb_function_info info;
+    duckdb_data_chunk input;
+    duckdb_vector output;
+  };
+  static const char *ResourceName();
+  static void Call(Napi::Env env, Napi::Function callback, const Payload &payload);
+  static void SetError(const Payload &payload, const char *message);
+};
 
 struct ScalarFunctionInternalExtraInfo {
-  std::unique_ptr<ScalarFunctionBindTSFN> bind_tsfn;
-  std::unique_ptr<ScalarFunctionMainTSFN> main_tsfn;
+  DuckDBThreadCallback<ScalarFunctionBindCallbackTraits> bind_callback;
+  DuckDBThreadCallback<ScalarFunctionMainCallbackTraits> main_callback;
   std::shared_ptr<ManagedObjectReference> user_extra_info_ref;
 
-  // Held to answer one question: is the env still alive? See the destructor.
-  std::shared_ptr<NapiRefReaper> env_state;
-
-  explicit ScalarFunctionInternalExtraInfo(std::shared_ptr<NapiRefReaper> env_state_in)
-    : env_state(std::move(env_state_in)) {}
-
-  ~ScalarFunctionInternalExtraInfo() {
-    // Once the env has begun tearing down, Node has already destroyed these
-    // thread-safe functions, and releasing them again is a use-after-free. Node
-    // runs env cleanup hooks before finalizers, so this is accurate by the time
-    // this destructor runs from one.
-    if (!env_state || !env_state->EnvIsAlive()) {
-      return;
-    }
-    if (bool(bind_tsfn)) {
-      bind_tsfn->Release();
-    }
-    if (bool(main_tsfn)) {
-      main_tsfn->Release();
-    }
-  }
-
-  // Thread-safe functions are created referenced, which keeps the event loop
-  // alive for as long as they exist. These are only released when this extra
-  // info is destroyed, which needs the scalar function to be unregistered and
-  // its handle destroyed -- so a registered scalar function would otherwise stop
-  // its process (or its worker thread) from ever exiting. Unreferencing them is
-  // safe: a call in flight is always inside a query, and the async worker
-  // running that query keeps the loop alive on its own.
+  explicit ScalarFunctionInternalExtraInfo(const std::shared_ptr<NapiRefReaper> &env_state)
+    : bind_callback(env_state), main_callback(env_state) {}
 
   void SetBindFunction(Napi::Env env, Napi::Function func) {
-    if (bool(bind_tsfn)) {
-      bind_tsfn->Release();
-    }
-    bind_tsfn = std::make_unique<ScalarFunctionBindTSFN>(ScalarFunctionBindTSFN::New(env, func, "ScalarFunctionBind", 0, 1));
-    bind_tsfn->Unref(env);
+    bind_callback.Set(env, func);
   }
 
   void SetMainFunction(Napi::Env env, Napi::Function func) {
-    if (bool(main_tsfn)) {
-      main_tsfn->Release();
-    }
-    main_tsfn = std::make_unique<ScalarFunctionMainTSFN>(ScalarFunctionMainTSFN::New(env, func, "ScalarFunctionMain", 0, 1));
-    main_tsfn->Unref(env);
+    main_callback.Set(env, func);
   }
 
   void SetUserExtraInfo(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object user_extra_info) {

--- a/bindings/src/scalar_function_helpers.h
+++ b/bindings/src/scalar_function_helpers.h
@@ -1,9 +1,141 @@
 #pragma once
 
 #include "externals.h"
+#include "duckdb_thread_callback.h"
+#include "napi_ref_reaper.h"
 #include <memory>
 
 // Scalar functions
+//
+// Everything specific to the scalar function family lives here, including its
+// external: the object behind that external is ScalarFunctionHolder, which owns
+// family-specific state and so does not belong in externals.h. Later function
+// families should follow the same shape.
+
+static const napi_type_tag ScalarFunctionTypeTag = {
+  0x95D48B7051D14994, 0x9F883D7DF5DEA86D
+};
+
+// Callbacks
+
+struct ScalarFunctionBindCallbackTraits {
+  using Payload = duckdb_bind_info;
+
+  static const char *ResourceName() {
+    return "ScalarFunctionBind";
+  }
+
+  static void Call(Napi::Env env, Napi::Function callback, const Payload &payload) {
+    callback.Call(
+      env.Undefined(),
+      {
+        CreateExternalForBindInfoWithoutFinalizer(env, payload)
+      }
+    );
+  }
+
+  static void SetError(const Payload &payload, const char *message) {
+    duckdb_scalar_function_bind_set_error(payload, message);
+  }
+};
+
+struct ScalarFunctionMainCallbackTraits {
+  struct Payload {
+    duckdb_function_info info;
+    duckdb_data_chunk input;
+    duckdb_vector output;
+  };
+
+  static const char *ResourceName() {
+    return "ScalarFunctionMain";
+  }
+
+  static void Call(Napi::Env env, Napi::Function callback, const Payload &payload) {
+    callback.Call(
+      env.Undefined(),
+      {
+        CreateExternalForFunctionInfoWithoutFinalizer(env, payload.info),
+        CreateExternalForDataChunkWithoutFinalizer(env, payload.input),
+        CreateExternalForVectorWithoutFinalizer(env, payload.output)
+      }
+    );
+  }
+
+  static void SetError(const Payload &payload, const char *message) {
+    duckdb_scalar_function_set_error(payload.info, message);
+  }
+};
+
+// Extra info
+
+struct ScalarFunctionInternalExtraInfo {
+  DuckDBThreadCallback<ScalarFunctionBindCallbackTraits> bind_callback;
+  DuckDBThreadCallback<ScalarFunctionMainCallbackTraits> main_callback;
+  std::shared_ptr<ManagedObjectReference> user_extra_info_ref;
+
+  explicit ScalarFunctionInternalExtraInfo(const std::shared_ptr<NapiRefReaper> &env_state)
+    : bind_callback(env_state), main_callback(env_state) {}
+
+  void SetBindFunction(Napi::Env env, Napi::Function func) {
+    bind_callback.Set(env, func);
+  }
+
+  void SetMainFunction(Napi::Env env, Napi::Function func) {
+    main_callback.Set(env, func);
+  }
+
+  void SetUserExtraInfo(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object user_extra_info) {
+    user_extra_info_ref = user_extra_info.IsUndefined() ? nullptr : MakeManagedObjectReference(reaper, user_extra_info);
+  }
+};
+
+inline void DeleteScalarFunctionInternalExtraInfo(ScalarFunctionInternalExtraInfo *internal_extra_info) {
+  delete internal_extra_info;
+}
+
+// External
+
+struct ScalarFunctionHolder {
+  duckdb_scalar_function scalar_function;
+  ScalarFunctionInternalExtraInfo *internal_extra_info;
+
+  ScalarFunctionHolder(duckdb_scalar_function scalar_function_in): scalar_function(scalar_function_in), internal_extra_info(nullptr) {}
+
+  ~ScalarFunctionHolder() {
+    // duckdb_destroy_scalar_function is a no-op if already destroyed
+    duckdb_destroy_scalar_function(&scalar_function);
+  }
+
+  ScalarFunctionInternalExtraInfo *EnsureInternalExtraInfo(const std::shared_ptr<NapiRefReaper> &env_state) {
+    if (!internal_extra_info) {
+      internal_extra_info = new ScalarFunctionInternalExtraInfo(env_state);
+      duckdb_scalar_function_set_extra_info(scalar_function, internal_extra_info, reinterpret_cast<duckdb_delete_callback_t>(DeleteScalarFunctionInternalExtraInfo));
+    }
+    return internal_extra_info;
+  }
+};
+
+inline ScalarFunctionHolder *CreateScalarFunctionHolder(duckdb_scalar_function scalar_function) {
+  return new ScalarFunctionHolder(scalar_function);
+}
+
+inline void FinalizeScalarFunctionHolder(Napi::BasicEnv, ScalarFunctionHolder *holder) {
+  delete holder;
+}
+
+inline Napi::External<ScalarFunctionHolder> CreateExternalForScalarFunction(Napi::Env env, duckdb_scalar_function scalar_function) {
+  return CreateExternal<ScalarFunctionHolder>(env, ScalarFunctionTypeTag, CreateScalarFunctionHolder(scalar_function), FinalizeScalarFunctionHolder);
+}
+
+inline ScalarFunctionHolder *GetScalarFunctionHolderFromExternal(Napi::Env env, Napi::Value value) {
+  return GetDataFromExternal<ScalarFunctionHolder>(env, ScalarFunctionTypeTag, value, "Invalid scalar function argument");
+}
+
+inline duckdb_scalar_function GetScalarFunctionFromExternal(Napi::Env env, Napi::Value value) {
+  return GetScalarFunctionHolderFromExternal(env, value)->scalar_function;
+}
+
+// Bind data
 
 struct ScalarFunctionInternalBindData {
   std::shared_ptr<ManagedObjectReference> user_bind_data_ref;
@@ -38,24 +170,7 @@ inline ScalarFunctionInternalBindData *CopyScalarFunctionInternalBindData(Scalar
   return new_internal_bind_data;
 }
 
-// Bind callback
-
-inline const char *ScalarFunctionBindCallbackTraits::ResourceName() {
-  return "ScalarFunctionBind";
-}
-
-inline void ScalarFunctionBindCallbackTraits::Call(Napi::Env env, Napi::Function callback, const Payload &payload) {
-  callback.Call(
-    env.Undefined(),
-    {
-      CreateExternalForBindInfoWithoutFinalizer(env, payload)
-    }
-  );
-}
-
-inline void ScalarFunctionBindCallbackTraits::SetError(const Payload &payload, const char *message) {
-  duckdb_scalar_function_bind_set_error(payload, message);
-}
+// Entry points handed to DuckDB
 
 inline ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromBindInfo(duckdb_bind_info bind_info) {
   return reinterpret_cast<ScalarFunctionInternalExtraInfo*>(duckdb_scalar_function_bind_get_extra_info(bind_info));
@@ -63,27 +178,6 @@ inline ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromBi
 
 inline void ScalarFunctionBindFunction(duckdb_bind_info info) {
   GetScalarFunctionInternalExtraInfoFromBindInfo(info)->bind_callback.Invoke(info);
-}
-
-// Main callback
-
-inline const char *ScalarFunctionMainCallbackTraits::ResourceName() {
-  return "ScalarFunctionMain";
-}
-
-inline void ScalarFunctionMainCallbackTraits::Call(Napi::Env env, Napi::Function callback, const Payload &payload) {
-  callback.Call(
-    env.Undefined(),
-    {
-      CreateExternalForFunctionInfoWithoutFinalizer(env, payload.info),
-      CreateExternalForDataChunkWithoutFinalizer(env, payload.input),
-      CreateExternalForVectorWithoutFinalizer(env, payload.output)
-    }
-  );
-}
-
-inline void ScalarFunctionMainCallbackTraits::SetError(const Payload &payload, const char *message) {
-  duckdb_scalar_function_set_error(payload.info, message);
 }
 
 inline ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromFunctionInfo(duckdb_function_info function_info) {

--- a/bindings/src/scalar_function_helpers.h
+++ b/bindings/src/scalar_function_helpers.h
@@ -1,9 +1,7 @@
 #pragma once
 
 #include "externals.h"
-#include <condition_variable>
 #include <memory>
-#include <mutex>
 
 // Scalar functions
 
@@ -40,33 +38,23 @@ inline ScalarFunctionInternalBindData *CopyScalarFunctionInternalBindData(Scalar
   return new_internal_bind_data;
 }
 
-struct ScalarFunctionBindTSFNData {
-  duckdb_bind_info info;
-  std::condition_variable *cv;
-  std::mutex *cv_mutex;
-  bool done;
-};
+// Bind callback
 
-inline void ScalarFunctionBindTSFNCallback(Napi::Env env, Napi::Function callback, ScalarFunctionBindTSFNContext *context, ScalarFunctionBindTSFNData *data) {
-  if (env != nullptr) {
-    if (callback != nullptr) {
-      try {
-        callback.Call(
-          env.Undefined(),
-          {
-            CreateExternalForBindInfoWithoutFinalizer(env, data->info)
-          }
-        );
-      } catch (const Napi::Error &err) {
-        duckdb_scalar_function_bind_set_error(data->info, err.Message().c_str());
-      }
+inline const char *ScalarFunctionBindCallbackTraits::ResourceName() {
+  return "ScalarFunctionBind";
+}
+
+inline void ScalarFunctionBindCallbackTraits::Call(Napi::Env env, Napi::Function callback, const Payload &payload) {
+  callback.Call(
+    env.Undefined(),
+    {
+      CreateExternalForBindInfoWithoutFinalizer(env, payload)
     }
-  }
-  {
-    std::lock_guard lk(*data->cv_mutex);
-    data->done = true;
-    data->cv->notify_one();
-  } 
+  );
+}
+
+inline void ScalarFunctionBindCallbackTraits::SetError(const Payload &payload, const char *message) {
+  duckdb_scalar_function_bind_set_error(payload, message);
 }
 
 inline ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromBindInfo(duckdb_bind_info bind_info) {
@@ -74,58 +62,28 @@ inline ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromBi
 }
 
 inline void ScalarFunctionBindFunction(duckdb_bind_info info) {
-  auto internal_extra_info = GetScalarFunctionInternalExtraInfoFromBindInfo(info);
-  auto data = reinterpret_cast<ScalarFunctionBindTSFNData*>(duckdb_malloc(sizeof(ScalarFunctionBindTSFNData)));
-  data->info = info;
-  data->cv = new std::condition_variable;
-  data->cv_mutex = new std::mutex;
-  data->done = false;
-  // The "blocking" part of this call only waits for queue space, not for the JS function call to complete.
-  // Since we specify no limit to the queue space, it in fact never blocks.
-  auto status = internal_extra_info->bind_tsfn->BlockingCall(data);
-  if (status == napi_ok) {
-    // Wait for the JS function call to complete.
-    std::unique_lock<std::mutex> lk(*data->cv_mutex);
-    data->cv->wait(lk, [&]{ return data->done; });
-  } else {
-    duckdb_scalar_function_bind_set_error(info, "BlockingCall returned not ok");
-  }
-  delete data->cv;
-  delete data->cv_mutex;
-  duckdb_free(data);
+  GetScalarFunctionInternalExtraInfoFromBindInfo(info)->bind_callback.Invoke(info);
 }
 
-struct ScalarFunctionMainTSFNData {
-  duckdb_function_info info;
-  duckdb_data_chunk input;
-  duckdb_vector output;
-  std::condition_variable *cv;
-  std::mutex *cv_mutex;
-  bool done;
-};
+// Main callback
 
-inline void ScalarFunctionMainTSFNCallback(Napi::Env env, Napi::Function callback, ScalarFunctionMainTSFNContext *context, ScalarFunctionMainTSFNData *data) {
-  if (env != nullptr) {
-    if (callback != nullptr) {
-      try {
-        callback.Call(
-          env.Undefined(),
-          {
-            CreateExternalForFunctionInfoWithoutFinalizer(env, data->info),
-            CreateExternalForDataChunkWithoutFinalizer(env, data->input),
-            CreateExternalForVectorWithoutFinalizer(env, data->output)
-          }
-        );
-      } catch (const Napi::Error &err) {
-        duckdb_scalar_function_set_error(data->info, err.Message().c_str());
-      }
+inline const char *ScalarFunctionMainCallbackTraits::ResourceName() {
+  return "ScalarFunctionMain";
+}
+
+inline void ScalarFunctionMainCallbackTraits::Call(Napi::Env env, Napi::Function callback, const Payload &payload) {
+  callback.Call(
+    env.Undefined(),
+    {
+      CreateExternalForFunctionInfoWithoutFinalizer(env, payload.info),
+      CreateExternalForDataChunkWithoutFinalizer(env, payload.input),
+      CreateExternalForVectorWithoutFinalizer(env, payload.output)
     }
-  }
-  {
-    std::lock_guard lk(*data->cv_mutex);
-    data->done = true;
-    data->cv->notify_one();
-  }
+  );
+}
+
+inline void ScalarFunctionMainCallbackTraits::SetError(const Payload &payload, const char *message) {
+  duckdb_scalar_function_set_error(payload.info, message);
 }
 
 inline ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromFunctionInfo(duckdb_function_info function_info) {
@@ -133,25 +91,5 @@ inline ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromFu
 }
 
 inline void ScalarFunctionMainFunction(duckdb_function_info info, duckdb_data_chunk input, duckdb_vector output) {
-  auto internal_extra_info = GetScalarFunctionInternalExtraInfoFromFunctionInfo(info);
-  auto data = reinterpret_cast<ScalarFunctionMainTSFNData*>(duckdb_malloc(sizeof(ScalarFunctionMainTSFNData)));
-  data->info = info;
-  data->input = input;
-  data->output = output;
-  data->cv = new std::condition_variable;
-  data->cv_mutex = new std::mutex;
-  data->done = false;
-  // The "blocking" part of this call only waits for queue space, not for the JS function call to complete.
-  // Since we specify no limit to the queue space, it in fact never blocks.
-  auto status = internal_extra_info->main_tsfn->BlockingCall(data);
-  if (status == napi_ok) {
-    // Wait for the JS function call to complete.
-    std::unique_lock<std::mutex> lk(*data->cv_mutex);
-    data->cv->wait(lk, [&]{ return data->done; });
-  } else {
-    duckdb_scalar_function_set_error(info, "BlockingCall returned not ok");
-  }
-  delete data->cv;
-  delete data->cv_mutex;
-  duckdb_free(data);
+  GetScalarFunctionInternalExtraInfoFromFunctionInfo(info)->main_callback.Invoke({info, input, output});
 }

--- a/bindings/test/stress/scalar_function_refs.test.ts
+++ b/bindings/test/stress/scalar_function_refs.test.ts
@@ -1,8 +1,6 @@
 import duckdb from '@duckdb/node-bindings';
-import { createRequire } from 'node:module';
 import v8 from 'node:v8';
 import vm from 'node:vm';
-import { Worker } from 'node:worker_threads';
 import { expect, suite, test } from 'vitest';
 import { withConnection } from '../utils/withConnection';
 import { withDatabase } from '../utils/withDatabase';
@@ -15,6 +13,9 @@ import { withDatabase } from '../utils/withDatabase';
 // To check the invariant these tests are protecting -- that a reference is only
 // ever destroyed on the JS thread -- build with instrumentation enabled and run
 // any suite; see the comment on duckdb_node_instrument_napi_refs in binding.gyp.
+//
+// Env teardown is covered by test/worker_threads.test.ts in the main suite, since
+// that is deterministic and worth running on every platform.
 
 // Obtain gc() without requiring the process to be launched with --expose-gc.
 //
@@ -182,91 +183,5 @@ suite('scalar function reference lifetime', () => {
       }
       forceGC();
     });
-  });
-
-  // The reaper is owned by the addon and therefore scoped to a napi_env. Under
-  // worker_threads the addon is instantiated per env, so this covers both that
-  // scoping and the env teardown path that runs NapiRefReaper::Shutdown -- which
-  // never runs for the main env, since Node skips instance data finalizers at
-  // process exit.
-  test('references are reaped per env under worker_threads', async () => {
-    const bindings_path = createRequire(import.meta.url).resolve(
-      '@duckdb/node-bindings',
-    );
-    const queries_per_worker = 25;
-    const chunks_per_query = 3; // range(5000) at a vector size of 2048
-
-    const worker_source = `
-      const { parentPort, workerData } = require('node:worker_threads');
-      const duckdb = require(workerData.bindings_path);
-      (async () => {
-        const db = await duckdb.open();
-        const connection = await duckdb.connect(db);
-        const fn = duckdb.create_scalar_function();
-        duckdb.scalar_function_set_name(fn, 'my_func');
-        duckdb.scalar_function_set_return_type(
-          fn,
-          duckdb.create_logical_type(duckdb.Type.VARCHAR),
-        );
-        duckdb.scalar_function_set_volatile(fn);
-        duckdb.scalar_function_set_extra_info(fn, { token: 'extra_info' });
-        duckdb.scalar_function_set_bind(fn, (info) => {
-          duckdb.scalar_function_set_bind_data(info, { token: 'bind_data' });
-        });
-        let calls = 0;
-        duckdb.scalar_function_set_function(fn, (info, input, output) => {
-          calls++;
-          const bind_data = duckdb.scalar_function_get_bind_data(info);
-          const extra_info = duckdb.scalar_function_get_extra_info(info);
-          if (bind_data.token !== 'bind_data' || extra_info.token !== 'extra_info') {
-            throw new Error('reference corrupted in worker');
-          }
-          const rowCount = duckdb.data_chunk_get_size(input);
-          for (let i = 0; i < rowCount; i++) {
-            duckdb.vector_assign_string_element(output, i, 'ok');
-          }
-        });
-        duckdb.register_scalar_function(connection, fn);
-        duckdb.destroy_scalar_function_sync(fn);
-        for (let i = 0; i < ${queries_per_worker}; i++) {
-          await duckdb.query(connection, 'select my_func() from range(5000)');
-        }
-        duckdb.disconnect_sync(connection);
-        duckdb.close_sync(db);
-        parentPort.postMessage({ calls });
-      })().catch((e) => {
-        parentPort.postMessage({ error: String((e && e.message) || e) });
-      });
-    `;
-
-    function runWorker(): Promise<{ calls?: number; error?: string }> {
-      return new Promise((resolve, reject) => {
-        const worker = new Worker(worker_source, {
-          eval: true,
-          workerData: { bindings_path },
-        });
-        let message: { calls?: number; error?: string } | undefined;
-        worker.on('message', (m) => {
-          message = m;
-        });
-        worker.on('error', reject);
-        worker.on('exit', (code) => {
-          if (code !== 0) {
-            reject(new Error(`worker exited with code ${code}`));
-          } else {
-            resolve(message ?? { error: 'worker sent no message' });
-          }
-        });
-      });
-    }
-
-    // Several envs concurrently, each with its own addon instance and reaper.
-    const results = await Promise.all(
-      Array.from({ length: 4 }, () => runWorker()),
-    );
-    for (const result of results) {
-      expect(result.error).toBeUndefined();
-      expect(result.calls).toBe(queries_per_worker * chunks_per_query);
-    }
   });
 });

--- a/bindings/test/worker_threads.test.ts
+++ b/bindings/test/worker_threads.test.ts
@@ -153,8 +153,12 @@ suite('worker threads', () => {
         if (timer) {
           clearTimeout(timer);
         }
-        // Leaves nothing running behind a failure.
-        await Promise.all(workers.map((worker) => worker.terminate()));
+        // Best effort, and deliberately not awaited: terminate() does not settle
+        // for a worker wedged inside a blocking native call, and awaiting it here
+        // swallowed the diagnostic above in favour of vitest's own timeout.
+        for (const worker of workers) {
+          void worker.terminate();
+        }
       }
     },
     testTimeoutMs,

--- a/bindings/test/worker_threads.test.ts
+++ b/bindings/test/worker_threads.test.ts
@@ -11,8 +11,14 @@ import { expect, suite, test } from 'vitest';
 // It caught a deadlock on its first CI run -- an unreleased thread-safe function
 // blocking env teardown, from a release that could only happen once teardown had
 // finished -- which reproduced on Linux but not macOS. It is deterministic and
-// takes well under a second, so it belongs in the main suite where it runs on
-// every platform, rather than in test/stress.
+// takes well under a second locally, so it belongs in the main suite where it
+// runs on every platform, rather than in test/stress.
+//
+// Because the failure mode it guards against is a hang, the deadline below is
+// generous: a slow runner should not fail, only a genuine hang should. When one
+// happens, the reported state distinguishes "the worker never finished its work"
+// from "the worker finished but its env never tore down", which is the
+// distinction that matters.
 
 const bindings_path = createRequire(import.meta.url).resolve(
   '@duckdb/node-bindings',
@@ -22,10 +28,12 @@ const worker_count = 4;
 const queries_per_worker = 25;
 const chunks_per_query = 3; // range(5000) at a vector size of 2048
 
+const deadlineMs = 25000;
+const testTimeoutMs = 40000; // Above deadlineMs, so the diagnostic below wins.
+
 // Each worker registers a scalar function, checks on every invocation that its
 // extra info and bind data are intact, then closes everything and reports how
-// many times it was called. A worker that hangs on teardown never emits its
-// 'exit' event, which fails the test.
+// many times it was called.
 const worker_source = `
   const { parentPort, workerData } = require('node:worker_threads');
   const duckdb = require(workerData.bindings_path);
@@ -69,38 +77,86 @@ const worker_source = `
   });
 `;
 
-function runWorker(): Promise<{ calls?: number; error?: string }> {
-  return new Promise((resolve, reject) => {
-    const worker = new Worker(worker_source, {
-      eval: true,
-      workerData: { bindings_path },
-    });
-    let message: { calls?: number; error?: string } | undefined;
-    worker.on('message', (m) => {
-      message = m;
-    });
-    worker.on('error', reject);
-    // Resolving on 'exit' rather than 'message' is the point: the work
-    // completing is not enough, the env has to tear down too.
-    worker.on('exit', (code) => {
-      if (code !== 0) {
-        reject(new Error(`worker exited with code ${code}`));
-      } else {
-        resolve(message ?? { error: 'worker sent no message' });
-      }
-    });
+interface WorkerOutcome {
+  calls?: number;
+  error?: string;
+}
+
+interface WorkerProgress {
+  online: boolean;
+  reported: boolean; // finished its work and posted a result
+  exited: boolean; // its env tore down
+}
+
+function describe(progress: readonly WorkerProgress[]): string {
+  const states = progress.map((p, i) => {
+    if (p.exited) return `${i}:exited`;
+    if (p.reported) return `${i}:WORK DONE BUT NEVER EXITED`;
+    if (p.online) return `${i}:ONLINE BUT WORK UNFINISHED`;
+    return `${i}:NEVER STARTED`;
   });
+  return `workers did not all exit within ${deadlineMs}ms [${states.join(', ')}]`;
 }
 
 suite('worker threads', () => {
-  test('scalar functions work, and their envs tear down, in workers', async () => {
-    // Several envs concurrently, each with its own addon instance and reaper.
-    const results = await Promise.all(
-      Array.from({ length: worker_count }, () => runWorker()),
-    );
-    for (const result of results) {
-      expect(result.error).toBeUndefined();
-      expect(result.calls).toBe(queries_per_worker * chunks_per_query);
-    }
-  });
+  test(
+    'scalar functions work, and their envs tear down, in workers',
+    async () => {
+      const progress: WorkerProgress[] = Array.from(
+        { length: worker_count },
+        () => ({ online: false, reported: false, exited: false }),
+      );
+      const workers: Worker[] = [];
+
+      const runs = progress.map((state, index) => {
+        return new Promise<WorkerOutcome>((resolve, reject) => {
+          const worker = new Worker(worker_source, {
+            eval: true,
+            workerData: { bindings_path },
+          });
+          workers.push(worker);
+          let outcome: WorkerOutcome | undefined;
+          worker.on('online', () => {
+            state.online = true;
+          });
+          worker.on('message', (m: WorkerOutcome) => {
+            outcome = m;
+            state.reported = true;
+          });
+          worker.on('error', reject);
+          // Resolving on 'exit' rather than 'message' is the point: the work
+          // completing is not enough, the env has to tear down too.
+          worker.on('exit', (code) => {
+            state.exited = true;
+            if (code !== 0) {
+              reject(new Error(`worker ${index} exited with code ${code}`));
+            } else {
+              resolve(outcome ?? { error: 'worker sent no message' });
+            }
+          });
+        });
+      });
+
+      let timer: NodeJS.Timeout | undefined;
+      try {
+        const results = await Promise.race([
+          Promise.all(runs),
+          new Promise<never>((_, reject) => {
+            timer = setTimeout(() => reject(new Error(describe(progress))), deadlineMs);
+          }),
+        ]);
+        for (const result of results) {
+          expect(result.error).toBeUndefined();
+          expect(result.calls).toBe(queries_per_worker * chunks_per_query);
+        }
+      } finally {
+        if (timer) {
+          clearTimeout(timer);
+        }
+        // Leaves nothing running behind a failure.
+        await Promise.all(workers.map((worker) => worker.terminate()));
+      }
+    },
+    testTimeoutMs,
+  );
 });

--- a/bindings/test/worker_threads.test.ts
+++ b/bindings/test/worker_threads.test.ts
@@ -1,0 +1,106 @@
+import { createRequire } from 'node:module';
+import { Worker } from 'node:worker_threads';
+import { expect, suite, test } from 'vitest';
+
+// Worker threads are the only place an env is ever torn down for real: Node skips
+// instance data finalizers for the main env at process exit. So this is the only
+// coverage for the teardown half of the thread-safe function lifetime rules in
+// src/duckdb_thread_callback.h, and for the reaper being scoped per env rather
+// than per process.
+//
+// It caught a deadlock on its first CI run -- an unreleased thread-safe function
+// blocking env teardown, from a release that could only happen once teardown had
+// finished -- which reproduced on Linux but not macOS. It is deterministic and
+// takes well under a second, so it belongs in the main suite where it runs on
+// every platform, rather than in test/stress.
+
+const bindings_path = createRequire(import.meta.url).resolve(
+  '@duckdb/node-bindings',
+);
+
+const worker_count = 4;
+const queries_per_worker = 25;
+const chunks_per_query = 3; // range(5000) at a vector size of 2048
+
+// Each worker registers a scalar function, checks on every invocation that its
+// extra info and bind data are intact, then closes everything and reports how
+// many times it was called. A worker that hangs on teardown never emits its
+// 'exit' event, which fails the test.
+const worker_source = `
+  const { parentPort, workerData } = require('node:worker_threads');
+  const duckdb = require(workerData.bindings_path);
+  (async () => {
+    const db = await duckdb.open();
+    const connection = await duckdb.connect(db);
+    const fn = duckdb.create_scalar_function();
+    duckdb.scalar_function_set_name(fn, 'my_func');
+    duckdb.scalar_function_set_return_type(
+      fn,
+      duckdb.create_logical_type(duckdb.Type.VARCHAR),
+    );
+    duckdb.scalar_function_set_volatile(fn);
+    duckdb.scalar_function_set_extra_info(fn, { token: 'extra_info' });
+    duckdb.scalar_function_set_bind(fn, (info) => {
+      duckdb.scalar_function_set_bind_data(info, { token: 'bind_data' });
+    });
+    let calls = 0;
+    duckdb.scalar_function_set_function(fn, (info, input, output) => {
+      calls++;
+      const bind_data = duckdb.scalar_function_get_bind_data(info);
+      const extra_info = duckdb.scalar_function_get_extra_info(info);
+      if (bind_data.token !== 'bind_data' || extra_info.token !== 'extra_info') {
+        throw new Error('reference corrupted in worker');
+      }
+      const rowCount = duckdb.data_chunk_get_size(input);
+      for (let i = 0; i < rowCount; i++) {
+        duckdb.vector_assign_string_element(output, i, 'ok');
+      }
+    });
+    duckdb.register_scalar_function(connection, fn);
+    duckdb.destroy_scalar_function_sync(fn);
+    for (let i = 0; i < ${queries_per_worker}; i++) {
+      await duckdb.query(connection, 'select my_func() from range(5000)');
+    }
+    duckdb.disconnect_sync(connection);
+    duckdb.close_sync(db);
+    parentPort.postMessage({ calls });
+  })().catch((e) => {
+    parentPort.postMessage({ error: String((e && e.message) || e) });
+  });
+`;
+
+function runWorker(): Promise<{ calls?: number; error?: string }> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(worker_source, {
+      eval: true,
+      workerData: { bindings_path },
+    });
+    let message: { calls?: number; error?: string } | undefined;
+    worker.on('message', (m) => {
+      message = m;
+    });
+    worker.on('error', reject);
+    // Resolving on 'exit' rather than 'message' is the point: the work
+    // completing is not enough, the env has to tear down too.
+    worker.on('exit', (code) => {
+      if (code !== 0) {
+        reject(new Error(`worker exited with code ${code}`));
+      } else {
+        resolve(message ?? { error: 'worker sent no message' });
+      }
+    });
+  });
+}
+
+suite('worker threads', () => {
+  test('scalar functions work, and their envs tear down, in workers', async () => {
+    // Several envs concurrently, each with its own addon instance and reaper.
+    const results = await Promise.all(
+      Array.from({ length: worker_count }, () => runWorker()),
+    );
+    for (const result of results) {
+      expect(result.error).toBeUndefined();
+      expect(result.calls).toBe(queries_per_worker * chunks_per_query);
+    }
+  });
+});


### PR DESCRIPTION
Scalar functions hand two callbacks to DuckDB, and each hand-rolled the same
sequence: create a thread-safe function, unreference it, marshal arguments, block
the calling DuckDB thread on a condition variable, translate a thrown JS error
into the right `set_error`, and release without touching an env that has begun
tearing down.

Table functions add four more — bind, init, local init and main — and two of those
steps are exactly where the bugs in #456 and #457 were. This does the extraction
first, so that work starts from the rules rather than reproducing them six times.

## The helper

`DuckDBThreadCallback<Traits>`, where the traits type supplies the payload,
resource name, argument marshalling and error reporting. The lifetime rules are
now stated once, in one place, with the reasoning attached:

1. Thread-safe functions are created referenced and hold the event loop open, so
   unreference at creation (#457).
2. Node destroys them during env teardown before running finalizers, so never
   release once the env is going away (#457).
3. Replacing a callback releases the one it replaces.

Both rules are still load bearing after the extraction, verified by breaking each
one *inside the helper*: removing the unreference makes the exit tests hang;
removing the env liveness check makes them abort.

**The signalling protocol is unchanged** — per call heap allocation, freed by the
waiting thread, `notify_one` inside the lock. An earlier revision of this branch
simplified that to a stack allocation with `notify_one` outside the lock, and it
caused intermittent hangs on both macOS runners: a plain scalar function query on
x64, and the worker test on arm64, with everything else green. Together those two
changes are a use-after-free — the JS thread sets `done` and releases the lock,
the waiting thread wakes, sees `done`, returns from `Invoke` and destroys the
condition variable, and only then does `notify_one` touch it. With a fast JS
thread the waiter often never reaches the wait at all.

That explains the symptom and is undefined behaviour regardless, but I could not
reproduce it locally even with a widened window and the stack deliberately
reused, so it is not proven to be the cause. Since the simplification was never
needed and would underpin four more callbacks, the original was restored instead.
The extraction is now purely structural.

## Moving the scalar family out of externals.h

`externals.h` is the machinery for handle types crossing the boundary, but
`ScalarFunctionHolder` owns family-specific state — the callbacks and the user's
extra info — so it and everything behind it belong with the family.

The block moves as a unit because it is one dependency chain: the holder needs the
extra info complete, and `CreateExternalForScalarFunction` needs the holder
complete. Splitting it anywhere trades the move for a declaration and definition
split.

It also removes a split introduced earlier in this branch: the callback traits had
to be declared in `externals.h` and defined in `scalar_function_helpers.h` purely
because `CreateExternalForVectorWithoutFinalizer` sits below where they were
needed. Below the external helpers they are ordinary inline structs, defined once.

Three includes in `externals.h` went stale with the move — `napi_ref_reaper.h`,
`<memory>` and `<cstddef>` — and are removed rather than left for others to pick
up transitively. `napi_ref_reaper.h` is now included directly by the two files
that use its symbols. Verified on Linux as well as macOS, since dropping standard
library includes is exactly the change that can pass under libc++ and fail under
libstdc++.

The tradeoff is that the type tag list in `externals.h` is no longer complete.
Collecting all tags into a header of their own would restore that and stays
available — tags are pure data, so nothing here blocks it.

Table functions should follow the same shape in their own header.

## Moving the worker_threads test into the main suite

Worker threads are the only place an env is ever torn down for real — Node skips
instance data finalizers for the main env at process exit — so this test is the
only coverage for the teardown half of those rules. It is deterministic and takes
well under a second.

But `test:stress` runs exactly once in CI: inside the instrumented step, on Linux
x64 glibc, on PRs only. It never runs against the shipped build configuration on
any platform. Moving this one test into the main suite gets it onto all eight
platforms on every PR. The three genuinely stress-shaped tests stay in
`test/stress`.

It earned that immediately: running on macOS for the first time is what surfaced
the signalling regression above.

Two changes fell out of that. The failure mode this test guards against is a hang,
and "timed out in 5000ms" cannot tell a hang from a slow machine, so it now has a
deadline generous enough that only a hang fails and reports per-worker state when
it trips — never started, online but work unfinished, or work done but never
exited, the last being the symptom of the deadlock it exists for. And terminating
the workers is best effort rather than awaited, because `terminate()` does not
settle for a worker wedged inside a blocking native call, which swallowed that
diagnostic in favour of vitest's own timeout.

Confirmed it keeps its teeth after the move: removing the reaper's env cleanup
hook and running `pnpm test` in a Linux container fails `worker_threads.test.ts`
(and the exit tests, since that hook is what makes `EnvIsAlive()` accurate).

## Verification

All eight CI platforms green, including both macOS jobs that failed twice against
the earlier revision. Locally on macOS and in a Linux container, normal and
instrumented builds: bindings 274, stress 3, api 145. Signature files unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
