### PR TITLE
Expose creating a vector and referencing a value into one

### DIFF
--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -1057,8 +1057,10 @@ export function data_chunk_get_size(chunk: DataChunk): number;
 export function data_chunk_set_size(chunk: DataChunk, size: number): void;
 
 // DUCKDB_C_API duckdb_vector duckdb_create_vector(duckdb_logical_type type, idx_t capacity);
+export function create_vector(logical_type: LogicalType, capacity: number): Vector;
 
 // DUCKDB_C_API void duckdb_destroy_vector(duckdb_vector *vector);
+// not exposed: destroyed in finalizer
 
 // DUCKDB_C_API duckdb_logical_type duckdb_vector_get_column_type(duckdb_vector vector);
 export function vector_get_column_type(vector: Vector): LogicalType;
@@ -1103,6 +1105,7 @@ export function array_vector_get_child(vector: Vector): Vector;
 // DUCKDB_C_API void duckdb_vector_copy_sel(duckdb_vector src, duckdb_vector dst, duckdb_selection_vector sel, idx_t src_count, idx_t src_offset, idx_t dst_offset);
 
 // DUCKDB_C_API void duckdb_vector_reference_value(duckdb_vector vector, duckdb_value value);
+export function vector_reference_value(vector: Vector, value: Value): void;
 
 // DUCKDB_C_API void duckdb_vector_reference_vector(duckdb_vector to_vector, duckdb_vector from_vector);
 

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -254,6 +254,8 @@ public:
       InstanceMethod("data_chunk_get_size", &DuckDBNodeAddon::data_chunk_get_size),
       InstanceMethod("data_chunk_set_size", &DuckDBNodeAddon::data_chunk_set_size),
 
+      InstanceMethod("create_vector", &DuckDBNodeAddon::create_vector),
+      InstanceMethod("vector_reference_value", &DuckDBNodeAddon::vector_reference_value),
       InstanceMethod("vector_get_column_type", &DuckDBNodeAddon::vector_get_column_type),
       InstanceMethod("vector_get_data", &DuckDBNodeAddon::vector_get_data),
       InstanceMethod("vector_get_validity", &DuckDBNodeAddon::vector_get_validity),
@@ -2790,10 +2792,20 @@ private:
   }
 
   // DUCKDB_C_API duckdb_vector duckdb_create_vector(duckdb_logical_type type, idx_t capacity);
-  // TODO vector creation
+  // function create_vector(logical_type: LogicalType, capacity: number): Vector
+  Napi::Value create_vector(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto logical_type = GetLogicalTypeFromExternal(env, info[0]);
+    auto capacity = info[1].As<Napi::Number>().Uint32Value();
+    auto vector = duckdb_create_vector(logical_type, capacity);
+    if (!vector) {
+      throw Napi::Error::New(env, "Failed to create vector");
+    }
+    return CreateExternalForVector(env, vector);
+  }
 
   // DUCKDB_C_API void duckdb_destroy_vector(duckdb_vector *vector);
-  // TODO vector creation
+  // not exposed: destroyed in finalizer
 
   // DUCKDB_C_API duckdb_logical_type duckdb_vector_get_column_type(duckdb_vector vector);
   // function vector_get_column_type(vector: Vector): LogicalType
@@ -2929,7 +2941,14 @@ private:
   // TODO vector manipulation
 
   // DUCKDB_C_API void duckdb_vector_reference_value(duckdb_vector vector, duckdb_value value);
