### PR TITLE
Add table function bindings

### DIFF
--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -1253,32 +1253,56 @@ export function table_function_supports_projection_pushdown(table_function: Tabl
 export function register_table_function(connection: Connection, table_function: TableFunction): void;
 
 // DUCKDB_C_API void *duckdb_bind_get_extra_info(duckdb_bind_info info);
+export function bind_get_extra_info(bind_info: TableFunctionBindInfo): object | undefined;
+
 // DUCKDB_C_API void duckdb_table_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);
+export function table_function_get_client_context(bind_info: TableFunctionBindInfo): ClientContext;
+
 // DUCKDB_C_API void duckdb_bind_add_result_column(duckdb_bind_info info, const char *name, duckdb_logical_type type);
 export function bind_add_result_column(bind_info: TableFunctionBindInfo, name: string, logical_type: LogicalType): void;
 
 // DUCKDB_C_API idx_t duckdb_bind_get_parameter_count(duckdb_bind_info info);
+export function bind_get_parameter_count(bind_info: TableFunctionBindInfo): number;
+
 // DUCKDB_C_API duckdb_value duckdb_bind_get_parameter(duckdb_bind_info info, idx_t index);
+export function bind_get_parameter(bind_info: TableFunctionBindInfo, index: number): Value;
+
 // DUCKDB_C_API duckdb_value duckdb_bind_get_named_parameter(duckdb_bind_info info, const char *name);
+export function bind_get_named_parameter(bind_info: TableFunctionBindInfo, name: string): Value | null;
+
 // DUCKDB_C_API void duckdb_bind_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
 export function bind_set_bind_data(bind_info: TableFunctionBindInfo, bind_data: object): void;
 
 // DUCKDB_C_API void duckdb_bind_set_cardinality(duckdb_bind_info info, idx_t cardinality, bool is_exact);
+export function bind_set_cardinality(bind_info: TableFunctionBindInfo, cardinality: number, is_exact: boolean): void;
+
 // DUCKDB_C_API void duckdb_bind_set_error(duckdb_bind_info info, const char *error);
 export function bind_set_error(bind_info: TableFunctionBindInfo, error: string): void;
 
 // DUCKDB_C_API void *duckdb_init_get_extra_info(duckdb_init_info info);
+export function init_get_extra_info(init_info: TableFunctionInitInfo): object | undefined;
+
 // DUCKDB_C_API void *duckdb_init_get_bind_data(duckdb_init_info info);
+export function init_get_bind_data(init_info: TableFunctionInitInfo): object | undefined;
+
 // DUCKDB_C_API void duckdb_init_set_init_data(duckdb_init_info info, void *init_data, duckdb_delete_callback_t destroy);
 export function init_set_init_data(init_info: TableFunctionInitInfo, init_data: object): void;
 
 // DUCKDB_C_API idx_t duckdb_init_get_column_count(duckdb_init_info info);
+export function init_get_column_count(init_info: TableFunctionInitInfo): number;
+
 // DUCKDB_C_API idx_t duckdb_init_get_column_index(duckdb_init_info info, idx_t column_index);
+export function init_get_column_index(init_info: TableFunctionInitInfo, column_index: number): number;
+
 // DUCKDB_C_API void duckdb_init_set_max_threads(duckdb_init_info info, idx_t max_threads);
+export function init_set_max_threads(init_info: TableFunctionInitInfo, max_threads: number): void;
+
 // DUCKDB_C_API void duckdb_init_set_error(duckdb_init_info info, const char *error);
 export function init_set_error(init_info: TableFunctionInitInfo, error: string): void;
 
 // DUCKDB_C_API void *duckdb_function_get_extra_info(duckdb_function_info info);
+export function function_get_extra_info(function_info: TableFunctionInfo): object | undefined;
+
 // DUCKDB_C_API void *duckdb_function_get_bind_data(duckdb_function_info info);
 export function function_get_bind_data(function_info: TableFunctionInfo): object | undefined;
 

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -183,13 +183,45 @@ export interface TimestampParts {
   time: TimeParts;
 }
 
-export interface BindInfo {
+// The C API reuses one opaque handle type for bind info, init info and function
+// info across function families, but the struct behind each handle differs per
+// family and is reinterpret_cast with no check. Passing one family's handle to
+// another family's accessor corrupts memory rather than failing, so each family
+// gets its own type here, and its own runtime type tag in the bindings.
+//
+// __duckdb_type records the underlying C type; __duckdb_function_kind is what
+// keeps the families from being assignable to one another.
+
+export interface ScalarFunctionBindInfo {
   __duckdb_type: 'duckdb_bind_info';
+  __duckdb_function_kind: 'scalar_function';
 }
 
-export interface FunctionInfo {
+export interface ScalarFunctionInfo {
   __duckdb_type: 'duckdb_function_info';
+  __duckdb_function_kind: 'scalar_function';
 }
+
+export interface TableFunctionBindInfo {
+  __duckdb_type: 'duckdb_bind_info';
+  __duckdb_function_kind: 'table_function';
+}
+
+export interface TableFunctionInitInfo {
+  __duckdb_type: 'duckdb_init_info';
+  __duckdb_function_kind: 'table_function';
+}
+
+export interface TableFunctionInfo {
+  __duckdb_type: 'duckdb_function_info';
+  __duckdb_function_kind: 'table_function';
+}
+
+/** @deprecated Renamed to ScalarFunctionBindInfo. */
+export type BindInfo = ScalarFunctionBindInfo;
+
+/** @deprecated Renamed to ScalarFunctionInfo. */
+export type FunctionInfo = ScalarFunctionInfo;
 
 export interface Vector {
   __duckdb_type: 'duckdb_vector';
@@ -273,8 +305,8 @@ export interface ExtractedStatementsAndCount {
   statement_count: number;
 }
 
-export type ScalarFunctionBindFunction = (info: BindInfo) => void;
-export type ScalarFunctionMainFunction = (info: FunctionInfo, input: DataChunk, output: Vector) => void;
+export type ScalarFunctionBindFunction = (info: ScalarFunctionBindInfo) => void;
+export type ScalarFunctionMainFunction = (info: ScalarFunctionInfo, input: DataChunk, output: Vector) => void;
 
 // Functions
 
@@ -1110,13 +1142,13 @@ export function scalar_function_set_extra_info(scalar_function: ScalarFunction, 
 export function scalar_function_set_bind(scalar_function: ScalarFunction, func: ScalarFunctionBindFunction): void;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
-export function scalar_function_set_bind_data(info: BindInfo, bind_data: object): void;
+export function scalar_function_set_bind_data(info: ScalarFunctionBindInfo, bind_data: object): void;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_bind_data_copy(duckdb_bind_info info, duckdb_copy_callback_t copy);
 // not exposed: handled by scalar_function_set_bind_data
 
 // DUCKDB_C_API void duckdb_scalar_function_bind_set_error(duckdb_bind_info info, const char *error);
-export function scalar_function_bind_set_error(bind_info: BindInfo, error: string): void;
+export function scalar_function_bind_set_error(bind_info: ScalarFunctionBindInfo, error: string): void;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_function(duckdb_scalar_function scalar_function, duckdb_scalar_function_t function);
 export function scalar_function_set_function(scalar_function: ScalarFunction, func: ScalarFunctionMainFunction): void;
@@ -1125,19 +1157,19 @@ export function scalar_function_set_function(scalar_function: ScalarFunction, fu
 export function register_scalar_function(connection: Connection, scalar_function: ScalarFunction): void;
 
 // DUCKDB_C_API void *duckdb_scalar_function_get_extra_info(duckdb_function_info info);
-export function scalar_function_get_extra_info(function_info: FunctionInfo): object | undefined;
+export function scalar_function_get_extra_info(function_info: ScalarFunctionInfo): object | undefined;
 
 // DUCKDB_C_API void *duckdb_scalar_function_bind_get_extra_info(duckdb_bind_info info);
-export function scalar_function_bind_get_extra_info(bind_info: BindInfo): object | undefined;
+export function scalar_function_bind_get_extra_info(bind_info: ScalarFunctionBindInfo): object | undefined;
 
 // DUCKDB_C_API void *duckdb_scalar_function_get_bind_data(duckdb_function_info info);
-export function scalar_function_get_bind_data(function_info: FunctionInfo): object | undefined;
+export function scalar_function_get_bind_data(function_info: ScalarFunctionInfo): object | undefined;
 
 // DUCKDB_C_API void duckdb_scalar_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);
-export function scalar_function_get_client_context(bind_info: BindInfo): ClientContext;
+export function scalar_function_get_client_context(bind_info: ScalarFunctionBindInfo): ClientContext;
 
 // DUCKDB_C_API void duckdb_scalar_function_set_error(duckdb_function_info info, const char *error);
-export function scalar_function_set_error(function_info: FunctionInfo, error: string): void;
+export function scalar_function_set_error(function_info: ScalarFunctionInfo, error: string): void;
 
 // DUCKDB_C_API duckdb_scalar_function_set duckdb_create_scalar_function_set(const char *name);
 // DUCKDB_C_API void duckdb_destroy_scalar_function_set(duckdb_scalar_function_set *scalar_function_set);

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -285,6 +285,10 @@ export interface ScalarFunction {
   __duckdb_type: 'duckdb_scalar_function';
 }
 
+export interface TableFunction {
+  __duckdb_type: 'duckdb_table_function';
+}
+
 // export interface SelectionVector {
 //   __duckdb_type: 'duckdb_selection_vector';
 // }
@@ -1210,17 +1214,32 @@ export function scalar_function_set_error(function_info: ScalarFunctionInfo, err
 // DUCKDB_C_API duckdb_state duckdb_register_aggregate_function_set(duckdb_connection con, duckdb_aggregate_function_set set);
 
 // DUCKDB_C_API duckdb_table_function duckdb_create_table_function();
+export function create_table_function(): TableFunction;
+
 // DUCKDB_C_API void duckdb_destroy_table_function(duckdb_table_function *table_function);
+export function destroy_table_function_sync(table_function: TableFunction): void;
+
 // DUCKDB_C_API void duckdb_table_function_set_name(duckdb_table_function table_function, const char *name);
+export function table_function_set_name(table_function: TableFunction, name: string): void;
+
 // DUCKDB_C_API void duckdb_table_function_add_parameter(duckdb_table_function table_function, duckdb_logical_type type);
+export function table_function_add_parameter(table_function: TableFunction, logical_type: LogicalType): void;
+
 // DUCKDB_C_API void duckdb_table_function_add_named_parameter(duckdb_table_function table_function, const char *name, duckdb_logical_type type);
+export function table_function_add_named_parameter(table_function: TableFunction, name: string, logical_type: LogicalType): void;
+
 // DUCKDB_C_API void duckdb_table_function_set_extra_info(duckdb_table_function table_function, void *extra_info, duckdb_delete_callback_t destroy);
+export function table_function_set_extra_info(table_function: TableFunction, extra_info: object): void;
+
 // DUCKDB_C_API void duckdb_table_function_set_bind(duckdb_table_function table_function, duckdb_table_function_bind_t bind);
 // DUCKDB_C_API void duckdb_table_function_set_init(duckdb_table_function table_function, duckdb_table_function_init_t init);
 // DUCKDB_C_API void duckdb_table_function_set_local_init(duckdb_table_function table_function, duckdb_table_function_init_t init);
 // DUCKDB_C_API void duckdb_table_function_set_function(duckdb_table_function table_function, duckdb_table_function_t function);
 // DUCKDB_C_API void duckdb_table_function_supports_projection_pushdown(duckdb_table_function table_function, bool pushdown);
+export function table_function_supports_projection_pushdown(table_function: TableFunction, pushdown: boolean): void;
+
 // DUCKDB_C_API duckdb_state duckdb_register_table_function(duckdb_connection con, duckdb_table_function function);
+export function register_table_function(connection: Connection, table_function: TableFunction): void;
 
 // DUCKDB_C_API void *duckdb_bind_get_extra_info(duckdb_bind_info info);
 // DUCKDB_C_API void duckdb_table_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);

--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -95,7 +95,6 @@ export enum Type {
   VARIANT = 41,
 }
 
-
 // Types (no explicit destroy)
 
 export interface Date_ {
@@ -311,6 +310,10 @@ export interface ExtractedStatementsAndCount {
 
 export type ScalarFunctionBindFunction = (info: ScalarFunctionBindInfo) => void;
 export type ScalarFunctionMainFunction = (info: ScalarFunctionInfo, input: DataChunk, output: Vector) => void;
+
+export type TableFunctionBindFunction = (info: TableFunctionBindInfo) => void;
+export type TableFunctionInitFunction = (info: TableFunctionInitInfo) => void;
+export type TableFunctionMainFunction = (info: TableFunctionInfo, output: DataChunk) => void;
 
 // Functions
 
@@ -1232,9 +1235,17 @@ export function table_function_add_named_parameter(table_function: TableFunction
 export function table_function_set_extra_info(table_function: TableFunction, extra_info: object): void;
 
 // DUCKDB_C_API void duckdb_table_function_set_bind(duckdb_table_function table_function, duckdb_table_function_bind_t bind);
+export function table_function_set_bind(table_function: TableFunction, func: TableFunctionBindFunction): void;
+
 // DUCKDB_C_API void duckdb_table_function_set_init(duckdb_table_function table_function, duckdb_table_function_init_t init);
+export function table_function_set_init(table_function: TableFunction, func: TableFunctionInitFunction): void;
+
 // DUCKDB_C_API void duckdb_table_function_set_local_init(duckdb_table_function table_function, duckdb_table_function_init_t init);
+export function table_function_set_local_init(table_function: TableFunction, func: TableFunctionInitFunction): void;
+
 // DUCKDB_C_API void duckdb_table_function_set_function(duckdb_table_function table_function, duckdb_table_function_t function);
+export function table_function_set_function(table_function: TableFunction, func: TableFunctionMainFunction): void;
+
 // DUCKDB_C_API void duckdb_table_function_supports_projection_pushdown(duckdb_table_function table_function, bool pushdown);
 export function table_function_supports_projection_pushdown(table_function: TableFunction, pushdown: boolean): void;
 
@@ -1244,26 +1255,41 @@ export function register_table_function(connection: Connection, table_function: 
 // DUCKDB_C_API void *duckdb_bind_get_extra_info(duckdb_bind_info info);
 // DUCKDB_C_API void duckdb_table_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);
 // DUCKDB_C_API void duckdb_bind_add_result_column(duckdb_bind_info info, const char *name, duckdb_logical_type type);
+export function bind_add_result_column(bind_info: TableFunctionBindInfo, name: string, logical_type: LogicalType): void;
+
 // DUCKDB_C_API idx_t duckdb_bind_get_parameter_count(duckdb_bind_info info);
 // DUCKDB_C_API duckdb_value duckdb_bind_get_parameter(duckdb_bind_info info, idx_t index);
 // DUCKDB_C_API duckdb_value duckdb_bind_get_named_parameter(duckdb_bind_info info, const char *name);
 // DUCKDB_C_API void duckdb_bind_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
+export function bind_set_bind_data(bind_info: TableFunctionBindInfo, bind_data: object): void;
+
 // DUCKDB_C_API void duckdb_bind_set_cardinality(duckdb_bind_info info, idx_t cardinality, bool is_exact);
 // DUCKDB_C_API void duckdb_bind_set_error(duckdb_bind_info info, const char *error);
+export function bind_set_error(bind_info: TableFunctionBindInfo, error: string): void;
 
 // DUCKDB_C_API void *duckdb_init_get_extra_info(duckdb_init_info info);
 // DUCKDB_C_API void *duckdb_init_get_bind_data(duckdb_init_info info);
 // DUCKDB_C_API void duckdb_init_set_init_data(duckdb_init_info info, void *init_data, duckdb_delete_callback_t destroy);
+export function init_set_init_data(init_info: TableFunctionInitInfo, init_data: object): void;
+
 // DUCKDB_C_API idx_t duckdb_init_get_column_count(duckdb_init_info info);
 // DUCKDB_C_API idx_t duckdb_init_get_column_index(duckdb_init_info info, idx_t column_index);
 // DUCKDB_C_API void duckdb_init_set_max_threads(duckdb_init_info info, idx_t max_threads);
 // DUCKDB_C_API void duckdb_init_set_error(duckdb_init_info info, const char *error);
+export function init_set_error(init_info: TableFunctionInitInfo, error: string): void;
 
 // DUCKDB_C_API void *duckdb_function_get_extra_info(duckdb_function_info info);
 // DUCKDB_C_API void *duckdb_function_get_bind_data(duckdb_function_info info);
+export function function_get_bind_data(function_info: TableFunctionInfo): object | undefined;
+
 // DUCKDB_C_API void *duckdb_function_get_init_data(duckdb_function_info info);
+export function function_get_init_data(function_info: TableFunctionInfo): object | undefined;
+
 // DUCKDB_C_API void *duckdb_function_get_local_init_data(duckdb_function_info info);
+export function function_get_local_init_data(function_info: TableFunctionInfo): object | undefined;
+
 // DUCKDB_C_API void duckdb_function_set_error(duckdb_function_info info, const char *error);
+export function function_set_error(function_info: TableFunctionInfo, error: string): void;
 
 // DUCKDB_C_API void duckdb_add_replacement_scan(duckdb_database db, duckdb_replacement_callback_t replacement, void *extra_data, duckdb_delete_callback_t delete_callback);
 // DUCKDB_C_API void duckdb_replacement_scan_set_function_name(duckdb_replacement_scan_info info, const char *function_name);

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -15,6 +15,7 @@
 #include "externals.h"
 #include "napi_ref_reaper.h"
 #include "scalar_function_helpers.h"
+#include "table_function_helpers.h"
 #include "promise_workers.h"
 #include "enums.h"
 
@@ -289,6 +290,15 @@ public:
       InstanceMethod("scalar_function_get_bind_data", &DuckDBNodeAddon::scalar_function_get_bind_data),
       InstanceMethod("scalar_function_get_client_context", &DuckDBNodeAddon::scalar_function_get_client_context),
       InstanceMethod("scalar_function_set_error", &DuckDBNodeAddon::scalar_function_set_error),
+
+      InstanceMethod("create_table_function", &DuckDBNodeAddon::create_table_function),
+      InstanceMethod("destroy_table_function_sync", &DuckDBNodeAddon::destroy_table_function_sync),
+      InstanceMethod("table_function_set_name", &DuckDBNodeAddon::table_function_set_name),
+      InstanceMethod("table_function_add_parameter", &DuckDBNodeAddon::table_function_add_parameter),
+      InstanceMethod("table_function_add_named_parameter", &DuckDBNodeAddon::table_function_add_named_parameter),
+      InstanceMethod("table_function_set_extra_info", &DuckDBNodeAddon::table_function_set_extra_info),
+      InstanceMethod("table_function_supports_projection_pushdown", &DuckDBNodeAddon::table_function_supports_projection_pushdown),
+      InstanceMethod("register_table_function", &DuckDBNodeAddon::register_table_function),
 
       InstanceMethod("appender_create", &DuckDBNodeAddon::appender_create),
       InstanceMethod("appender_create_ext", &DuckDBNodeAddon::appender_create_ext),
@@ -3245,22 +3255,64 @@ private:
   // TODO aggregate function set
 
   // DUCKDB_C_API duckdb_table_function duckdb_create_table_function();
-  // TODO table function
+  // function create_table_function(): TableFunction
+  Napi::Value create_table_function(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto table_function = duckdb_create_table_function();
+    return CreateExternalForTableFunction(env, table_function);
+  }
 
   // DUCKDB_C_API void duckdb_destroy_table_function(duckdb_table_function *table_function);
-  // TODO table function
+  // function destroy_table_function_sync(table_function: TableFunction): void
+  Napi::Value destroy_table_function_sync(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto holder = GetTableFunctionHolderFromExternal(env, info[0]);
+    // duckdb_destroy_table_function is a no-op if already destroyed
+    duckdb_destroy_table_function(&holder->table_function);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_table_function_set_name(duckdb_table_function table_function, const char *name);
-  // TODO table function
+  // function table_function_set_name(table_function: TableFunction, name: string): void
+  Napi::Value table_function_set_name(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto table_function = GetTableFunctionFromExternal(env, info[0]);
+    std::string name = info[1].As<Napi::String>();
+    duckdb_table_function_set_name(table_function, name.c_str());
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_table_function_add_parameter(duckdb_table_function table_function, duckdb_logical_type type);
-  // TODO table function
+  // function table_function_add_parameter(table_function: TableFunction, logical_type: LogicalType): void
+  Napi::Value table_function_add_parameter(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto table_function = GetTableFunctionFromExternal(env, info[0]);
+    auto logical_type = GetLogicalTypeFromExternal(env, info[1]);
+    duckdb_table_function_add_parameter(table_function, logical_type);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_table_function_add_named_parameter(duckdb_table_function table_function, const char *name, duckdb_logical_type type);
-  // TODO table function
+  // function table_function_add_named_parameter(table_function: TableFunction, name: string, logical_type: LogicalType): void
+  Napi::Value table_function_add_named_parameter(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto table_function = GetTableFunctionFromExternal(env, info[0]);
+    std::string name = info[1].As<Napi::String>();
+    auto logical_type = GetLogicalTypeFromExternal(env, info[2]);
+    duckdb_table_function_add_named_parameter(table_function, name.c_str(), logical_type);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_table_function_set_extra_info(duckdb_table_function table_function, void *extra_info, duckdb_delete_callback_t destroy);
-  // TODO table function
+  // function table_function_set_extra_info(table_function: TableFunction, extra_info: object): void
+  Napi::Value table_function_set_extra_info(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto holder = GetTableFunctionHolderFromExternal(env, info[0]);
+    auto user_extra_info = info[1].As<Napi::Object>();
+    holder->EnsureInternalExtraInfo();
+    holder->internal_extra_info->SetUserExtraInfo(ref_reaper, user_extra_info);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_table_function_set_bind(duckdb_table_function table_function, duckdb_table_function_bind_t bind);
   // TODO table function
@@ -3275,10 +3327,26 @@ private:
   // TODO table function
 
   // DUCKDB_C_API void duckdb_table_function_supports_projection_pushdown(duckdb_table_function table_function, bool pushdown);
-  // TODO table function
+  // function table_function_supports_projection_pushdown(table_function: TableFunction, pushdown: boolean): void
+  Napi::Value table_function_supports_projection_pushdown(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto table_function = GetTableFunctionFromExternal(env, info[0]);
+    auto pushdown = info[1].As<Napi::Boolean>().Value();
+    duckdb_table_function_supports_projection_pushdown(table_function, pushdown);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API duckdb_state duckdb_register_table_function(duckdb_connection con, duckdb_table_function function);
-  // TODO table function
+  // function register_table_function(connection: Connection, table_function: TableFunction): void
+  Napi::Value register_table_function(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto connection = GetConnectionFromExternal(env, info[0]);
+    auto table_function = GetTableFunctionFromExternal(env, info[1]);
+    if (duckdb_register_table_function(connection, table_function)) {
+      throw Napi::Error::New(env, "Failed to register table function");
+    }
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void *duckdb_bind_get_extra_info(duckdb_bind_info info);
   // TODO bind info

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -298,7 +298,20 @@ public:
       InstanceMethod("table_function_add_named_parameter", &DuckDBNodeAddon::table_function_add_named_parameter),
       InstanceMethod("table_function_set_extra_info", &DuckDBNodeAddon::table_function_set_extra_info),
       InstanceMethod("table_function_supports_projection_pushdown", &DuckDBNodeAddon::table_function_supports_projection_pushdown),
+      InstanceMethod("table_function_set_bind", &DuckDBNodeAddon::table_function_set_bind),
+      InstanceMethod("table_function_set_init", &DuckDBNodeAddon::table_function_set_init),
+      InstanceMethod("table_function_set_local_init", &DuckDBNodeAddon::table_function_set_local_init),
+      InstanceMethod("table_function_set_function", &DuckDBNodeAddon::table_function_set_function),
       InstanceMethod("register_table_function", &DuckDBNodeAddon::register_table_function),
+      InstanceMethod("bind_add_result_column", &DuckDBNodeAddon::bind_add_result_column),
+      InstanceMethod("bind_set_bind_data", &DuckDBNodeAddon::bind_set_bind_data),
+      InstanceMethod("bind_set_error", &DuckDBNodeAddon::bind_set_error),
+      InstanceMethod("init_set_init_data", &DuckDBNodeAddon::init_set_init_data),
+      InstanceMethod("init_set_error", &DuckDBNodeAddon::init_set_error),
+      InstanceMethod("function_get_bind_data", &DuckDBNodeAddon::function_get_bind_data),
+      InstanceMethod("function_get_init_data", &DuckDBNodeAddon::function_get_init_data),
+      InstanceMethod("function_get_local_init_data", &DuckDBNodeAddon::function_get_local_init_data),
+      InstanceMethod("function_set_error", &DuckDBNodeAddon::function_set_error),
 
       InstanceMethod("appender_create", &DuckDBNodeAddon::appender_create),
       InstanceMethod("appender_create_ext", &DuckDBNodeAddon::appender_create_ext),
@@ -3309,22 +3322,58 @@ private:
     auto env = info.Env();
     auto holder = GetTableFunctionHolderFromExternal(env, info[0]);
     auto user_extra_info = info[1].As<Napi::Object>();
-    holder->EnsureInternalExtraInfo();
+    holder->EnsureInternalExtraInfo(ref_reaper);
     holder->internal_extra_info->SetUserExtraInfo(ref_reaper, user_extra_info);
     return env.Undefined();
   }
 
   // DUCKDB_C_API void duckdb_table_function_set_bind(duckdb_table_function table_function, duckdb_table_function_bind_t bind);
-  // TODO table function
+  // function table_function_set_bind(table_function: TableFunction, func: TableFunctionBindFunction): void
+  Napi::Value table_function_set_bind(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto holder = GetTableFunctionHolderFromExternal(env, info[0]);
+    auto func = info[1].As<Napi::Function>();
+    holder->EnsureInternalExtraInfo(ref_reaper);
+    holder->internal_extra_info->SetBindFunction(env, func);
+    duckdb_table_function_set_bind(holder->table_function, &TableFunctionBindFunction);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_table_function_set_init(duckdb_table_function table_function, duckdb_table_function_init_t init);
-  // TODO table function
+  // function table_function_set_init(table_function: TableFunction, func: TableFunctionInitFunction): void
+  Napi::Value table_function_set_init(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto holder = GetTableFunctionHolderFromExternal(env, info[0]);
+    auto func = info[1].As<Napi::Function>();
+    holder->EnsureInternalExtraInfo(ref_reaper);
+    holder->internal_extra_info->SetInitFunction(env, func);
+    duckdb_table_function_set_init(holder->table_function, &TableFunctionInitFunction);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_table_function_set_local_init(duckdb_table_function table_function, duckdb_table_function_init_t init);
-  // TODO table function
+  // function table_function_set_local_init(table_function: TableFunction, func: TableFunctionInitFunction): void
+  Napi::Value table_function_set_local_init(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto holder = GetTableFunctionHolderFromExternal(env, info[0]);
+    auto func = info[1].As<Napi::Function>();
+    holder->EnsureInternalExtraInfo(ref_reaper);
+    holder->internal_extra_info->SetLocalInitFunction(env, func);
+    duckdb_table_function_set_local_init(holder->table_function, &TableFunctionLocalInitFunction);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_table_function_set_function(duckdb_table_function table_function, duckdb_table_function_t function);
-  // TODO table function
+  // function table_function_set_function(table_function: TableFunction, func: TableFunctionMainFunction): void
+  Napi::Value table_function_set_function(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto holder = GetTableFunctionHolderFromExternal(env, info[0]);
+    auto func = info[1].As<Napi::Function>();
+    holder->EnsureInternalExtraInfo(ref_reaper);
+    holder->internal_extra_info->SetMainFunction(env, func);
+    duckdb_table_function_set_function(holder->table_function, &TableFunctionMainFunction);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_table_function_supports_projection_pushdown(duckdb_table_function table_function, bool pushdown);
   // function table_function_supports_projection_pushdown(table_function: TableFunction, pushdown: boolean): void
@@ -3355,7 +3404,15 @@ private:
   // TODO bind info
 
   // DUCKDB_C_API void duckdb_bind_add_result_column(duckdb_bind_info info, const char *name, duckdb_logical_type type);
-  // TODO bind info
+  // function bind_add_result_column(bind_info: TableFunctionBindInfo, name: string, logical_type: LogicalType): void
+  Napi::Value bind_add_result_column(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto bind_info = GetTableFunctionBindInfoFromExternal(env, info[0]);
+    std::string name = info[1].As<Napi::String>();
+    auto logical_type = GetLogicalTypeFromExternal(env, info[2]);
+    duckdb_bind_add_result_column(bind_info, name.c_str(), logical_type);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API idx_t duckdb_bind_get_parameter_count(duckdb_bind_info info);
   // TODO bind info
@@ -3367,13 +3424,29 @@ private:
   // TODO bind info
 
   // DUCKDB_C_API void duckdb_bind_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
-  // TODO bind info
+  // function bind_set_bind_data(bind_info: TableFunctionBindInfo, bind_data: object): void
+  Napi::Value bind_set_bind_data(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto bind_info = GetTableFunctionBindInfoFromExternal(env, info[0]);
+    auto user_bind_data = info[1].As<Napi::Object>();
+    auto internal_bind_data = new TableFunctionInternalBindData();
+    internal_bind_data->SetUserBindData(ref_reaper, user_bind_data);
+    duckdb_bind_set_bind_data(bind_info, internal_bind_data, reinterpret_cast<duckdb_delete_callback_t>(DeleteTableFunctionInternalBindData));
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_bind_set_cardinality(duckdb_bind_info info, idx_t cardinality, bool is_exact);
   // TODO bind info
 
   // DUCKDB_C_API void duckdb_bind_set_error(duckdb_bind_info info, const char *error);
-  // TODO bind info
+  // function bind_set_error(bind_info: TableFunctionBindInfo, error: string): void
+  Napi::Value bind_set_error(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto bind_info = GetTableFunctionBindInfoFromExternal(env, info[0]);
+    std::string error = info[1].As<Napi::String>();
+    duckdb_bind_set_error(bind_info, error.c_str());
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void *duckdb_init_get_extra_info(duckdb_init_info info);
   // TODO init info
@@ -3382,7 +3455,16 @@ private:
   // TODO init info
 
   // DUCKDB_C_API void duckdb_init_set_init_data(duckdb_init_info info, void *init_data, duckdb_delete_callback_t destroy);
-  // TODO init info
+  // function init_set_init_data(init_info: TableFunctionInitInfo, init_data: object): void
+  Napi::Value init_set_init_data(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetTableFunctionInitInfoFromExternal(env, info[0]);
+    auto user_init_data = info[1].As<Napi::Object>();
+    auto internal_init_data = new TableFunctionInternalInitData();
+    internal_init_data->SetUserInitData(ref_reaper, user_init_data);
+    duckdb_init_set_init_data(init_info, internal_init_data, reinterpret_cast<duckdb_delete_callback_t>(DeleteTableFunctionInternalInitData));
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API idx_t duckdb_init_get_column_count(duckdb_init_info info);
   // TODO init info
@@ -3394,22 +3476,63 @@ private:
   // TODO init info
 
   // DUCKDB_C_API void duckdb_init_set_error(duckdb_init_info info, const char *error);
-  // TODO init info
+  // function init_set_error(init_info: TableFunctionInitInfo, error: string): void
+  Napi::Value init_set_error(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetTableFunctionInitInfoFromExternal(env, info[0]);
+    std::string error = info[1].As<Napi::String>();
+    duckdb_init_set_error(init_info, error.c_str());
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void *duckdb_function_get_extra_info(duckdb_function_info info);
   // TODO function info
 
   // DUCKDB_C_API void *duckdb_function_get_bind_data(duckdb_function_info info);
-  // TODO function info
+  // function function_get_bind_data(function_info: TableFunctionInfo): object | undefined
+  Napi::Value function_get_bind_data(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto function_info = GetTableFunctionInfoFromExternal(env, info[0]);
+    auto internal_data = reinterpret_cast<TableFunctionInternalBindData*>(duckdb_function_get_bind_data(function_info));
+    if (!internal_data || !internal_data->user_bind_data_ref) {
+      return env.Undefined();
+    }
+    return internal_data->user_bind_data_ref->ref.Value();
+  }
 
   // DUCKDB_C_API void *duckdb_function_get_init_data(duckdb_function_info info);
-  // TODO function info
+  // function function_get_init_data(function_info: TableFunctionInfo): object | undefined
+  Napi::Value function_get_init_data(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto function_info = GetTableFunctionInfoFromExternal(env, info[0]);
+    auto internal_data = reinterpret_cast<TableFunctionInternalInitData*>(duckdb_function_get_init_data(function_info));
+    if (!internal_data || !internal_data->user_init_data_ref) {
+      return env.Undefined();
+    }
+    return internal_data->user_init_data_ref->ref.Value();
+  }
 
   // DUCKDB_C_API void *duckdb_function_get_local_init_data(duckdb_function_info info);
-  // TODO function info
+  // function function_get_local_init_data(function_info: TableFunctionInfo): object | undefined
+  Napi::Value function_get_local_init_data(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto function_info = GetTableFunctionInfoFromExternal(env, info[0]);
+    auto internal_data = reinterpret_cast<TableFunctionInternalInitData*>(duckdb_function_get_local_init_data(function_info));
+    if (!internal_data || !internal_data->user_init_data_ref) {
+      return env.Undefined();
+    }
+    return internal_data->user_init_data_ref->ref.Value();
+  }
 
   // DUCKDB_C_API void duckdb_function_set_error(duckdb_function_info info, const char *error);
-  // TODO function info
+  // function function_set_error(function_info: TableFunctionInfo, error: string): void
+  Napi::Value function_set_error(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto function_info = GetTableFunctionInfoFromExternal(env, info[0]);
+    std::string error = info[1].As<Napi::String>();
+    duckdb_function_set_error(function_info, error.c_str());
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_add_replacement_scan(duckdb_database db, duckdb_replacement_callback_t replacement, void *extra_data, duckdb_delete_callback_t delete_callback);
   // TODO replacement scan

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -3040,10 +3040,10 @@ private:
   }
 
   // DUCKDB_C_API void duckdb_scalar_function_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
-  // function scalar_function_set_bind_data(info: BindInfo, bind_data: object): void
+  // function scalar_function_set_bind_data(info: ScalarFunctionBindInfo, bind_data: object): void
   Napi::Value scalar_function_set_bind_data(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto bind_info = GetBindInfoFromExternal(env, info[0]);
+    auto bind_info = GetScalarFunctionBindInfoFromExternal(env, info[0]);
     auto user_bind_data = info[1].As<Napi::Object>();
     auto internal_bind_data = new ScalarFunctionInternalBindData();
     internal_bind_data->SetUserBindData(ref_reaper, user_bind_data);
@@ -3056,10 +3056,10 @@ private:
   // not exposed: handled by scalar_function_set_bind_data
 
   // DUCKDB_C_API void duckdb_scalar_function_bind_set_error(duckdb_bind_info info, const char *error);
-  // function scalar_function_bind_set_error(bind_info: BindInfo, error: string): void
+  // function scalar_function_bind_set_error(bind_info: ScalarFunctionBindInfo, error: string): void
   Napi::Value scalar_function_bind_set_error(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto bind_info = GetBindInfoFromExternal(env, info[0]);
+    auto bind_info = GetScalarFunctionBindInfoFromExternal(env, info[0]);
     std::string error = info[1].As<Napi::String>();
     duckdb_scalar_function_bind_set_error(bind_info, error.c_str());
     return env.Undefined();
@@ -3090,10 +3090,10 @@ private:
   }
 
   // DUCKDB_C_API void *duckdb_scalar_function_get_extra_info(duckdb_function_info info);
-  // function scalar_function_get_extra_info(function_info: FunctionInfo): object | undefined
+  // function scalar_function_get_extra_info(function_info: ScalarFunctionInfo): object | undefined
   Napi::Value scalar_function_get_extra_info(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto function_info = GetFunctionInfoFromExternal(env, info[0]);
+    auto function_info = GetScalarFunctionInfoFromExternal(env, info[0]);
     auto internal_extra_info = GetScalarFunctionInternalExtraInfoFromFunctionInfo(function_info);
     if (!internal_extra_info || !internal_extra_info->user_extra_info_ref) {
       return env.Undefined();
@@ -3102,10 +3102,10 @@ private:
   }
 
   // DUCKDB_C_API void *duckdb_scalar_function_bind_get_extra_info(duckdb_bind_info info);
-  // function scalar_function_bind_get_extra_info(bind_info: BindInfo): object | undefined
+  // function scalar_function_bind_get_extra_info(bind_info: ScalarFunctionBindInfo): object | undefined
   Napi::Value scalar_function_bind_get_extra_info(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto bind_info = GetBindInfoFromExternal(env, info[0]);
+    auto bind_info = GetScalarFunctionBindInfoFromExternal(env, info[0]);
     auto internal_extra_info = GetScalarFunctionInternalExtraInfoFromBindInfo(bind_info);
     if (!internal_extra_info || !internal_extra_info->user_extra_info_ref) {
       return env.Undefined();
@@ -3114,10 +3114,10 @@ private:
   }
 
   // DUCKDB_C_API void *duckdb_scalar_function_get_bind_data(duckdb_function_info info);
-  // function scalar_function_get_bind_data(function_info: FunctionInfo): object | undefined
+  // function scalar_function_get_bind_data(function_info: ScalarFunctionInfo): object | undefined
   Napi::Value scalar_function_get_bind_data(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto function_info = GetFunctionInfoFromExternal(env, info[0]);
+    auto function_info = GetScalarFunctionInfoFromExternal(env, info[0]);
     auto internal_bind_data = reinterpret_cast<ScalarFunctionInternalBindData*>(duckdb_scalar_function_get_bind_data(function_info));
     if (!internal_bind_data || !internal_bind_data->user_bind_data_ref) {
       return env.Undefined();
@@ -3126,10 +3126,10 @@ private:
   }
 
   // DUCKDB_C_API void duckdb_scalar_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);
-  // function scalar_function_get_client_context(bind_info: BindInfo): ClientContext
+  // function scalar_function_get_client_context(bind_info: ScalarFunctionBindInfo): ClientContext
   Napi::Value scalar_function_get_client_context(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto bind_info = GetBindInfoFromExternal(env, info[0]);
+    auto bind_info = GetScalarFunctionBindInfoFromExternal(env, info[0]);
     duckdb_client_context client_context;
     duckdb_scalar_function_get_client_context(bind_info, &client_context);
     if (!client_context) {
@@ -3139,10 +3139,10 @@ private:
   }
 
   // DUCKDB_C_API void duckdb_scalar_function_set_error(duckdb_function_info info, const char *error);
-  // function scalar_function_set_error(function_info: FunctionInfo, error: string): void
+  // function scalar_function_set_error(function_info: ScalarFunctionInfo, error: string): void
   Napi::Value scalar_function_set_error(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto function_info = GetFunctionInfoFromExternal(env, info[0]);
+    auto function_info = GetScalarFunctionInfoFromExternal(env, info[0]);
     std::string error = info[1].As<Napi::String>();
     duckdb_scalar_function_set_error(function_info, error.c_str());
     return env.Undefined();

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -303,11 +303,23 @@ public:
       InstanceMethod("table_function_set_local_init", &DuckDBNodeAddon::table_function_set_local_init),
       InstanceMethod("table_function_set_function", &DuckDBNodeAddon::table_function_set_function),
       InstanceMethod("register_table_function", &DuckDBNodeAddon::register_table_function),
+      InstanceMethod("bind_get_extra_info", &DuckDBNodeAddon::bind_get_extra_info),
+      InstanceMethod("table_function_get_client_context", &DuckDBNodeAddon::table_function_get_client_context),
       InstanceMethod("bind_add_result_column", &DuckDBNodeAddon::bind_add_result_column),
+      InstanceMethod("bind_get_parameter_count", &DuckDBNodeAddon::bind_get_parameter_count),
+      InstanceMethod("bind_get_parameter", &DuckDBNodeAddon::bind_get_parameter),
+      InstanceMethod("bind_get_named_parameter", &DuckDBNodeAddon::bind_get_named_parameter),
+      InstanceMethod("bind_set_cardinality", &DuckDBNodeAddon::bind_set_cardinality),
       InstanceMethod("bind_set_bind_data", &DuckDBNodeAddon::bind_set_bind_data),
       InstanceMethod("bind_set_error", &DuckDBNodeAddon::bind_set_error),
+      InstanceMethod("init_get_extra_info", &DuckDBNodeAddon::init_get_extra_info),
+      InstanceMethod("init_get_bind_data", &DuckDBNodeAddon::init_get_bind_data),
       InstanceMethod("init_set_init_data", &DuckDBNodeAddon::init_set_init_data),
+      InstanceMethod("init_get_column_count", &DuckDBNodeAddon::init_get_column_count),
+      InstanceMethod("init_get_column_index", &DuckDBNodeAddon::init_get_column_index),
+      InstanceMethod("init_set_max_threads", &DuckDBNodeAddon::init_set_max_threads),
       InstanceMethod("init_set_error", &DuckDBNodeAddon::init_set_error),
+      InstanceMethod("function_get_extra_info", &DuckDBNodeAddon::function_get_extra_info),
       InstanceMethod("function_get_bind_data", &DuckDBNodeAddon::function_get_bind_data),
       InstanceMethod("function_get_init_data", &DuckDBNodeAddon::function_get_init_data),
       InstanceMethod("function_get_local_init_data", &DuckDBNodeAddon::function_get_local_init_data),
@@ -3398,10 +3410,29 @@ private:
   }
 
   // DUCKDB_C_API void *duckdb_bind_get_extra_info(duckdb_bind_info info);
-  // TODO bind info
+  // function bind_get_extra_info(bind_info: TableFunctionBindInfo): object | undefined
+  Napi::Value bind_get_extra_info(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto bind_info = GetTableFunctionBindInfoFromExternal(env, info[0]);
+    auto internal_extra_info = GetTableFunctionInternalExtraInfoFromBindInfo(bind_info);
+    if (!internal_extra_info || !internal_extra_info->user_extra_info_ref) {
+      return env.Undefined();
+    }
+    return internal_extra_info->user_extra_info_ref->ref.Value();
+  }
 
   // DUCKDB_C_API void duckdb_table_function_get_client_context(duckdb_bind_info info, duckdb_client_context *out_context);
-  // TODO bind info
+  // function table_function_get_client_context(bind_info: TableFunctionBindInfo): ClientContext
+  Napi::Value table_function_get_client_context(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto bind_info = GetTableFunctionBindInfoFromExternal(env, info[0]);
+    duckdb_client_context client_context;
+    duckdb_table_function_get_client_context(bind_info, &client_context);
+    if (!client_context) {
+      throw Napi::Error::New(env, "Failed to get client context");
+    }
+    return CreateExternalForClientContext(env, client_context);
+  }
 
   // DUCKDB_C_API void duckdb_bind_add_result_column(duckdb_bind_info info, const char *name, duckdb_logical_type type);
   // function bind_add_result_column(bind_info: TableFunctionBindInfo, name: string, logical_type: LogicalType): void
@@ -3415,13 +3446,40 @@ private:
   }
 
   // DUCKDB_C_API idx_t duckdb_bind_get_parameter_count(duckdb_bind_info info);
-  // TODO bind info
+  // function bind_get_parameter_count(bind_info: TableFunctionBindInfo): number
+  Napi::Value bind_get_parameter_count(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto bind_info = GetTableFunctionBindInfoFromExternal(env, info[0]);
+    auto parameter_count = duckdb_bind_get_parameter_count(bind_info);
+    return Napi::Number::New(env, parameter_count);
+  }
 
   // DUCKDB_C_API duckdb_value duckdb_bind_get_parameter(duckdb_bind_info info, idx_t index);
-  // TODO bind info
+  // function bind_get_parameter(bind_info: TableFunctionBindInfo, index: number): Value
+  Napi::Value bind_get_parameter(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto bind_info = GetTableFunctionBindInfoFromExternal(env, info[0]);
+    auto index = info[1].As<Napi::Number>().Uint32Value();
+    auto value = duckdb_bind_get_parameter(bind_info, index);
+    if (!value) {
+      throw Napi::Error::New(env, "Failed to get parameter");
+    }
+    return CreateExternalForValue(env, value);
+  }
 
   // DUCKDB_C_API duckdb_value duckdb_bind_get_named_parameter(duckdb_bind_info info, const char *name);
-  // TODO bind info
+  // function bind_get_named_parameter(bind_info: TableFunctionBindInfo, name: string): Value | null
+  Napi::Value bind_get_named_parameter(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto bind_info = GetTableFunctionBindInfoFromExternal(env, info[0]);
+    std::string name = info[1].As<Napi::String>();
+    auto value = duckdb_bind_get_named_parameter(bind_info, name.c_str());
+    if (!value) {
+      // The C API returns null when no parameter with this name was supplied.
+      return env.Null();
+    }
+    return CreateExternalForValue(env, value);
+  }
 
   // DUCKDB_C_API void duckdb_bind_set_bind_data(duckdb_bind_info info, void *bind_data, duckdb_delete_callback_t destroy);
   // function bind_set_bind_data(bind_info: TableFunctionBindInfo, bind_data: object): void
@@ -3436,7 +3494,17 @@ private:
   }
 
   // DUCKDB_C_API void duckdb_bind_set_cardinality(duckdb_bind_info info, idx_t cardinality, bool is_exact);
-  // TODO bind info
+  // function bind_set_cardinality(bind_info: TableFunctionBindInfo, cardinality: number, is_exact: boolean): void
+  Napi::Value bind_set_cardinality(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto bind_info = GetTableFunctionBindInfoFromExternal(env, info[0]);
+    // Read as 64 bits: unlike a chunk size or a column count, a cardinality
+    // estimate can exceed what fits in 32.
+    auto cardinality = info[1].As<Napi::Number>().Int64Value();
+    auto is_exact = info[2].As<Napi::Boolean>().Value();
+    duckdb_bind_set_cardinality(bind_info, cardinality, is_exact);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_bind_set_error(duckdb_bind_info info, const char *error);
   // function bind_set_error(bind_info: TableFunctionBindInfo, error: string): void
@@ -3449,10 +3517,28 @@ private:
   }
 
   // DUCKDB_C_API void *duckdb_init_get_extra_info(duckdb_init_info info);
-  // TODO init info
+  // function init_get_extra_info(init_info: TableFunctionInitInfo): object | undefined
+  Napi::Value init_get_extra_info(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetTableFunctionInitInfoFromExternal(env, info[0]);
+    auto internal_extra_info = GetTableFunctionInternalExtraInfoFromInitInfo(init_info);
+    if (!internal_extra_info || !internal_extra_info->user_extra_info_ref) {
+      return env.Undefined();
+    }
+    return internal_extra_info->user_extra_info_ref->ref.Value();
+  }
 
   // DUCKDB_C_API void *duckdb_init_get_bind_data(duckdb_init_info info);
-  // TODO init info
+  // function init_get_bind_data(init_info: TableFunctionInitInfo): object | undefined
+  Napi::Value init_get_bind_data(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetTableFunctionInitInfoFromExternal(env, info[0]);
+    auto internal_bind_data = reinterpret_cast<TableFunctionInternalBindData*>(duckdb_init_get_bind_data(init_info));
+    if (!internal_bind_data || !internal_bind_data->user_bind_data_ref) {
+      return env.Undefined();
+    }
+    return internal_bind_data->user_bind_data_ref->ref.Value();
+  }
 
   // DUCKDB_C_API void duckdb_init_set_init_data(duckdb_init_info info, void *init_data, duckdb_delete_callback_t destroy);
   // function init_set_init_data(init_info: TableFunctionInitInfo, init_data: object): void
@@ -3467,13 +3553,33 @@ private:
   }
 
   // DUCKDB_C_API idx_t duckdb_init_get_column_count(duckdb_init_info info);
-  // TODO init info
+  // function init_get_column_count(init_info: TableFunctionInitInfo): number
+  Napi::Value init_get_column_count(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetTableFunctionInitInfoFromExternal(env, info[0]);
+    auto column_count = duckdb_init_get_column_count(init_info);
+    return Napi::Number::New(env, column_count);
+  }
 
   // DUCKDB_C_API idx_t duckdb_init_get_column_index(duckdb_init_info info, idx_t column_index);
-  // TODO init info
+  // function init_get_column_index(init_info: TableFunctionInitInfo, column_index: number): number
+  Napi::Value init_get_column_index(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetTableFunctionInitInfoFromExternal(env, info[0]);
+    auto column_index = info[1].As<Napi::Number>().Uint32Value();
+    auto index = duckdb_init_get_column_index(init_info, column_index);
+    return Napi::Number::New(env, index);
+  }
 
   // DUCKDB_C_API void duckdb_init_set_max_threads(duckdb_init_info info, idx_t max_threads);
-  // TODO init info
+  // function init_set_max_threads(init_info: TableFunctionInitInfo, max_threads: number): void
+  Napi::Value init_set_max_threads(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetTableFunctionInitInfoFromExternal(env, info[0]);
+    auto max_threads = info[1].As<Napi::Number>().Uint32Value();
+    duckdb_init_set_max_threads(init_info, max_threads);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_init_set_error(duckdb_init_info info, const char *error);
   // function init_set_error(init_info: TableFunctionInitInfo, error: string): void
@@ -3486,7 +3592,16 @@ private:
   }
 
   // DUCKDB_C_API void *duckdb_function_get_extra_info(duckdb_function_info info);
-  // TODO function info
+  // function function_get_extra_info(function_info: TableFunctionInfo): object | undefined
+  Napi::Value function_get_extra_info(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto function_info = GetTableFunctionInfoFromExternal(env, info[0]);
+    auto internal_extra_info = GetTableFunctionInternalExtraInfoFromFunctionInfo(function_info);
+    if (!internal_extra_info || !internal_extra_info->user_extra_info_ref) {
+      return env.Undefined();
+    }
+    return internal_extra_info->user_extra_info_ref->ref.Value();
+  }
 
   // DUCKDB_C_API void *duckdb_function_get_bind_data(duckdb_function_info info);
   // function function_get_bind_data(function_info: TableFunctionInfo): object | undefined
@@ -4444,10 +4559,10 @@ NODE_API_ADDON(DuckDBNodeAddon)
 /*
 
 546 DUCKDB_C_API
-    271 function
+    304 function
      25 not exposed
      41 deprecated
-    209 TODO
+    176 TODO
         8 arrow
         5 error data
         2 utf8
@@ -4461,10 +4576,6 @@ NODE_API_ADDON(DuckDBNodeAddon)
         3 selection vector
        12 aggregate function
         4 aggregate function set
-       12 table function
-        9 bind info
-        7 init info
-        5 function info
         4 replacement scan
         5 profiling info
         1 appender create query

--- a/bindings/src/externals.h
+++ b/bindings/src/externals.h
@@ -44,15 +44,6 @@ inline duckdb_appender GetAppenderFromExternal(Napi::Env env, Napi::Value value)
   return GetDataFromExternal<_duckdb_appender>(env, AppenderTypeTag, value, "Invalid appender argument");
 }
 
-inline Napi::External<_duckdb_bind_info> CreateExternalForBindInfoWithoutFinalizer(Napi::Env env, duckdb_bind_info bind_info) {
-  // BindInfo objects are never explicitly created; they are passed in to function callbacks.
-  return CreateExternalWithoutFinalizer<_duckdb_bind_info>(env, BindInfoTypeTag, bind_info);
-}
-
-inline duckdb_bind_info GetBindInfoFromExternal(Napi::Env env, Napi::Value value) {
-  return GetDataFromExternal<_duckdb_bind_info>(env, BindInfoTypeTag, value, "Invalid bind info argument");
-}
-
 inline void FinalizeClientContext(Napi::BasicEnv, duckdb_client_context client_context) {
   duckdb_destroy_client_context(&client_context);
 }
@@ -168,15 +159,6 @@ inline Napi::External<_duckdb_extracted_statements> CreateExternalForExtractedSt
 
 inline duckdb_extracted_statements GetExtractedStatementsFromExternal(Napi::Env env, Napi::Value value) {
   return GetDataFromExternal<_duckdb_extracted_statements>(env, ExtractedStatementsTypeTag, value, "Invalid extracted statements argument");
-}
-
-inline Napi::External<_duckdb_function_info> CreateExternalForFunctionInfoWithoutFinalizer(Napi::Env env, duckdb_function_info function_info) {
-  // FunctionInfo objects are never explicitly created; they are passed in to function callbacks.
-  return CreateExternalWithoutFinalizer<_duckdb_function_info>(env, FunctionInfoTypeTag, function_info);
-}
-
-inline duckdb_function_info GetFunctionInfoFromExternal(Napi::Env env, Napi::Value value) {
-  return GetDataFromExternal<_duckdb_function_info>(env, FunctionInfoTypeTag, value, "Invalid function info argument");
 }
 
 inline void FinalizeInstanceCache(Napi::BasicEnv, duckdb_instance_cache instance_cache) {

--- a/bindings/src/scalar_function_helpers.h
+++ b/bindings/src/scalar_function_helpers.h
@@ -13,6 +13,32 @@
 // family-specific state and so does not belong in externals.h. Later function
 // families should follow the same shape.
 
+// Info externals
+//
+// These wrap duckdb_bind_info and duckdb_function_info, which the C API also
+// reuses for other function families. The struct behind each handle differs per
+// family and is reinterpret_cast with no check, so a scalar handle passed to a
+// table function accessor would corrupt memory. The per-family tags make that a
+// thrown error instead.
+//
+// Neither is ever created explicitly; both are passed in to callbacks.
+
+inline Napi::External<_duckdb_bind_info> CreateExternalForScalarFunctionBindInfo(Napi::Env env, duckdb_bind_info bind_info) {
+  return CreateExternalWithoutFinalizer<_duckdb_bind_info>(env, ScalarFunctionBindInfoTypeTag, bind_info);
+}
+
+inline duckdb_bind_info GetScalarFunctionBindInfoFromExternal(Napi::Env env, Napi::Value value) {
+  return GetDataFromExternal<_duckdb_bind_info>(env, ScalarFunctionBindInfoTypeTag, value, "Invalid scalar function bind info argument");
+}
+
+inline Napi::External<_duckdb_function_info> CreateExternalForScalarFunctionInfo(Napi::Env env, duckdb_function_info function_info) {
+  return CreateExternalWithoutFinalizer<_duckdb_function_info>(env, ScalarFunctionInfoTypeTag, function_info);
+}
+
+inline duckdb_function_info GetScalarFunctionInfoFromExternal(Napi::Env env, Napi::Value value) {
+  return GetDataFromExternal<_duckdb_function_info>(env, ScalarFunctionInfoTypeTag, value, "Invalid scalar function info argument");
+}
+
 // Callbacks
 
 struct ScalarFunctionBindCallbackTraits {
@@ -26,7 +52,7 @@ struct ScalarFunctionBindCallbackTraits {
     callback.Call(
       env.Undefined(),
       {
-        CreateExternalForBindInfoWithoutFinalizer(env, payload)
+        CreateExternalForScalarFunctionBindInfo(env, payload)
       }
     );
   }
@@ -51,7 +77,7 @@ struct ScalarFunctionMainCallbackTraits {
     callback.Call(
       env.Undefined(),
       {
-        CreateExternalForFunctionInfoWithoutFinalizer(env, payload.info),
+        CreateExternalForScalarFunctionInfo(env, payload.info),
         CreateExternalForDataChunkWithoutFinalizer(env, payload.input),
         CreateExternalForVectorWithoutFinalizer(env, payload.output)
       }

--- a/bindings/src/table_function_helpers.h
+++ b/bindings/src/table_function_helpers.h
@@ -1,0 +1,103 @@
+#pragma once
+
+#include "externals.h"
+#include "duckdb_thread_callback.h"
+#include "type_tags.h"
+#include "napi_ref_reaper.h"
+#include <memory>
+
+// Table functions
+//
+// Everything specific to the table function family lives here, including its
+// external: the object behind that external is TableFunctionHolder, which owns
+// family-specific state and so does not belong in externals.h. This mirrors
+// scalar_function_helpers.h.
+
+// Info externals
+//
+// duckdb_bind_info and duckdb_function_info are the same C types the scalar
+// family uses, and duckdb_init_info is shared with scalar function init. The
+// struct behind each differs per family and is reinterpret_cast with no check, so
+// each family tags its own; see the note in type_tags.h.
+//
+// None of these is ever created explicitly; all are passed in to callbacks.
+
+inline Napi::External<_duckdb_bind_info> CreateExternalForTableFunctionBindInfo(Napi::Env env, duckdb_bind_info bind_info) {
+  return CreateExternalWithoutFinalizer<_duckdb_bind_info>(env, TableFunctionBindInfoTypeTag, bind_info);
+}
+
+inline duckdb_bind_info GetTableFunctionBindInfoFromExternal(Napi::Env env, Napi::Value value) {
+  return GetDataFromExternal<_duckdb_bind_info>(env, TableFunctionBindInfoTypeTag, value, "Invalid table function bind info argument");
+}
+
+inline Napi::External<_duckdb_init_info> CreateExternalForTableFunctionInitInfo(Napi::Env env, duckdb_init_info init_info) {
+  return CreateExternalWithoutFinalizer<_duckdb_init_info>(env, TableFunctionInitInfoTypeTag, init_info);
+}
+
+inline duckdb_init_info GetTableFunctionInitInfoFromExternal(Napi::Env env, Napi::Value value) {
+  return GetDataFromExternal<_duckdb_init_info>(env, TableFunctionInitInfoTypeTag, value, "Invalid table function init info argument");
+}
+
+inline Napi::External<_duckdb_function_info> CreateExternalForTableFunctionInfo(Napi::Env env, duckdb_function_info function_info) {
+  return CreateExternalWithoutFinalizer<_duckdb_function_info>(env, TableFunctionInfoTypeTag, function_info);
+}
+
+inline duckdb_function_info GetTableFunctionInfoFromExternal(Napi::Env env, Napi::Value value) {
+  return GetDataFromExternal<_duckdb_function_info>(env, TableFunctionInfoTypeTag, value, "Invalid table function info argument");
+}
+
+// Extra info
+
+struct TableFunctionInternalExtraInfo {
+  std::shared_ptr<ManagedObjectReference> user_extra_info_ref;
+
+  void SetUserExtraInfo(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object user_extra_info) {
+    user_extra_info_ref = user_extra_info.IsUndefined() ? nullptr : MakeManagedObjectReference(reaper, user_extra_info);
+  }
+};
+
+inline void DeleteTableFunctionInternalExtraInfo(TableFunctionInternalExtraInfo *internal_extra_info) {
+  delete internal_extra_info;
+}
+
+// External
+
+struct TableFunctionHolder {
+  duckdb_table_function table_function;
+  TableFunctionInternalExtraInfo *internal_extra_info;
+
+  TableFunctionHolder(duckdb_table_function table_function_in): table_function(table_function_in), internal_extra_info(nullptr) {}
+
+  ~TableFunctionHolder() {
+    // duckdb_destroy_table_function is a no-op if already destroyed
+    duckdb_destroy_table_function(&table_function);
+  }
+
+  TableFunctionInternalExtraInfo *EnsureInternalExtraInfo() {
+    if (!internal_extra_info) {
+      internal_extra_info = new TableFunctionInternalExtraInfo();
+      duckdb_table_function_set_extra_info(table_function, internal_extra_info, reinterpret_cast<duckdb_delete_callback_t>(DeleteTableFunctionInternalExtraInfo));
+    }
+    return internal_extra_info;
+  }
+};
+
+inline TableFunctionHolder *CreateTableFunctionHolder(duckdb_table_function table_function) {
+  return new TableFunctionHolder(table_function);
+}
+
+inline void FinalizeTableFunctionHolder(Napi::BasicEnv, TableFunctionHolder *holder) {
+  delete holder;
+}
+
+inline Napi::External<TableFunctionHolder> CreateExternalForTableFunction(Napi::Env env, duckdb_table_function table_function) {
+  return CreateExternal<TableFunctionHolder>(env, TableFunctionTypeTag, CreateTableFunctionHolder(table_function), FinalizeTableFunctionHolder);
+}
+
+inline TableFunctionHolder *GetTableFunctionHolderFromExternal(Napi::Env env, Napi::Value value) {
+  return GetDataFromExternal<TableFunctionHolder>(env, TableFunctionTypeTag, value, "Invalid table function argument");
+}
+
+inline duckdb_table_function GetTableFunctionFromExternal(Napi::Env env, Napi::Value value) {
+  return GetTableFunctionHolderFromExternal(env, value)->table_function;
+}

--- a/bindings/src/table_function_helpers.h
+++ b/bindings/src/table_function_helpers.h
@@ -46,10 +46,127 @@ inline duckdb_function_info GetTableFunctionInfoFromExternal(Napi::Env env, Napi
   return GetDataFromExternal<_duckdb_function_info>(env, TableFunctionInfoTypeTag, value, "Invalid table function info argument");
 }
 
+// Callbacks
+//
+// Init and local init take the same arguments and report errors the same way.
+// They still need distinct traits, so that the two callbacks are distinct types
+// and each keeps its own thread-safe function.
+
+struct TableFunctionBindCallbackTraits {
+  using Payload = duckdb_bind_info;
+
+  static const char *ResourceName() {
+    return "TableFunctionBind";
+  }
+
+  static void Call(Napi::Env env, Napi::Function callback, const Payload &payload) {
+    callback.Call(
+      env.Undefined(),
+      {
+        CreateExternalForTableFunctionBindInfo(env, payload)
+      }
+    );
+  }
+
+  static void SetError(const Payload &payload, const char *message) {
+    duckdb_bind_set_error(payload, message);
+  }
+};
+
+struct TableFunctionInitCallbackTraits {
+  using Payload = duckdb_init_info;
+
+  static const char *ResourceName() {
+    return "TableFunctionInit";
+  }
+
+  static void Call(Napi::Env env, Napi::Function callback, const Payload &payload) {
+    callback.Call(
+      env.Undefined(),
+      {
+        CreateExternalForTableFunctionInitInfo(env, payload)
+      }
+    );
+  }
+
+  static void SetError(const Payload &payload, const char *message) {
+    duckdb_init_set_error(payload, message);
+  }
+};
+
+struct TableFunctionLocalInitCallbackTraits {
+  using Payload = duckdb_init_info;
+
+  static const char *ResourceName() {
+    return "TableFunctionLocalInit";
+  }
+
+  static void Call(Napi::Env env, Napi::Function callback, const Payload &payload) {
+    callback.Call(
+      env.Undefined(),
+      {
+        CreateExternalForTableFunctionInitInfo(env, payload)
+      }
+    );
+  }
+
+  static void SetError(const Payload &payload, const char *message) {
+    duckdb_init_set_error(payload, message);
+  }
+};
+
+struct TableFunctionMainCallbackTraits {
+  struct Payload {
+    duckdb_function_info info;
+    duckdb_data_chunk output;
+  };
+
+  static const char *ResourceName() {
+    return "TableFunctionMain";
+  }
+
+  static void Call(Napi::Env env, Napi::Function callback, const Payload &payload) {
+    callback.Call(
+      env.Undefined(),
+      {
+        CreateExternalForTableFunctionInfo(env, payload.info),
+        CreateExternalForDataChunkWithoutFinalizer(env, payload.output)
+      }
+    );
+  }
+
+  static void SetError(const Payload &payload, const char *message) {
+    duckdb_function_set_error(payload.info, message);
+  }
+};
+
 // Extra info
 
 struct TableFunctionInternalExtraInfo {
+  DuckDBThreadCallback<TableFunctionBindCallbackTraits> bind_callback;
+  DuckDBThreadCallback<TableFunctionInitCallbackTraits> init_callback;
+  DuckDBThreadCallback<TableFunctionLocalInitCallbackTraits> local_init_callback;
+  DuckDBThreadCallback<TableFunctionMainCallbackTraits> main_callback;
   std::shared_ptr<ManagedObjectReference> user_extra_info_ref;
+
+  explicit TableFunctionInternalExtraInfo(const std::shared_ptr<NapiRefReaper> &env_state)
+    : bind_callback(env_state), init_callback(env_state), local_init_callback(env_state), main_callback(env_state) {}
+
+  void SetBindFunction(Napi::Env env, Napi::Function func) {
+    bind_callback.Set(env, func);
+  }
+
+  void SetInitFunction(Napi::Env env, Napi::Function func) {
+    init_callback.Set(env, func);
+  }
+
+  void SetLocalInitFunction(Napi::Env env, Napi::Function func) {
+    local_init_callback.Set(env, func);
+  }
+
+  void SetMainFunction(Napi::Env env, Napi::Function func) {
+    main_callback.Set(env, func);
+  }
 
   void SetUserExtraInfo(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object user_extra_info) {
     user_extra_info_ref = user_extra_info.IsUndefined() ? nullptr : MakeManagedObjectReference(reaper, user_extra_info);
@@ -73,9 +190,9 @@ struct TableFunctionHolder {
     duckdb_destroy_table_function(&table_function);
   }
 
-  TableFunctionInternalExtraInfo *EnsureInternalExtraInfo() {
+  TableFunctionInternalExtraInfo *EnsureInternalExtraInfo(const std::shared_ptr<NapiRefReaper> &env_state) {
     if (!internal_extra_info) {
-      internal_extra_info = new TableFunctionInternalExtraInfo();
+      internal_extra_info = new TableFunctionInternalExtraInfo(env_state);
       duckdb_table_function_set_extra_info(table_function, internal_extra_info, reinterpret_cast<duckdb_delete_callback_t>(DeleteTableFunctionInternalExtraInfo));
     }
     return internal_extra_info;
@@ -100,4 +217,68 @@ inline TableFunctionHolder *GetTableFunctionHolderFromExternal(Napi::Env env, Na
 
 inline duckdb_table_function GetTableFunctionFromExternal(Napi::Env env, Napi::Value value) {
   return GetTableFunctionHolderFromExternal(env, value)->table_function;
+}
+
+// Bind data and init data
+//
+// Both hold a user object through the reaper, so that the reference is destroyed
+// on the JS thread whatever thread DuckDB tears the query down on. Unlike scalar
+// functions there is no copy callback to implement: table function bind data is
+// never copied by the C API.
+//
+// Init data is used for both the global init and the per-thread local init, which
+// DuckDB keeps separate but stores the same way.
+
+struct TableFunctionInternalBindData {
+  std::shared_ptr<ManagedObjectReference> user_bind_data_ref;
+
+  void SetUserBindData(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object user_bind_data) {
+    user_bind_data_ref = user_bind_data.IsUndefined() ? nullptr : MakeManagedObjectReference(reaper, user_bind_data);
+  }
+};
+
+inline void DeleteTableFunctionInternalBindData(TableFunctionInternalBindData *internal_bind_data) {
+  delete internal_bind_data;
+}
+
+struct TableFunctionInternalInitData {
+  std::shared_ptr<ManagedObjectReference> user_init_data_ref;
+
+  void SetUserInitData(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object user_init_data) {
+    user_init_data_ref = user_init_data.IsUndefined() ? nullptr : MakeManagedObjectReference(reaper, user_init_data);
+  }
+};
+
+inline void DeleteTableFunctionInternalInitData(TableFunctionInternalInitData *internal_init_data) {
+  delete internal_init_data;
+}
+
+// Entry points handed to DuckDB
+
+inline TableFunctionInternalExtraInfo *GetTableFunctionInternalExtraInfoFromBindInfo(duckdb_bind_info bind_info) {
+  return reinterpret_cast<TableFunctionInternalExtraInfo*>(duckdb_bind_get_extra_info(bind_info));
+}
+
+inline TableFunctionInternalExtraInfo *GetTableFunctionInternalExtraInfoFromInitInfo(duckdb_init_info init_info) {
+  return reinterpret_cast<TableFunctionInternalExtraInfo*>(duckdb_init_get_extra_info(init_info));
+}
+
+inline TableFunctionInternalExtraInfo *GetTableFunctionInternalExtraInfoFromFunctionInfo(duckdb_function_info function_info) {
+  return reinterpret_cast<TableFunctionInternalExtraInfo*>(duckdb_function_get_extra_info(function_info));
+}
+
+inline void TableFunctionBindFunction(duckdb_bind_info info) {
+  GetTableFunctionInternalExtraInfoFromBindInfo(info)->bind_callback.Invoke(info);
+}
+
+inline void TableFunctionInitFunction(duckdb_init_info info) {
+  GetTableFunctionInternalExtraInfoFromInitInfo(info)->init_callback.Invoke(info);
+}
+
+inline void TableFunctionLocalInitFunction(duckdb_init_info info) {
+  GetTableFunctionInternalExtraInfoFromInitInfo(info)->local_init_callback.Invoke(info);
+}
+
+inline void TableFunctionMainFunction(duckdb_function_info info, duckdb_data_chunk output) {
+  GetTableFunctionInternalExtraInfoFromFunctionInfo(info)->main_callback.Invoke({info, output});
 }

--- a/bindings/src/type_tags.h
+++ b/bindings/src/type_tags.h
@@ -3,7 +3,13 @@
 #include "napi_setup.h"
 
 // Type tags for the externals that cross the boundary, in one place so that the
-// full set is visible and no value is used twice. The externals themselves live
+// full set is visible and no value is used twice.
+//
+// Note that bind info, init info and function info get a tag per function family.
+// The C API reuses one opaque handle type for each of them across scalar, table
+// and later function families, but the structs behind those handles are unrelated
+// and are reinterpret_cast without any check, so mixing them corrupts memory
+// rather than failing. Separate tags turn that into a thrown error. The externals themselves live
 // with what they wrap: generic ones in externals.h, and family-specific ones --
 // whose object owns family state -- in that family's header.
 //
@@ -15,10 +21,6 @@
 
 inline constexpr napi_type_tag AppenderTypeTag = {
   0x32E0AB3B83F74A89, 0xB785905D92D54996
-};
-
-inline constexpr napi_type_tag BindInfoTypeTag = {
-  0x9922F8468F9A43C0, 0xB2573B112B9600D8
 };
 
 inline constexpr napi_type_tag ClientContextTypeTag = {
@@ -45,10 +47,6 @@ inline constexpr napi_type_tag ExtractedStatementsTypeTag = {
   0x59288E1C60C44EEB, 0xBFA35376EE0F04DD
 };
 
-inline constexpr napi_type_tag FunctionInfoTypeTag = {
-  0xB0E6739D698048EA, 0x9E79734E3E137AC3
-};
-
 inline constexpr napi_type_tag InstanceCacheTypeTag = {
   0x2F3346E30FB5457C, 0xB9201EE5112EEF9F
 };
@@ -69,8 +67,32 @@ inline constexpr napi_type_tag ResultTypeTag = {
   0x08F7FE3AE12345E5, 0x8733310DC29372D9
 };
 
+inline constexpr napi_type_tag ScalarFunctionBindInfoTypeTag = {
+  0x9922F8468F9A43C0, 0xB2573B112B9600D8
+};
+
+inline constexpr napi_type_tag ScalarFunctionInfoTypeTag = {
+  0xB0E6739D698048EA, 0x9E79734E3E137AC3
+};
+
 inline constexpr napi_type_tag ScalarFunctionTypeTag = {
   0x95D48B7051D14994, 0x9F883D7DF5DEA86D
+};
+
+inline constexpr napi_type_tag TableFunctionBindInfoTypeTag = {
+  0xFF9280FBDC3341E3, 0xAE7F563D67540007
+};
+
+inline constexpr napi_type_tag TableFunctionInfoTypeTag = {
+  0xA8CFE12055EE470C, 0xB37877D9FDD36A98
+};
+
+inline constexpr napi_type_tag TableFunctionInitInfoTypeTag = {
+  0x45B24025B7B443D9, 0xA2978778FE81AD51
+};
+
+inline constexpr napi_type_tag TableFunctionTypeTag = {
+  0xBECF7A8CEBA84520, 0xBFC47C84A51544EF
 };
 
 inline constexpr napi_type_tag ValueTypeTag = {

--- a/bindings/test/stress/table_function_refs.test.ts
+++ b/bindings/test/stress/table_function_refs.test.ts
@@ -1,0 +1,268 @@
+import duckdb from '@duckdb/node-bindings';
+import v8 from 'node:v8';
+import vm from 'node:vm';
+import { expect, suite, test } from 'vitest';
+import { withConnection } from '../utils/withConnection';
+import { withDatabase } from '../utils/withDatabase';
+
+// The table function counterpart of scalar_function_refs.test.ts. Table
+// functions hold three user objects rather than two -- extra info, bind data and
+// init data, the last of which also covers per-thread local init data -- and drop
+// them across more threads, so the reference lifetime is worth exercising here
+// too.
+//
+// Excluded from `pnpm test`; run with `pnpm test:stress`. Env teardown is covered
+// by test/worker_threads.test.ts in the main suite.
+
+v8.setFlagsFromString('--expose-gc');
+const forceGC = vm.runInNewContext('gc') as () => void;
+v8.setFlagsFromString('--no-expose-gc');
+
+// Registers a table function that checks, on every callback, that the objects it
+// was given earlier are still intact. A mismatch throws, which the bindings
+// surface as a query error, failing the awaiting test.
+//
+// Nothing on the JS side retains these objects: only the references taken by the
+// bindings keep them alive.
+function registerCheckedFunction(
+  connection: duckdb.Connection,
+  name: string,
+  { rowCount = 100, gcInMainFunction = false } = {},
+): { callCount: () => number } {
+  let calls = 0;
+  const table_function = duckdb.create_table_function();
+  duckdb.table_function_set_name(table_function, name);
+  duckdb.table_function_set_extra_info(table_function, {
+    'extra_info_token': `extra_info_${name}`,
+  });
+  duckdb.table_function_set_bind(table_function, (info) => {
+    const extra_info = duckdb.bind_get_extra_info(info) as {
+      extra_info_token: string;
+    };
+    if (extra_info?.extra_info_token !== `extra_info_${name}`) {
+      throw new Error(`extra info corrupted during bind of ${name}`);
+    }
+    const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+    duckdb.bind_add_result_column(info, 'my_column', varchar_type);
+    duckdb.bind_set_bind_data(info, {
+      'bind_data_token': `bind_data_${name}`,
+      rowCount,
+    });
+  });
+  duckdb.table_function_set_init(table_function, (info) => {
+    const bind_data = duckdb.init_get_bind_data(info) as {
+      bind_data_token: string;
+    };
+    if (bind_data?.bind_data_token !== `bind_data_${name}`) {
+      throw new Error(`bind data corrupted during init of ${name}`);
+    }
+    duckdb.init_set_init_data(info, {
+      'init_data_token': `init_data_${name}`,
+      'next_row': 0,
+    });
+  });
+  duckdb.table_function_set_local_init(table_function, (info) => {
+    duckdb.init_set_init_data(info, {
+      'local_token': `local_init_${name}`,
+    });
+  });
+  duckdb.table_function_set_function(table_function, (info, output) => {
+    if (gcInMainFunction) {
+      forceGC();
+    }
+    calls++;
+    const extra_info = duckdb.function_get_extra_info(info) as {
+      extra_info_token: string;
+    };
+    const bind_data = duckdb.function_get_bind_data(info) as {
+      bind_data_token: string;
+      rowCount: number;
+    };
+    const init_data = duckdb.function_get_init_data(info) as {
+      init_data_token: string;
+      next_row: number;
+    };
+    const local_data = duckdb.function_get_local_init_data(info) as {
+      local_token: string;
+    };
+    if (extra_info?.extra_info_token !== `extra_info_${name}`) {
+      throw new Error(`extra info corrupted in ${name}`);
+    }
+    if (bind_data?.bind_data_token !== `bind_data_${name}`) {
+      throw new Error(`bind data corrupted in ${name}`);
+    }
+    if (init_data?.init_data_token !== `init_data_${name}`) {
+      throw new Error(`init data corrupted in ${name}`);
+    }
+    if (local_data?.local_token !== `local_init_${name}`) {
+      throw new Error(`local init data corrupted in ${name}`);
+    }
+    const chunkSize = Math.min(
+      duckdb.vector_size(),
+      bind_data.rowCount - init_data.next_row,
+    );
+    const vector = duckdb.data_chunk_get_vector(output, 0);
+    for (let i = 0; i < chunkSize; i++) {
+      duckdb.vector_assign_string_element(vector, i, 'ok');
+    }
+    duckdb.data_chunk_set_size(output, chunkSize);
+    init_data.next_row += chunkSize;
+  });
+  duckdb.register_table_function(connection, table_function);
+  duckdb.destroy_table_function_sync(table_function);
+  return { callCount: () => calls };
+}
+
+suite('table function reference lifetime', () => {
+  test('extra info, bind data and init data survive garbage collection', async () => {
+    await withConnection(async (connection) => {
+      const fn = registerCheckedFunction(connection, 'my_func', {
+        gcInMainFunction: true,
+      });
+      for (let i = 0; i < 20; i++) {
+        await duckdb.query(connection, 'select * from my_func()');
+      }
+      expect(fn.callCount()).toBeGreaterThanOrEqual(20);
+    });
+  });
+
+  test('many registered functions under GC pressure', async () => {
+    await withConnection(async (connection) => {
+      for (let i = 0; i < 100; i++) {
+        const name = `my_func_${i}`;
+        const fn = registerCheckedFunction(connection, name, { rowCount: 10 });
+        await duckdb.query(connection, `select * from ${name}()`);
+        expect(fn.callCount()).toBeGreaterThan(0);
+        if (i % 10 === 0) {
+          forceGC();
+        }
+      }
+      forceGC();
+    });
+  });
+
+  test('concurrent queries while the JS thread is busy', async () => {
+    const rounds = 10;
+    await withDatabase({}, async (db) => {
+      const registrar = await duckdb.connect(db);
+      const connections: duckdb.Connection[] = [];
+      try {
+        const fn = registerCheckedFunction(registrar, 'my_func', {
+          rowCount: duckdb.vector_size() * 2,
+        });
+        for (let i = 0; i < 8; i++) {
+          connections.push(await duckdb.connect(db));
+        }
+
+        let churning = true;
+        const churning_promise = (async () => {
+          while (churning) {
+            const garbage: object[] = [];
+            for (let i = 0; i < 10000; i++) {
+              garbage.push({ i });
+            }
+            await new Promise((resolve) => setImmediate(resolve));
+          }
+        })();
+
+        try {
+          // allSettled, and the finally below, keep a failure loud: rejecting
+          // early would leave queries in flight and the teardown would then
+          // disconnect underneath them and hang.
+          for (let round = 0; round < rounds; round++) {
+            const results = await Promise.allSettled(
+              connections.map((connection) =>
+                duckdb.query(connection, 'select * from my_func()'),
+              ),
+            );
+            const rejected = results.filter((r) => r.status === 'rejected');
+            if (rejected.length > 0) {
+              throw new Error(
+                `${rejected.length} of ${results.length} queries failed in round ${round}: ${rejected[0].reason}`,
+              );
+            }
+          }
+        } finally {
+          churning = false;
+          await churning_promise;
+        }
+
+        expect(fn.callCount()).toBeGreaterThanOrEqual(
+          connections.length * rounds,
+        );
+      } finally {
+        for (const connection of connections) {
+          duckdb.disconnect_sync(connection);
+        }
+        duckdb.disconnect_sync(registrar);
+      }
+      forceGC();
+    });
+  });
+
+  test('parallel scan with max threads set', async () => {
+    await withConnection(async (connection) => {
+      // With more than one thread, DuckDB runs local init per thread and calls
+      // the main function from several threads at once. Every call still has to
+      // find its own local init data intact, which the checks above assert.
+      let localInits = 0;
+      const table_function = duckdb.create_table_function();
+      duckdb.table_function_set_name(table_function, 'my_func');
+      const total = duckdb.vector_size() * 8;
+      duckdb.table_function_set_bind(table_function, (info) => {
+        const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+        duckdb.bind_add_result_column(info, 'my_column', varchar_type);
+        duckdb.bind_set_bind_data(info, { 'remaining': total });
+      });
+      duckdb.table_function_set_init(table_function, (info) => {
+        duckdb.init_set_max_threads(info, 4);
+        duckdb.init_set_init_data(info, { 'shared_remaining': total });
+      });
+      duckdb.table_function_set_local_init(table_function, (info) => {
+        localInits++;
+        duckdb.init_set_init_data(info, { 'local_token': 'local' });
+      });
+      duckdb.table_function_set_function(table_function, (info, output) => {
+        const init_data = duckdb.function_get_init_data(info) as {
+          shared_remaining: number;
+        };
+        const local_data = duckdb.function_get_local_init_data(info) as {
+          local_token: string;
+        };
+        if (local_data?.local_token !== 'local') {
+          throw new Error('local init data corrupted');
+        }
+        // Callbacks are serialized through the JS thread, so this shared counter
+        // needs no locking even though DuckDB may call from several threads.
+        const chunkSize = Math.min(
+          duckdb.vector_size(),
+          init_data.shared_remaining,
+        );
+        const vector = duckdb.data_chunk_get_vector(output, 0);
+        for (let i = 0; i < chunkSize; i++) {
+          duckdb.vector_assign_string_element(vector, i, 'ok');
+        }
+        duckdb.data_chunk_set_size(output, chunkSize);
+        init_data.shared_remaining -= chunkSize;
+      });
+      duckdb.register_table_function(connection, table_function);
+      duckdb.destroy_table_function_sync(table_function);
+
+      const result = await duckdb.query(
+        connection,
+        'select count(*) as n from my_func()',
+      );
+      const chunk = await duckdb.fetch_chunk(result);
+      const vector = duckdb.data_chunk_get_vector(chunk!, 0);
+      const countData = duckdb.vector_get_data(vector, 8);
+      expect(new DataView(countData.buffer).getBigInt64(0, true)).toBe(
+        BigInt(total),
+      );
+      // One local init per scanning thread: measured at 4 here, matching the
+      // max threads set above, with the main function called 12 times across
+      // them. How many the scheduler actually uses depends on the machine, so
+      // only the row count is asserted exactly.
+      expect(localInits).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/bindings/test/table_functions.test.ts
+++ b/bindings/test/table_functions.test.ts
@@ -1,0 +1,58 @@
+import duckdb from '@duckdb/node-bindings';
+import { expect, suite, test } from 'vitest';
+import { withConnection } from './utils/withConnection';
+
+suite('table functions', () => {
+  test('create', () => {
+    const table_function = duckdb.create_table_function();
+    expect(table_function).toBeTruthy();
+  });
+  test('set name', () => {
+    const table_function = duckdb.create_table_function();
+    duckdb.table_function_set_name(table_function, 'my_func');
+  });
+  test('add parameters', () => {
+    const table_function = duckdb.create_table_function();
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    duckdb.table_function_add_parameter(table_function, int_type);
+    const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+    duckdb.table_function_add_named_parameter(
+      table_function,
+      'my_named_param',
+      varchar_type,
+    );
+  });
+  test('supports projection pushdown', () => {
+    const table_function = duckdb.create_table_function();
+    duckdb.table_function_supports_projection_pushdown(table_function, true);
+    duckdb.table_function_supports_projection_pushdown(table_function, false);
+  });
+  test('set extra info', () => {
+    const table_function = duckdb.create_table_function();
+    duckdb.table_function_set_extra_info(table_function, {
+      'my_extra_info_key': 'my_extra_info_value',
+    });
+  });
+  test('destroy', () => {
+    const table_function = duckdb.create_table_function();
+    duckdb.destroy_table_function_sync(table_function);
+    // Destroying twice is a no-op, not a crash.
+    duckdb.destroy_table_function_sync(table_function);
+  });
+  test('register fails without bind, init and main functions', async () => {
+    await withConnection(async (connection) => {
+      const table_function = duckdb.create_table_function();
+      duckdb.table_function_set_name(table_function, 'my_func');
+      // DuckDB requires at least a name, a bind, an init and a main function.
+      expect(() =>
+        duckdb.register_table_function(connection, table_function),
+      ).toThrowError('Failed to register table function');
+    });
+  });
+  test('a scalar function external is not a table function', () => {
+    const scalar_function = duckdb.create_scalar_function();
+    expect(() =>
+      duckdb.table_function_set_name(scalar_function as never, 'my_func'),
+    ).toThrowError('Invalid table function argument');
+  });
+});

--- a/bindings/test/table_functions.test.ts
+++ b/bindings/test/table_functions.test.ts
@@ -3,6 +3,7 @@ import { expect, suite, test } from 'vitest';
 import { data } from './utils/expectedVectors';
 import { expectResult } from './utils/expectResult';
 import { withConnection } from './utils/withConnection';
+import { withDatabase } from './utils/withDatabase';
 
 suite('table functions', () => {
   test('create', () => {
@@ -521,6 +522,122 @@ suite('table functions', () => {
       expect(new DataView(countData.buffer).getBigInt64(0, true)).toBe(
         BigInt(duckdb.vector_size() * 2),
       );
+    });
+  });
+
+  test('error handling (exception in local init func)', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, {
+        localInitFunction: () => {
+          throw new Error('my_local_init_error');
+        },
+      });
+      await expect(
+        duckdb.query(connection, 'select * from my_func()'),
+      ).rejects.toThrow('my_local_init_error');
+    });
+  });
+
+  test('error handling (set error in local init func)', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, {
+        localInitFunction: (info) => {
+          duckdb.init_set_error(info, 'my_local_init_error');
+        },
+      });
+      await expect(
+        duckdb.query(connection, 'select * from my_func()'),
+      ).rejects.toThrow('my_local_init_error');
+    });
+  });
+
+  test('a scan producing no rows', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, { rowCount: 0 });
+      const result = await duckdb.query(connection, 'select * from my_func()');
+      await expectResult(result, {
+        chunkCount: 0,
+        rowCount: 0,
+        columns: [
+          { name: 'my_column', logicalType: { typeId: duckdb.Type.VARCHAR } },
+        ],
+        chunks: [],
+      });
+    });
+  });
+
+  test('registering the same name twice keeps the first registration', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, { rowCount: 1 });
+      // The C API docs say registering an existing name returns an error. It does
+      // not: the second registration reports success and is then ignored, so the
+      // first function is what runs. Re-registering to replace a function
+      // silently does nothing.
+      registerFunction(connection, { rowCount: 2 });
+      const result = await duckdb.query(connection, 'select * from my_func()');
+      await expectResult(result, {
+        chunkCount: 1,
+        rowCount: 1,
+        columns: [
+          { name: 'my_column', logicalType: { typeId: duckdb.Type.VARCHAR } },
+        ],
+        chunks: [{ rowCount: 1, vectors: [data(16, [true], ['row_0'])] }],
+      });
+    });
+  });
+
+  test('the function outlives the connection that registered it', async () => {
+    // Registration goes into the database catalog, so the extra info holding the
+    // callbacks has to stay alive for other connections after the registering
+    // one is gone.
+    await withDatabase({}, async (db) => {
+      const registrar = await duckdb.connect(db);
+      registerFunction(registrar, { rowCount: 2 });
+      duckdb.disconnect_sync(registrar);
+
+      const connection = await duckdb.connect(db);
+      try {
+        const result = await duckdb.query(
+          connection,
+          'select * from my_func()',
+        );
+        await expectResult(result, {
+          chunkCount: 1,
+          rowCount: 2,
+          columns: [
+            { name: 'my_column', logicalType: { typeId: duckdb.Type.VARCHAR } },
+          ],
+          chunks: [
+            { rowCount: 2, vectors: [data(16, [true, true], ['row_0', 'row_1'])] },
+          ],
+        });
+      } finally {
+        duckdb.disconnect_sync(connection);
+      }
+    });
+  });
+
+  test('a scan can be interrupted', async () => {
+    await withConnection(async (connection) => {
+      let calls = 0;
+      registerFunction(connection, {
+        mainFunction: (_info, output) => {
+          calls++;
+          // Never signals completion, so the scan runs until interrupted.
+          const vector = duckdb.data_chunk_get_vector(output, 0);
+          for (let i = 0; i < duckdb.vector_size(); i++) {
+            duckdb.vector_assign_string_element(vector, i, 'row');
+          }
+          duckdb.data_chunk_set_size(output, duckdb.vector_size());
+          if (calls === 3) {
+            duckdb.interrupt(connection);
+          }
+        },
+      });
+      await expect(
+        duckdb.query(connection, 'select * from my_func()'),
+      ).rejects.toThrow(/INTERRUPT|interrupted/i);
+      expect(calls).toBeGreaterThanOrEqual(3);
     });
   });
 });

--- a/bindings/test/table_functions.test.ts
+++ b/bindings/test/table_functions.test.ts
@@ -332,4 +332,195 @@ suite('table functions', () => {
       expect(caught).toBe('Invalid scalar function info argument');
     });
   });
+
+  test('positional and named parameters', async () => {
+    await withConnection(async (connection) => {
+      const table_function = duckdb.create_table_function();
+      duckdb.table_function_set_name(table_function, 'my_func');
+      const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.table_function_add_parameter(table_function, int_type);
+      duckdb.table_function_add_named_parameter(
+        table_function,
+        'prefix',
+        varchar_type,
+      );
+      duckdb.table_function_set_bind(table_function, (info) => {
+        const parameter_count = duckdb.bind_get_parameter_count(info);
+        const count_value = duckdb.bind_get_parameter(info, 0);
+        const count = duckdb.get_int32(count_value);
+        const prefix_value = duckdb.bind_get_named_parameter(info, 'prefix');
+        const prefix = prefix_value ? duckdb.get_varchar(prefix_value) : 'none';
+        const missing = duckdb.bind_get_named_parameter(info, 'not_supplied');
+        duckdb.bind_add_result_column(info, 'my_column', varchar_type);
+        // Cardinality is only a hint to the optimizer, so nothing observable
+        // depends on it; this just exercises the call.
+        duckdb.bind_set_cardinality(info, count, true);
+        duckdb.bind_set_bind_data(info, {
+          count,
+          prefix,
+          parameter_count,
+          'missing_is_null': missing === null,
+        });
+      });
+      duckdb.table_function_set_init(table_function, (info) => {
+        duckdb.init_set_init_data(info, { 'done': false });
+      });
+      duckdb.table_function_set_function(table_function, (info, output) => {
+        const bind_data = duckdb.function_get_bind_data(info) as {
+          count: number;
+          prefix: string;
+          parameter_count: number;
+          missing_is_null: boolean;
+        };
+        const init_data = duckdb.function_get_init_data(info) as {
+          done: boolean;
+        };
+        if (init_data.done) {
+          duckdb.data_chunk_set_size(output, 0);
+          return;
+        }
+        const vector = duckdb.data_chunk_get_vector(output, 0);
+        for (let i = 0; i < bind_data.count; i++) {
+          duckdb.vector_assign_string_element(
+            vector,
+            i,
+            `${bind_data.prefix}_${i}_p${bind_data.parameter_count}_m${bind_data.missing_is_null}`,
+          );
+        }
+        duckdb.data_chunk_set_size(output, bind_data.count);
+        init_data.done = true;
+      });
+      duckdb.register_table_function(connection, table_function);
+      duckdb.destroy_table_function_sync(table_function);
+
+      const result = await duckdb.query(
+        connection,
+        "select * from my_func(2, prefix => 'row')",
+      );
+      await expectResult(result, {
+        chunkCount: 1,
+        rowCount: 2,
+        columns: [
+          { name: 'my_column', logicalType: { typeId: duckdb.Type.VARCHAR } },
+        ],
+        chunks: [
+          {
+            rowCount: 2,
+            vectors: [
+              data(
+                16,
+                [true, true],
+                ['row_0_p1_mtrue', 'row_1_p1_mtrue'],
+              ),
+            ],
+          },
+        ],
+      });
+    });
+  });
+
+  test('extra info is available to bind, init and the main function', async () => {
+    await withConnection(async (connection) => {
+      const seen: string[] = [];
+      const table_function = duckdb.create_table_function();
+      duckdb.table_function_set_name(table_function, 'my_func');
+      duckdb.table_function_set_extra_info(table_function, {
+        'token': 'extra_info',
+      });
+      duckdb.table_function_set_bind(table_function, (info) => {
+        seen.push(
+          `bind:${(duckdb.bind_get_extra_info(info) as { token: string }).token}`,
+        );
+        const client_context = duckdb.table_function_get_client_context(info);
+        seen.push(
+          `context:${duckdb.client_context_get_connection_id(client_context) > 0}`,
+        );
+        const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+        duckdb.bind_add_result_column(info, 'my_column', varchar_type);
+        duckdb.bind_set_bind_data(info, { 'token': 'bind_data' });
+      });
+      duckdb.table_function_set_init(table_function, (info) => {
+        seen.push(
+          `init:${(duckdb.init_get_extra_info(info) as { token: string }).token}`,
+        );
+        seen.push(
+          `init_bind_data:${(duckdb.init_get_bind_data(info) as { token: string }).token}`,
+        );
+        duckdb.init_set_init_data(info, { 'done': false });
+      });
+      duckdb.table_function_set_function(table_function, (info, output) => {
+        seen.push(
+          `main:${(duckdb.function_get_extra_info(info) as { token: string }).token}`,
+        );
+        duckdb.data_chunk_set_size(output, 0);
+      });
+      duckdb.register_table_function(connection, table_function);
+      duckdb.destroy_table_function_sync(table_function);
+
+      await duckdb.query(connection, 'select * from my_func()');
+      expect(seen).toStrictEqual([
+        'bind:extra_info',
+        'context:true',
+        'init:extra_info',
+        'init_bind_data:bind_data',
+        'main:extra_info',
+      ]);
+    });
+  });
+
+  test('projection pushdown reports the projected columns', async () => {
+    await withConnection(async (connection) => {
+      let projected: number[] | undefined;
+      const table_function = duckdb.create_table_function();
+      duckdb.table_function_set_name(table_function, 'my_func');
+      duckdb.table_function_supports_projection_pushdown(table_function, true);
+      duckdb.table_function_set_bind(table_function, (info) => {
+        const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+        duckdb.bind_add_result_column(info, 'a', varchar_type);
+        duckdb.bind_add_result_column(info, 'b', varchar_type);
+        duckdb.bind_add_result_column(info, 'c', varchar_type);
+        duckdb.bind_set_bind_data(info, {});
+      });
+      duckdb.table_function_set_init(table_function, (info) => {
+        const column_count = duckdb.init_get_column_count(info);
+        projected = [];
+        for (let i = 0; i < column_count; i++) {
+          projected.push(duckdb.init_get_column_index(info, i));
+        }
+        duckdb.init_set_init_data(info, { 'done': false });
+      });
+      duckdb.table_function_set_function(table_function, (_info, output) => {
+        duckdb.data_chunk_set_size(output, 0);
+      });
+      duckdb.register_table_function(connection, table_function);
+      duckdb.destroy_table_function_sync(table_function);
+
+      // Only column b is selected, so that is all init should be told about.
+      await duckdb.query(connection, 'select b from my_func()');
+      expect(projected).toStrictEqual([1]);
+    });
+  });
+
+  test('max threads can be set from init', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, {
+        rowCount: duckdb.vector_size() * 2,
+        initFunction: (info) => {
+          duckdb.init_set_max_threads(info, 4);
+          duckdb.init_set_init_data(info, { 'next_row': 0 });
+        },
+      });
+      const result = await duckdb.query(
+        connection,
+        'select count(*) as n from my_func()',
+      );
+      const chunk = await duckdb.fetch_chunk(result);
+      const vector = duckdb.data_chunk_get_vector(chunk!, 0);
+      const countData = duckdb.vector_get_data(vector, 8);
+      expect(new DataView(countData.buffer).getBigInt64(0, true)).toBe(
+        BigInt(duckdb.vector_size() * 2),
+      );
+    });
+  });
 });

--- a/bindings/test/table_functions.test.ts
+++ b/bindings/test/table_functions.test.ts
@@ -1,5 +1,7 @@
 import duckdb from '@duckdb/node-bindings';
 import { expect, suite, test } from 'vitest';
+import { data } from './utils/expectedVectors';
+import { expectResult } from './utils/expectResult';
 import { withConnection } from './utils/withConnection';
 
 suite('table functions', () => {
@@ -39,6 +41,59 @@ suite('table functions', () => {
     // Destroying twice is a no-op, not a crash.
     duckdb.destroy_table_function_sync(table_function);
   });
+  test('register and run', async () => {
+    await withConnection(async (connection) => {
+      const table_function = duckdb.create_table_function();
+      duckdb.table_function_set_name(table_function, 'my_func');
+      duckdb.table_function_set_bind(table_function, (info) => {
+        const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+        duckdb.bind_add_result_column(info, 'my_column', varchar_type);
+        duckdb.bind_set_bind_data(info, { 'row_count': 3 });
+      });
+      duckdb.table_function_set_init(table_function, (info) => {
+        duckdb.init_set_init_data(info, { 'next_row': 0 });
+      });
+      duckdb.table_function_set_function(table_function, (info, output) => {
+        const bind_data = duckdb.function_get_bind_data(info) as {
+          row_count: number;
+        };
+        const init_data = duckdb.function_get_init_data(info) as {
+          next_row: number;
+        };
+        const remaining = bind_data.row_count - init_data.next_row;
+        const vector = duckdb.data_chunk_get_vector(output, 0);
+        for (let i = 0; i < remaining; i++) {
+          duckdb.vector_assign_string_element(
+            vector,
+            i,
+            `row_${init_data.next_row + i}`,
+          );
+        }
+        // A zero-size chunk is how a scan reports that it is finished.
+        duckdb.data_chunk_set_size(output, remaining);
+        init_data.next_row += remaining;
+      });
+      duckdb.register_table_function(connection, table_function);
+      duckdb.destroy_table_function_sync(table_function);
+
+      const result = await duckdb.query(connection, 'select * from my_func()');
+      await expectResult(result, {
+        chunkCount: 1,
+        rowCount: 3,
+        columns: [
+          { name: 'my_column', logicalType: { typeId: duckdb.Type.VARCHAR } },
+        ],
+        chunks: [
+          {
+            rowCount: 3,
+            vectors: [
+              data(16, [true, true, true], ['row_0', 'row_1', 'row_2']),
+            ],
+          },
+        ],
+      });
+    });
+  });
   test('register fails without bind, init and main functions', async () => {
     await withConnection(async (connection) => {
       const table_function = duckdb.create_table_function();
@@ -54,5 +109,227 @@ suite('table functions', () => {
     expect(() =>
       duckdb.table_function_set_name(scalar_function as never, 'my_func'),
     ).toThrowError('Invalid table function argument');
+  });
+
+  // A minimal working function, so that each test below can break exactly one
+  // part of it and leave the rest valid.
+  function registerFunction(
+    connection: duckdb.Connection,
+    {
+      rowCount = 3,
+      bindFunction,
+      initFunction,
+      localInitFunction,
+      mainFunction,
+    }: {
+      rowCount?: number;
+      bindFunction?: duckdb.TableFunctionBindFunction;
+      initFunction?: duckdb.TableFunctionInitFunction;
+      localInitFunction?: duckdb.TableFunctionInitFunction;
+      mainFunction?: duckdb.TableFunctionMainFunction;
+    } = {},
+  ) {
+    const table_function = duckdb.create_table_function();
+    duckdb.table_function_set_name(table_function, 'my_func');
+    duckdb.table_function_set_bind(
+      table_function,
+      bindFunction ??
+        ((info) => {
+          const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+          duckdb.bind_add_result_column(info, 'my_column', varchar_type);
+          duckdb.bind_set_bind_data(info, { 'row_count': rowCount });
+        }),
+    );
+    duckdb.table_function_set_init(
+      table_function,
+      initFunction ??
+        ((info) => {
+          duckdb.init_set_init_data(info, { 'next_row': 0 });
+        }),
+    );
+    if (localInitFunction) {
+      duckdb.table_function_set_local_init(table_function, localInitFunction);
+    }
+    duckdb.table_function_set_function(
+      table_function,
+      mainFunction ??
+        ((info, output) => {
+          const bind_data = duckdb.function_get_bind_data(info) as {
+            row_count: number;
+          };
+          const init_data = duckdb.function_get_init_data(info) as {
+            next_row: number;
+          };
+          const chunkSize = Math.min(
+            duckdb.vector_size(),
+            bind_data.row_count - init_data.next_row,
+          );
+          const vector = duckdb.data_chunk_get_vector(output, 0);
+          for (let i = 0; i < chunkSize; i++) {
+            duckdb.vector_assign_string_element(
+              vector,
+              i,
+              `row_${init_data.next_row + i}`,
+            );
+          }
+          duckdb.data_chunk_set_size(output, chunkSize);
+          init_data.next_row += chunkSize;
+        }),
+    );
+    duckdb.register_table_function(connection, table_function);
+    duckdb.destroy_table_function_sync(table_function);
+  }
+
+  test('scan spanning multiple chunks', async () => {
+    await withConnection(async (connection) => {
+      // More than one vector's worth of rows, so the main function runs several
+      // times and has to be told where it left off by its init data.
+      const rowCount = duckdb.vector_size() * 2 + 5;
+      registerFunction(connection, { rowCount });
+      const result = await duckdb.query(
+        connection,
+        'select count(*) as n, min(my_column) as lo, max(my_column) as hi from my_func()',
+      );
+      const chunk = await duckdb.fetch_chunk(result);
+      expect(chunk).toBeTruthy();
+      expect(duckdb.data_chunk_get_size(chunk!)).toBe(1);
+      const countVector = duckdb.data_chunk_get_vector(chunk!, 0);
+      const countData = duckdb.vector_get_data(countVector, 8);
+      expect(new DataView(countData.buffer).getBigInt64(0, true)).toBe(
+        BigInt(rowCount),
+      );
+    });
+  });
+
+  test('local init data is available to the main function', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, {
+        localInitFunction: (info) => {
+          duckdb.init_set_init_data(info, { 'token': 'local_init' });
+        },
+        mainFunction: (info, output) => {
+          const local = duckdb.function_get_local_init_data(info) as {
+            token: string;
+          };
+          const init_data = duckdb.function_get_init_data(info) as {
+            next_row: number;
+          };
+          const chunkSize = init_data.next_row === 0 ? 1 : 0;
+          if (chunkSize > 0) {
+            const vector = duckdb.data_chunk_get_vector(output, 0);
+            duckdb.vector_assign_string_element(vector, 0, local.token);
+            init_data.next_row = 1;
+          }
+          duckdb.data_chunk_set_size(output, chunkSize);
+        },
+      });
+      const result = await duckdb.query(connection, 'select * from my_func()');
+      await expectResult(result, {
+        chunkCount: 1,
+        rowCount: 1,
+        columns: [
+          { name: 'my_column', logicalType: { typeId: duckdb.Type.VARCHAR } },
+        ],
+        chunks: [{ rowCount: 1, vectors: [data(16, [true], ['local_init'])] }],
+      });
+    });
+  });
+
+  test('error handling (exception in bind func)', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, {
+        bindFunction: () => {
+          throw new Error('my_bind_error');
+        },
+      });
+      await expect(
+        duckdb.query(connection, 'select * from my_func()'),
+      ).rejects.toThrow('my_bind_error');
+    });
+  });
+
+  test('error handling (set error in bind func)', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, {
+        bindFunction: (info) => {
+          duckdb.bind_set_error(info, 'my_bind_error');
+        },
+      });
+      await expect(
+        duckdb.query(connection, 'select * from my_func()'),
+      ).rejects.toThrow('my_bind_error');
+    });
+  });
+
+  test('error handling (exception in init func)', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, {
+        initFunction: () => {
+          throw new Error('my_init_error');
+        },
+      });
+      await expect(
+        duckdb.query(connection, 'select * from my_func()'),
+      ).rejects.toThrow('my_init_error');
+    });
+  });
+
+  test('error handling (set error in init func)', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, {
+        initFunction: (info) => {
+          duckdb.init_set_error(info, 'my_init_error');
+        },
+      });
+      await expect(
+        duckdb.query(connection, 'select * from my_func()'),
+      ).rejects.toThrow('my_init_error');
+    });
+  });
+
+  test('error handling (exception in main func)', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, {
+        mainFunction: () => {
+          throw new Error('my_main_error');
+        },
+      });
+      await expect(
+        duckdb.query(connection, 'select * from my_func()'),
+      ).rejects.toThrow('my_main_error');
+    });
+  });
+
+  test('error handling (set error in main func)', async () => {
+    await withConnection(async (connection) => {
+      registerFunction(connection, {
+        mainFunction: (info) => {
+          duckdb.function_set_error(info, 'my_main_error');
+        },
+      });
+      await expect(
+        duckdb.query(connection, 'select * from my_func()'),
+      ).rejects.toThrow('my_main_error');
+    });
+  });
+
+  test('a table function info is not a scalar function info', async () => {
+    await withConnection(async (connection) => {
+      let caught: string | undefined;
+      registerFunction(connection, {
+        mainFunction: (info, output) => {
+          try {
+            // Same underlying C type, different family: this must throw rather
+            // than reinterpret the handle as a scalar function's struct.
+            duckdb.scalar_function_get_bind_data(info as never);
+          } catch (e) {
+            caught = String((e as Error).message);
+          }
+          duckdb.data_chunk_set_size(output, 0);
+        },
+      });
+      await duckdb.query(connection, 'select * from my_func()');
+      expect(caught).toBe('Invalid scalar function info argument');
+    });
   });
 });


### PR DESCRIPTION
Implements all 33 table function entry points: the twelve `duckdb_table_function_*`
functions, nine bind info, seven init info, and five function info. The TODO
census drops from 209 to 176 and loses those four categories.

A table function now runs end to end — `select * from my_func()` returns rows,
with positional and named parameters, projection pushdown, and parallel scanning.

## Each function family gets its own info types

The C API reuses one opaque handle for `duckdb_bind_info`, `duckdb_init_info` and
`duckdb_function_info` across function families, but the structs behind those
handles are unrelated, and each family's accessors `reinterpret_cast` with no
check beyond a null test. Verified against duckdb v1.5.5: the table bind struct is
more than twice the size of the scalar one, so `duckdb_bind_add_result_column` on
a scalar bind info dereferences a vector reference from *past the end of the
object*. Worse, both families' client context accessors read the first member of
their struct, so that one call silently succeeds — the failure mode is "some calls
work, others corrupt the heap".

None of that is detectable at the C level, so this deviates: a type tag per family,
and in TypeScript a second phantom field. `__duckdb_type` still records the
underlying C type, keeping the header correspondence legible;
`__duckdb_function_kind` is what makes the families non-assignable. `BindInfo` and
`FunctionInfo` remain as deprecated aliases, so the api layer builds unchanged.

A test passes a `TableFunctionInfo` to `scalar_function_get_bind_data` and asserts
it throws rather than corrupting.

## Structure

`table_function_helpers.h` follows the shape `scalar_function_helpers.h` settled
on in #458: the family's info externals, extra info, holder, and the external for
the holder, with the tag coming from `type_tags.h`.

All four callbacks — bind, init, local init, main — go through
`DuckDBThreadCallback`, so each inherits the thread-safe function lifetime rules
rather than restating them. Init and local init need distinct traits despite
identical signatures, so each keeps its own thread-safe function.

Bind data and init data hold the user's object through the reaper. There is no
copy callback to implement here: the C API never copies table function bind data.

## idx_t widths

Cardinality is read as 64 bits, since unlike a chunk size or a column count an
estimate can exceed what fits in 32. Parameter index, column index and max threads
keep the 32-bit read.

## Two C API behaviours worth knowing

`bind_get_named_parameter` returns `null` rather than throwing when no parameter of
that name was supplied, which is what the C API reports and what a caller checking
for an optional parameter needs.

**Registering the same name twice does not fail**, contrary to the C API docs,
which say an existing name returns `DuckDBError`. It reports success and is then
ignored, so the first registration is what runs — re-registering to replace a
function silently does nothing. Measured, not assumed, and pinned by a test.

## Tests

28 in the main suite: scans of one chunk and of several that resume from init
data; positional and named parameters including an unsupplied one; extra info
reaching bind, init and main, plus the client context; projection pushdown,
asserting that selecting one column of three tells init about exactly that column;
max threads; all eight error paths (a thrown exception and an explicit `set_error`
from each of bind, init, local init and main); an empty scan; an interrupted scan;
and a function outliving the connection that registered it.

4 in `test/stress`: all three user objects surviving GC, a hundred registered
functions under GC pressure, concurrent queries from eight connections while the
JS thread churns, and a parallel scan with max threads set. That last is really
parallel — measured at four local init states, one per scanning thread, with the
main function called twelve times across them — which is what exercises per-thread
local init data. Only the row count is asserted exactly, since thread count depends
on the machine.

## Verification

macOS and a Linux container, normal and instrumented builds: bindings 302, stress
7, api 145. The instrumented build staying clean is the meaningful part — bind
data, init data and per-thread local init data references are created on the JS
thread and dropped by DuckDB across several of its own threads, and none is
destroyed off the JS thread. Signature files unchanged.

The api layer is untouched and builds unchanged. Exposing table functions there,
and renaming `DuckDBBindInfo` / `DuckDBFunctionInfo` to match the split above, are
left to a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