-  // TODO vector manipulation
+  // function vector_reference_value(vector: Vector, value: Value): void
+  Napi::Value vector_reference_value(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto vector = GetVectorFromExternal(env, info[0]);
+    auto value = GetValueFromExternal(env, info[1]);
+    duckdb_vector_reference_value(vector, value);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_vector_reference_vector(duckdb_vector to_vector, duckdb_vector from_vector);
   // TODO vector manipulation
@@ -4559,17 +4578,16 @@ NODE_API_ADDON(DuckDBNodeAddon)
 /*
 
 546 DUCKDB_C_API
-    304 function
-     25 not exposed
+    306 function
+     26 not exposed
      41 deprecated
-    176 TODO
+    173 TODO
         8 arrow
         5 error data
         2 utf8
         1 value to string
         1 register logical type
-        2 vector creation
-        4 vector manipulation
+        3 vector manipulation
         4 scalar function set
         2 scalar function expression
         7 scalar function init

--- a/bindings/src/externals.h
+++ b/bindings/src/externals.h
@@ -263,8 +263,23 @@ inline duckdb_value GetValueFromExternal(Napi::Env env, Napi::Value value) {
   return GetDataFromExternal<_duckdb_value>(env, ValueTypeTag, value, "Invalid value argument");
 }
 
+inline void FinalizeVector(Napi::BasicEnv, duckdb_vector vector) {
+  if (vector) {
+    duckdb_destroy_vector(&vector);
+    vector = nullptr;
+  }
+}
+
+// A vector created in its own right, which owns its memory and is destroyed when
+// it is collected. Contrast with the borrowed form below.
+inline Napi::External<_duckdb_vector> CreateExternalForVector(Napi::Env env, duckdb_vector vector) {
+  return CreateExternal<_duckdb_vector>(env, VectorTypeTag, vector, FinalizeVector);
+}
+
 inline Napi::External<_duckdb_vector> CreateExternalForVectorWithoutFinalizer(Napi::Env env, duckdb_vector vector) {
-  // Vectors live as long as their containing data chunk; they cannot be explicitly destroyed.
+  // A vector belonging to a data chunk lives as long as that chunk and must not
+  // be destroyed on its own. Both forms share a type tag, since either can be
+  // passed wherever a vector is accepted; only ownership differs.
   return CreateExternalWithoutFinalizer<_duckdb_vector>(env, VectorTypeTag, vector);
 }
 

--- a/bindings/test/create_vector.test.ts
+++ b/bindings/test/create_vector.test.ts
@@ -1,0 +1,109 @@
+import duckdb from '@duckdb/node-bindings';
+import { expect, suite, test } from 'vitest';
+
+// A created vector owns its memory, unlike one belonging to a data chunk, and is
+// destroyed when collected. Referencing a value into one turns that value into
+// something the vector reading path can read, which is the only way to get at the
+// contents of an ARRAY or UNION value: the value accessors reject both, since
+// duckdb_get_list_child and duckdb_get_struct_child guard on the exact type id.
+
+suite('create vector', () => {
+  test('create', () => {
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    const vector = duckdb.create_vector(int_type, 1);
+    expect(vector).toBeTruthy();
+    expect(duckdb.get_type_id(duckdb.vector_get_column_type(vector))).toBe(
+      duckdb.Type.INTEGER,
+    );
+  });
+
+  test('reference a primitive value', () => {
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    const vector = duckdb.create_vector(int_type, 1);
+    duckdb.vector_reference_value(vector, duckdb.create_int32(42));
+    const data = duckdb.vector_get_data(vector, 4);
+    expect(new DataView(data.buffer, data.byteOffset).getInt32(0, true)).toBe(
+      42,
+    );
+  });
+
+  test('reference a varchar value', () => {
+    const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+    const vector = duckdb.create_vector(varchar_type, 1);
+    duckdb.vector_reference_value(vector, duckdb.create_varchar('hello'));
+    // Inlined strings live in the vector's data; reading them here only needs to
+    // confirm the vector was populated.
+    const data = duckdb.vector_get_data(vector, 16);
+    expect(new DataView(data.buffer, data.byteOffset).getUint32(0, true)).toBe(
+      5,
+    );
+  });
+
+  test('reference an array value', () => {
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    // The type argument is the element type, not the array type.
+    const value = duckdb.create_array_value(int_type, [
+      duckdb.create_int32(1),
+      duckdb.create_int32(2),
+      duckdb.create_int32(3),
+    ]);
+    const vector = duckdb.create_vector(duckdb.get_value_type(value), 1);
+    duckdb.vector_reference_value(vector, value);
+    const child = duckdb.array_vector_get_child(vector);
+    const data = duckdb.vector_get_data(child, 3 * 4);
+    const view = new DataView(data.buffer, data.byteOffset);
+    expect([
+      view.getInt32(0, true),
+      view.getInt32(4, true),
+      view.getInt32(8, true),
+    ]).toStrictEqual([1, 2, 3]);
+  });
+
+  test('reference a union value', () => {
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+    const union_type = duckdb.create_union_type(
+      [int_type, varchar_type],
+      ['i', 's'],
+    );
+    const value = duckdb.create_union_value(
+      union_type,
+      1,
+      duckdb.create_varchar('hello'),
+    );
+    const vector = duckdb.create_vector(duckdb.get_value_type(value), 1);
+    duckdb.vector_reference_value(vector, value);
+    // A union is physically a struct whose first child is the tag.
+    const tagChild = duckdb.struct_vector_get_child(vector, 0);
+    const tagData = duckdb.vector_get_data(tagChild, 1);
+    expect(new DataView(tagData.buffer, tagData.byteOffset).getUint8(0)).toBe(1);
+  });
+
+  test('reference a list value', () => {
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    const value = duckdb.create_list_value(int_type, [
+      duckdb.create_int32(7),
+      duckdb.create_int32(8),
+    ]);
+    const vector = duckdb.create_vector(duckdb.get_value_type(value), 1);
+    duckdb.vector_reference_value(vector, value);
+    expect(duckdb.list_vector_get_size(vector)).toBe(2);
+    const child = duckdb.list_vector_get_child(vector);
+    const data = duckdb.vector_get_data(child, 2 * 4);
+    const view = new DataView(data.buffer, data.byteOffset);
+    expect([view.getInt32(0, true), view.getInt32(4, true)]).toStrictEqual([
+      7, 8,
+    ]);
+  });
+
+  test('many created vectors are reclaimed', () => {
+    // Created vectors are destroyed by their finalizer rather than explicitly,
+    // so this only checks that churning through a lot of them is well behaved.
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    for (let i = 0; i < 10000; i++) {
+      const vector = duckdb.create_vector(int_type, 1);
+      duckdb.vector_reference_value(vector, duckdb.create_int32(i));
+    }
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
`duckdb_create_vector` makes a vector that owns its memory, rather than borrowing
it from a data chunk, and `duckdb_vector_reference_value` copies a value into one.
Together they turn a `duckdb_value` into something the vector reading path can
read.

## Why

The value accessors cannot reach inside an ARRAY or a UNION.
`duckdb_get_list_child` and `duckdb_get_struct_child` guard on the exact logical
type id:

```cpp
if (val.type().id() != LogicalTypeId::LIST   || val.IsNull()) return nullptr;
if (val.type().id() != LogicalTypeId::STRUCT || val.IsNull()) return nullptr;
```

so both return null for those types, even though a union *is* physically a struct
and an array *is* a fixed-size list. I enumerated every C API function that takes a
`duckdb_value` — 44 of them — and none returns the children of an array or a union.

The asymmetry is visible in the C API itself: `duckdb_create_array_value` and
`duckdb_create_union_value` exist, so it can construct these values but not read
them back. That looks like an oversight worth raising upstream.

Referencing the value into a vector goes around it. The tests here read an array's
elements and a union's tag that way, along with primitives, varchar and lists.

## Notes

Both forms of vector share a type tag, since either can be passed wherever a
vector is accepted and only ownership differs. Data chunks already work this way —
`CreateExternalForDataChunk` and `CreateExternalForDataChunkWithoutFinalizer`
share `DataChunkTypeTag` — so this follows an established pattern rather than
introducing a second vector type.

Created vectors are destroyed by their finalizer, so `duckdb_destroy_vector` is
marked "not exposed: destroyed in finalizer", as with the other types cleaned up
that way. That also avoids the double-free a sync destroy plus a finalizer would
allow.

Census: 176 TODO to 173, with "vector creation" retired and "vector manipulation"
down to three.

## Verification

macOS and a Linux container, normal and instrumented builds: bindings 309,
stress 7, api 145. Signature files unchanged.

## What this is for

The api layer needs to convert a `duckdb_value` into a `DuckDBValue` to read table
function parameters. Doing that by hand means a second implementation of decisions
the vector reading code already makes, and it cannot cover ARRAY, UNION, GEOMETRY
or VARIANT. Going through a vector reuses the existing reader, so there is one
implementation and it covers everything.

Measured on the two routes: for scalars the vector route costs about 1 µs more per
value (374 ns to 1284 ns for an INTEGER), and for nested values it is the same or
faster (a five element list went from 4750 ns to 3240 ns). It is only reachable at
bind time, a handful of values per query, never per row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
