### PR TITLE
Add support for scalar function init

### DIFF
--- a/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
+++ b/bindings/pkgs/@duckdb/node-bindings/duckdb.d.ts
@@ -196,6 +196,11 @@ export interface ScalarFunctionBindInfo {
   __duckdb_function_kind: 'scalar_function';
 }
 
+export interface ScalarFunctionInitInfo {
+  __duckdb_type: 'duckdb_init_info';
+  __duckdb_function_kind: 'scalar_function';
+}
+
 export interface ScalarFunctionInfo {
   __duckdb_type: 'duckdb_function_info';
   __duckdb_function_kind: 'scalar_function';
@@ -309,6 +314,7 @@ export interface ExtractedStatementsAndCount {
 }
 
 export type ScalarFunctionBindFunction = (info: ScalarFunctionBindInfo) => void;
+export type ScalarFunctionInitFunction = (info: ScalarFunctionInitInfo) => void;
 export type ScalarFunctionMainFunction = (info: ScalarFunctionInfo, input: DataChunk, output: Vector) => void;
 
 export type TableFunctionBindFunction = (info: TableFunctionBindInfo) => void;
@@ -1190,12 +1196,25 @@ export function scalar_function_set_error(function_info: ScalarFunctionInfo, err
 // DUCKDB_C_API duckdb_expression duckdb_scalar_function_bind_get_argument(duckdb_bind_info info, idx_t index);
 
 // DUCKDB_C_API void *duckdb_scalar_function_get_state(duckdb_function_info info);
+export function scalar_function_get_state(function_info: ScalarFunctionInfo): object | undefined;
+
 // DUCKDB_C_API void duckdb_scalar_function_set_init(duckdb_scalar_function scalar_function, duckdb_scalar_function_init_t init);
+export function scalar_function_set_init(scalar_function: ScalarFunction, func: ScalarFunctionInitFunction): void;
+
 // DUCKDB_C_API void duckdb_scalar_function_init_set_error(duckdb_init_info info, const char *error);
+export function scalar_function_init_set_error(init_info: ScalarFunctionInitInfo, error: string): void;
+
 // DUCKDB_C_API void duckdb_scalar_function_init_set_state(duckdb_init_info info, void *state, duckdb_delete_callback_t destroy);
+export function scalar_function_init_set_state(init_info: ScalarFunctionInitInfo, state: object): void;
+
 // DUCKDB_C_API void duckdb_scalar_function_init_get_client_context(duckdb_init_info info, duckdb_client_context *out_context);
+export function scalar_function_init_get_client_context(init_info: ScalarFunctionInitInfo): ClientContext;
+
 // DUCKDB_C_API void *duckdb_scalar_function_init_get_bind_data(duckdb_init_info info);
+export function scalar_function_init_get_bind_data(init_info: ScalarFunctionInitInfo): object | undefined;
+
 // DUCKDB_C_API void *duckdb_scalar_function_init_get_extra_info(duckdb_init_info info);
+export function scalar_function_init_get_extra_info(init_info: ScalarFunctionInitInfo): object | undefined;
 
 // DUCKDB_C_API duckdb_selection_vector duckdb_create_selection_vector(idx_t size);
 // DUCKDB_C_API void duckdb_destroy_selection_vector(duckdb_selection_vector sel);

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -292,6 +292,13 @@ public:
       InstanceMethod("scalar_function_get_bind_data", &DuckDBNodeAddon::scalar_function_get_bind_data),
       InstanceMethod("scalar_function_get_client_context", &DuckDBNodeAddon::scalar_function_get_client_context),
       InstanceMethod("scalar_function_set_error", &DuckDBNodeAddon::scalar_function_set_error),
+      InstanceMethod("scalar_function_get_state", &DuckDBNodeAddon::scalar_function_get_state),
+      InstanceMethod("scalar_function_set_init", &DuckDBNodeAddon::scalar_function_set_init),
+      InstanceMethod("scalar_function_init_set_error", &DuckDBNodeAddon::scalar_function_init_set_error),
+      InstanceMethod("scalar_function_init_set_state", &DuckDBNodeAddon::scalar_function_init_set_state),
+      InstanceMethod("scalar_function_init_get_client_context", &DuckDBNodeAddon::scalar_function_init_get_client_context),
+      InstanceMethod("scalar_function_init_get_bind_data", &DuckDBNodeAddon::scalar_function_init_get_bind_data),
+      InstanceMethod("scalar_function_init_get_extra_info", &DuckDBNodeAddon::scalar_function_init_get_extra_info),
 
       InstanceMethod("create_table_function", &DuckDBNodeAddon::create_table_function),
       InstanceMethod("destroy_table_function_sync", &DuckDBNodeAddon::destroy_table_function_sync),
@@ -3221,25 +3228,87 @@ private:
   // TODO scalar function expression
 
   // DUCKDB_C_API void *duckdb_scalar_function_get_state(duckdb_function_info info);
-  // TODO scalar function init
+  // function scalar_function_get_state(function_info: ScalarFunctionInfo): object | undefined
+  Napi::Value scalar_function_get_state(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto function_info = GetScalarFunctionInfoFromExternal(env, info[0]);
+    auto internal_state = reinterpret_cast<ScalarFunctionInternalState*>(duckdb_scalar_function_get_state(function_info));
+    if (!internal_state || !internal_state->user_state_ref) {
+      return env.Undefined();
+    }
+    return internal_state->user_state_ref->ref.Value();
+  }
 
   // DUCKDB_C_API void duckdb_scalar_function_set_init(duckdb_scalar_function scalar_function, duckdb_scalar_function_init_t init);
-  // TODO scalar function init
+  // function scalar_function_set_init(scalar_function: ScalarFunction, func: ScalarFunctionInitFunction): void
+  Napi::Value scalar_function_set_init(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto holder = GetScalarFunctionHolderFromExternal(env, info[0]);
+    auto func = info[1].As<Napi::Function>();
+    holder->EnsureInternalExtraInfo(ref_reaper);
+    holder->internal_extra_info->SetInitFunction(env, func);
+    duckdb_scalar_function_set_init(holder->scalar_function, &ScalarFunctionInitFunction);
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_scalar_function_init_set_error(duckdb_init_info info, const char *error);
-  // TODO scalar function init
+  // function scalar_function_init_set_error(init_info: ScalarFunctionInitInfo, error: string): void
+  Napi::Value scalar_function_init_set_error(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetScalarFunctionInitInfoFromExternal(env, info[0]);
+    std::string error = info[1].As<Napi::String>();
+    duckdb_scalar_function_init_set_error(init_info, error.c_str());
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_scalar_function_init_set_state(duckdb_init_info info, void *state, duckdb_delete_callback_t destroy);
-  // TODO scalar function init
+  // function scalar_function_init_set_state(init_info: ScalarFunctionInitInfo, state: object): void
+  Napi::Value scalar_function_init_set_state(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetScalarFunctionInitInfoFromExternal(env, info[0]);
+    auto user_state = info[1].As<Napi::Object>();
+    auto internal_state = new ScalarFunctionInternalState();
+    internal_state->SetUserState(ref_reaper, user_state);
+    duckdb_scalar_function_init_set_state(init_info, internal_state, reinterpret_cast<duckdb_delete_callback_t>(DeleteScalarFunctionInternalState));
+    return env.Undefined();
+  }
 
   // DUCKDB_C_API void duckdb_scalar_function_init_get_client_context(duckdb_init_info info, duckdb_client_context *out_context);
-  // TODO scalar function init
+  // function scalar_function_init_get_client_context(init_info: ScalarFunctionInitInfo): ClientContext
+  Napi::Value scalar_function_init_get_client_context(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetScalarFunctionInitInfoFromExternal(env, info[0]);
+    duckdb_client_context client_context;
+    duckdb_scalar_function_init_get_client_context(init_info, &client_context);
+    if (!client_context) {
+      throw Napi::Error::New(env, "Failed to get client context");
+    }
+    return CreateExternalForClientContext(env, client_context);
+  }
 
   // DUCKDB_C_API void *duckdb_scalar_function_init_get_bind_data(duckdb_init_info info);
-  // TODO scalar function init
+  // function scalar_function_init_get_bind_data(init_info: ScalarFunctionInitInfo): object | undefined
+  Napi::Value scalar_function_init_get_bind_data(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetScalarFunctionInitInfoFromExternal(env, info[0]);
+    auto internal_bind_data = reinterpret_cast<ScalarFunctionInternalBindData*>(duckdb_scalar_function_init_get_bind_data(init_info));
+    if (!internal_bind_data || !internal_bind_data->user_bind_data_ref) {
+      return env.Undefined();
+    }
+    return internal_bind_data->user_bind_data_ref->ref.Value();
+  }
 
   // DUCKDB_C_API void *duckdb_scalar_function_init_get_extra_info(duckdb_init_info info);
-  // TODO scalar function init
+  // function scalar_function_init_get_extra_info(init_info: ScalarFunctionInitInfo): object | undefined
+  Napi::Value scalar_function_init_get_extra_info(const Napi::CallbackInfo& info) {
+    auto env = info.Env();
+    auto init_info = GetScalarFunctionInitInfoFromExternal(env, info[0]);
+    auto internal_extra_info = GetScalarFunctionInternalExtraInfoFromInitInfo(init_info);
+    if (!internal_extra_info || !internal_extra_info->user_extra_info_ref) {
+      return env.Undefined();
+    }
+    return internal_extra_info->user_extra_info_ref->ref.Value();
+  }
 
   // DUCKDB_C_API duckdb_selection_vector duckdb_create_selection_vector(idx_t size);
   // TODO selection vector
@@ -4578,10 +4647,10 @@ NODE_API_ADDON(DuckDBNodeAddon)
 /*
 
 546 DUCKDB_C_API
-    306 function
+    313 function
      26 not exposed
      41 deprecated
-    173 TODO
+    166 TODO
         8 arrow
         5 error data
         2 utf8
@@ -4590,7 +4659,6 @@ NODE_API_ADDON(DuckDBNodeAddon)
         3 vector manipulation
         4 scalar function set
         2 scalar function expression
-        7 scalar function init
         3 selection vector
        12 aggregate function
         4 aggregate function set

--- a/bindings/src/scalar_function_helpers.h
+++ b/bindings/src/scalar_function_helpers.h
@@ -31,6 +31,14 @@ inline duckdb_bind_info GetScalarFunctionBindInfoFromExternal(Napi::Env env, Nap
   return GetDataFromExternal<_duckdb_bind_info>(env, ScalarFunctionBindInfoTypeTag, value, "Invalid scalar function bind info argument");
 }
 
+inline Napi::External<_duckdb_init_info> CreateExternalForScalarFunctionInitInfo(Napi::Env env, duckdb_init_info init_info) {
+  return CreateExternalWithoutFinalizer<_duckdb_init_info>(env, ScalarFunctionInitInfoTypeTag, init_info);
+}
+
+inline duckdb_init_info GetScalarFunctionInitInfoFromExternal(Napi::Env env, Napi::Value value) {
+  return GetDataFromExternal<_duckdb_init_info>(env, ScalarFunctionInitInfoTypeTag, value, "Invalid scalar function init info argument");
+}
+
 inline Napi::External<_duckdb_function_info> CreateExternalForScalarFunctionInfo(Napi::Env env, duckdb_function_info function_info) {
   return CreateExternalWithoutFinalizer<_duckdb_function_info>(env, ScalarFunctionInfoTypeTag, function_info);
 }
@@ -59,6 +67,27 @@ struct ScalarFunctionBindCallbackTraits {
 
   static void SetError(const Payload &payload, const char *message) {
     duckdb_scalar_function_bind_set_error(payload, message);
+  }
+};
+
+struct ScalarFunctionInitCallbackTraits {
+  using Payload = duckdb_init_info;
+
+  static const char *ResourceName() {
+    return "ScalarFunctionInit";
+  }
+
+  static void Call(Napi::Env env, Napi::Function callback, const Payload &payload) {
+    callback.Call(
+      env.Undefined(),
+      {
+        CreateExternalForScalarFunctionInitInfo(env, payload)
+      }
+    );
+  }
+
+  static void SetError(const Payload &payload, const char *message) {
+    duckdb_scalar_function_init_set_error(payload, message);
   }
 };
 
@@ -93,14 +122,19 @@ struct ScalarFunctionMainCallbackTraits {
 
 struct ScalarFunctionInternalExtraInfo {
   DuckDBThreadCallback<ScalarFunctionBindCallbackTraits> bind_callback;
+  DuckDBThreadCallback<ScalarFunctionInitCallbackTraits> init_callback;
   DuckDBThreadCallback<ScalarFunctionMainCallbackTraits> main_callback;
   std::shared_ptr<ManagedObjectReference> user_extra_info_ref;
 
   explicit ScalarFunctionInternalExtraInfo(const std::shared_ptr<NapiRefReaper> &env_state)
-    : bind_callback(env_state), main_callback(env_state) {}
+    : bind_callback(env_state), init_callback(env_state), main_callback(env_state) {}
 
   void SetBindFunction(Napi::Env env, Napi::Function func) {
     bind_callback.Set(env, func);
+  }
+
+  void SetInitFunction(Napi::Env env, Napi::Function func) {
+    init_callback.Set(env, func);
   }
 
   void SetMainFunction(Napi::Env env, Napi::Function func) {
@@ -193,6 +227,22 @@ inline ScalarFunctionInternalBindData *CopyScalarFunctionInternalBindData(Scalar
   return new_internal_bind_data;
 }
 
+// State
+
+struct ScalarFunctionInternalState {
+  std::shared_ptr<ManagedObjectReference> user_state_ref;
+
+  void SetUserState(const std::shared_ptr<NapiRefReaper> &reaper, Napi::Object user_state) {
+    user_state_ref = user_state.IsUndefined() ? nullptr : MakeManagedObjectReference(reaper, user_state);
+  }
+};
+
+// State is local to a DuckDB worker thread, and DuckDB can destroy it on that
+// thread. The managed reference routes its N-API cleanup back to the JS thread.
+inline void DeleteScalarFunctionInternalState(ScalarFunctionInternalState *internal_state) {
+  delete internal_state;
+}
+
 // Entry points handed to DuckDB
 
 inline ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromBindInfo(duckdb_bind_info bind_info) {
@@ -201,6 +251,14 @@ inline ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromBi
 
 inline void ScalarFunctionBindFunction(duckdb_bind_info info) {
   GetScalarFunctionInternalExtraInfoFromBindInfo(info)->bind_callback.Invoke(info);
+}
+
+inline ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromInitInfo(duckdb_init_info init_info) {
+  return reinterpret_cast<ScalarFunctionInternalExtraInfo*>(duckdb_scalar_function_init_get_extra_info(init_info));
+}
+
+inline void ScalarFunctionInitFunction(duckdb_init_info info) {
+  GetScalarFunctionInternalExtraInfoFromInitInfo(info)->init_callback.Invoke(info);
 }
 
 inline ScalarFunctionInternalExtraInfo *GetScalarFunctionInternalExtraInfoFromFunctionInfo(duckdb_function_info function_info) {

--- a/bindings/src/type_tags.h
+++ b/bindings/src/type_tags.h
@@ -75,6 +75,10 @@ inline constexpr napi_type_tag ScalarFunctionInfoTypeTag = {
   0xB0E6739D698048EA, 0x9E79734E3E137AC3
 };
 
+inline constexpr napi_type_tag ScalarFunctionInitInfoTypeTag = {
+  0x66C20B7EDFBB42FB, 0xB183E571F8924220
+};
+
 inline constexpr napi_type_tag ScalarFunctionTypeTag = {
   0x95D48B7051D14994, 0x9F883D7DF5DEA86D
 };

--- a/bindings/test/fixtures/scalarFunctionExit.cjs
+++ b/bindings/test/fixtures/scalarFunctionExit.cjs
@@ -27,12 +27,16 @@ async function main() {
   duckdb.scalar_function_set_bind(scalar_function, (info) => {
     duckdb.scalar_function_set_bind_data(info, { 'token': 'bind_data' });
   });
+  duckdb.scalar_function_set_init(scalar_function, (info) => {
+    duckdb.scalar_function_init_set_state(info, { 'token': 'state' });
+  });
   duckdb.scalar_function_set_function(
     scalar_function,
-    (_info, input, output) => {
+    (info, input, output) => {
+      const state = duckdb.scalar_function_get_state(info);
       const rowCount = duckdb.data_chunk_get_size(input);
       for (let i = 0; i < rowCount; i++) {
-        duckdb.vector_assign_string_element(output, i, 'ok');
+        duckdb.vector_assign_string_element(output, i, state.token);
       }
     },
   );

--- a/bindings/test/scalar_functions.test.ts
+++ b/bindings/test/scalar_functions.test.ts
@@ -212,6 +212,174 @@ suite('scalar functions', () => {
       });
     });
   });
+  test('init state, bind data, extra info, and client context', async () => {
+    await withConnection(async (connection) => {
+      await duckdb.query(connection, 'set threads = 1');
+
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_counter');
+      const bigint_type = duckdb.create_logical_type(duckdb.Type.BIGINT);
+      duckdb.scalar_function_add_parameter(scalar_function, bigint_type);
+      duckdb.scalar_function_set_return_type(scalar_function, bigint_type);
+      duckdb.scalar_function_set_volatile(scalar_function);
+
+      const extra_info = { start: 5n };
+      const bind_data = { limit: 5005n };
+      duckdb.scalar_function_set_extra_info(scalar_function, extra_info);
+      duckdb.scalar_function_set_bind(scalar_function, (info) => {
+        duckdb.scalar_function_set_bind_data(info, bind_data);
+      });
+
+      let init_calls = 0;
+      let init_extra_info: object | undefined;
+      let init_bind_data: object | undefined;
+      let init_context_is_valid = false;
+      let wrong_function_family_error: string | undefined;
+      duckdb.scalar_function_set_init(scalar_function, (info) => {
+        init_calls++;
+        init_extra_info = duckdb.scalar_function_init_get_extra_info(info);
+        init_bind_data = duckdb.scalar_function_init_get_bind_data(info);
+        try {
+          // Same underlying C type, different family: this must throw rather
+          // than reinterpret scalar init info as table function init info.
+          duckdb.init_get_extra_info(info as never);
+        } catch (e) {
+          wrong_function_family_error = String((e as Error).message);
+        }
+        const client_context =
+          duckdb.scalar_function_init_get_client_context(info);
+        init_context_is_valid =
+          duckdb.client_context_get_connection_id(client_context) > 0;
+        duckdb.scalar_function_init_set_state(info, {
+          next: extra_info.start,
+        });
+      });
+
+      let main_calls = 0;
+      const seen_states = new Set<object>();
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (info, input, output) => {
+          main_calls++;
+          const state = duckdb.scalar_function_get_state(info) as {
+            next: bigint;
+          };
+          seen_states.add(state);
+          const row_count = duckdb.data_chunk_get_size(input);
+          const output_buffer = new ArrayBuffer(row_count * 8);
+          const output_view = new DataView(output_buffer);
+          for (let i = 0; i < row_count; i++) {
+            output_view.setBigInt64(i * 8, state.next, true);
+            state.next++;
+          }
+          duckdb.copy_data_to_vector(
+            output,
+            0,
+            output_buffer,
+            0,
+            output_buffer.byteLength,
+          );
+        },
+      );
+      duckdb.register_scalar_function(connection, scalar_function);
+      duckdb.destroy_scalar_function_sync(scalar_function);
+
+      const result = await duckdb.query(
+        connection,
+        `
+          select count(*) as row_count, min(value) as min_value, max(value) as max_value
+          from (select my_counter(i) as value from range(5000) r(i))
+        `,
+      );
+      const chunk = await duckdb.fetch_chunk(result);
+      expect(chunk).toBeTruthy();
+      expect(duckdb.data_chunk_get_size(chunk!)).toBe(1);
+      const row_count_data = duckdb.vector_get_data(
+        duckdb.data_chunk_get_vector(chunk!, 0),
+        8,
+      );
+      const min_data = duckdb.vector_get_data(
+        duckdb.data_chunk_get_vector(chunk!, 1),
+        8,
+      );
+      const max_data = duckdb.vector_get_data(
+        duckdb.data_chunk_get_vector(chunk!, 2),
+        8,
+      );
+      expect(
+        new DataView(
+          row_count_data.buffer,
+          row_count_data.byteOffset,
+          row_count_data.byteLength,
+        ).getBigInt64(0, true),
+      ).toBe(5000n);
+      expect(
+        new DataView(
+          min_data.buffer,
+          min_data.byteOffset,
+          min_data.byteLength,
+        ).getBigInt64(0, true),
+      ).toBe(5n);
+      expect(
+        new DataView(
+          max_data.buffer,
+          max_data.byteOffset,
+          max_data.byteLength,
+        ).getBigInt64(0, true),
+      ).toBe(5004n);
+      expect(init_calls).toBe(1);
+      expect(init_extra_info).toBe(extra_info);
+      expect(init_bind_data).toBe(bind_data);
+      expect(init_context_is_valid).toBe(true);
+      expect(wrong_function_family_error).toBe(
+        'Invalid table function init info argument',
+      );
+      expect(main_calls).toBeGreaterThan(1);
+      expect(seen_states.size).toBe(1);
+    });
+  });
+  test('error handling (exception in init func)', async () => {
+    await withConnection(async (connection) => {
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_func');
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_init(scalar_function, () => {
+        throw new Error('my_init_error');
+      });
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (_info, _input, _output) => {},
+      );
+      duckdb.register_scalar_function(connection, scalar_function);
+      duckdb.destroy_scalar_function_sync(scalar_function);
+
+      await expect(
+        duckdb.query(connection, 'select my_func()'),
+      ).rejects.toThrow('my_init_error');
+    });
+  });
+  test('error handling (set error in init func)', async () => {
+    await withConnection(async (connection) => {
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_func');
+      const varchar_type = duckdb.create_logical_type(duckdb.Type.VARCHAR);
+      duckdb.scalar_function_set_return_type(scalar_function, varchar_type);
+      duckdb.scalar_function_set_init(scalar_function, (info) => {
+        duckdb.scalar_function_init_set_error(info, 'my_init_error');
+      });
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (_info, _input, _output) => {},
+      );
+      duckdb.register_scalar_function(connection, scalar_function);
+      duckdb.destroy_scalar_function_sync(scalar_function);
+
+      await expect(
+        duckdb.query(connection, 'select my_func()'),
+      ).rejects.toThrow('my_init_error');
+    });
+  });
   test('error handling (exception in main func)', async () => {
     await withConnection(async (connection) => {
       const scalar_function = duckdb.create_scalar_function();

--- a/bindings/test/scalar_functions.test.ts
+++ b/bindings/test/scalar_functions.test.ts
@@ -340,13 +340,14 @@ suite('scalar functions', () => {
   });
   test('init runs once per worker thread', async () => {
     await withConnection(async (connection) => {
+      const row_group_size = 122_880;
       const thread_count = 4;
+      const row_group_margin = 2;
+      const rows = row_group_size * thread_count * row_group_margin;
       await duckdb.query(connection, `set threads = ${thread_count}`);
-      // Create enough row groups for every configured worker to enter the
-      // scalar function's parallel execution pipeline.
       await duckdb.query(
         connection,
-        'create table parallel_input as select i from range(1000000) r(i)',
+        `create table parallel_input as select i from range(${rows}) r(i)`,
       );
 
       const scalar_function = duckdb.create_scalar_function();

--- a/bindings/test/scalar_functions.test.ts
+++ b/bindings/test/scalar_functions.test.ts
@@ -338,6 +338,63 @@ suite('scalar functions', () => {
       expect(seen_states.size).toBe(1);
     });
   });
+  test('init runs once per worker thread', async () => {
+    await withConnection(async (connection) => {
+      const thread_count = 4;
+      await duckdb.query(connection, `set threads = ${thread_count}`);
+      // Create enough row groups for every configured worker to enter the
+      // scalar function's parallel execution pipeline.
+      await duckdb.query(
+        connection,
+        'create table parallel_input as select i from range(1000000) r(i)',
+      );
+
+      const scalar_function = duckdb.create_scalar_function();
+      duckdb.scalar_function_set_name(scalar_function, 'my_parallel_func');
+      const bigint_type = duckdb.create_logical_type(duckdb.Type.BIGINT);
+      duckdb.scalar_function_add_parameter(scalar_function, bigint_type);
+      duckdb.scalar_function_set_return_type(scalar_function, bigint_type);
+      duckdb.scalar_function_set_volatile(scalar_function);
+
+      let init_calls = 0;
+      duckdb.scalar_function_set_init(scalar_function, (info) => {
+        init_calls++;
+        duckdb.scalar_function_init_set_state(info, { id: init_calls });
+      });
+
+      const seen_states = new Set<object>();
+      duckdb.scalar_function_set_function(
+        scalar_function,
+        (info, input, output) => {
+          const state = duckdb.scalar_function_get_state(info);
+          if (!state) {
+            throw new Error('missing scalar function init state');
+          }
+          seen_states.add(state);
+          const row_count = duckdb.data_chunk_get_size(input);
+          const output_buffer = new BigInt64Array(row_count);
+          output_buffer.fill(1n);
+          duckdb.copy_data_to_vector(
+            output,
+            0,
+            output_buffer.buffer,
+            0,
+            output_buffer.byteLength,
+          );
+        },
+      );
+      duckdb.register_scalar_function(connection, scalar_function);
+      duckdb.destroy_scalar_function_sync(scalar_function);
+
+      await duckdb.query(
+        connection,
+        'select sum(my_parallel_func(i)) from parallel_input',
+      );
+
+      expect(init_calls).toBe(thread_count);
+      expect(seen_states.size).toBe(thread_count);
+    });
+  });
   test('error handling (exception in init func)', async () => {
     await withConnection(async (connection) => {
       const scalar_function = duckdb.create_scalar_function();

--- a/bindings/test/stress/scalar_function_refs.test.ts
+++ b/bindings/test/stress/scalar_function_refs.test.ts
@@ -6,9 +6,9 @@ import { withConnection } from '../utils/withConnection';
 import { withDatabase } from '../utils/withDatabase';
 
 // These tests exercise the lifetime of the Napi::ObjectReferences held for
-// user-supplied extra info and bind data (see src/napi_ref_reaper.h). They are
-// slower and less deterministic than the main suite, so they are excluded from
-// `pnpm test` and run with `pnpm test:stress`.
+// user-supplied extra info, bind data, and scalar function init state (see
+// src/napi_ref_reaper.h). They are slower and less deterministic than the main
+// suite, so they are excluded from `pnpm test` and run with `pnpm test:stress`.
 //
 // To check the invariant these tests are protecting -- that a reference is only
 // ever destroyed on the JS thread -- build with instrumentation enabled and run
@@ -62,6 +62,23 @@ function registerCheckedFunction(
       'bind_data_token': `bind_data_${name}`,
     });
   });
+  duckdb.scalar_function_set_init(scalar_function, (info) => {
+    const bind_data = duckdb.scalar_function_init_get_bind_data(info) as {
+      bind_data_token: string;
+    };
+    const extra_info = duckdb.scalar_function_init_get_extra_info(info) as {
+      extra_info_token: string;
+    };
+    if (bind_data?.bind_data_token !== `bind_data_${name}`) {
+      throw new Error(`bind data corrupted during init of ${name}`);
+    }
+    if (extra_info?.extra_info_token !== `extra_info_${name}`) {
+      throw new Error(`extra info corrupted during init of ${name}`);
+    }
+    duckdb.scalar_function_init_set_state(info, {
+      'state_token': `state_${name}`,
+    });
+  });
   duckdb.scalar_function_set_function(
     scalar_function,
     (info, input, output) => {
@@ -75,11 +92,17 @@ function registerCheckedFunction(
       const extra_info = duckdb.scalar_function_get_extra_info(info) as {
         extra_info_token: string;
       };
+      const state = duckdb.scalar_function_get_state(info) as {
+        state_token: string;
+      };
       if (bind_data?.bind_data_token !== `bind_data_${name}`) {
         throw new Error(`bind data corrupted in ${name}`);
       }
       if (extra_info?.extra_info_token !== `extra_info_${name}`) {
         throw new Error(`extra info corrupted in ${name}`);
+      }
+      if (state?.state_token !== `state_${name}`) {
+        throw new Error(`state corrupted in ${name}`);
       }
       const rowCount = duckdb.data_chunk_get_size(input);
       for (let i = 0; i < rowCount; i++) {
@@ -93,7 +116,7 @@ function registerCheckedFunction(
 }
 
 suite('scalar function reference lifetime', () => {
-  test('bind data and extra info survive garbage collection', async () => {
+  test('bind data, extra info, and init state survive garbage collection', async () => {
     await withConnection(async (connection) => {
       const fn = registerCheckedFunction(connection, 'my_func', {
         gcInMainFunction: true,
@@ -106,9 +129,10 @@ suite('scalar function reference lifetime', () => {
     });
   });
 
-  // Note that only bind data is destroyed off the JS thread here. Extra info is
-  // owned by the catalog entry and released at disconnect/close, both of which
-  // run on the JS thread, so it always takes the reaper's inline path.
+  // Note that bind data and init state can be destroyed off the JS thread here.
+  // Extra info is owned by the catalog entry and released at disconnect/close,
+  // both of which run on the JS thread, so it always takes the reaper's inline
+  // path.
   test('many registered functions under GC pressure', async () => {
     await withConnection(async (connection) => {
       for (let i = 0; i < 100; i++) {

--- a/bindings/test/worker_threads.test.ts
+++ b/bindings/test/worker_threads.test.ts
@@ -32,8 +32,8 @@ const deadlineMs = 25000;
 const testTimeoutMs = 40000; // Above deadlineMs, so the diagnostic below wins.
 
 // Each worker registers a scalar function, checks on every invocation that its
-// extra info and bind data are intact, then closes everything and reports how
-// many times it was called.
+// extra info, bind data, and init state are intact, then closes everything and
+// reports how many times it was called.
 const worker_source = `
   const { parentPort, workerData } = require('node:worker_threads');
   const duckdb = require(workerData.bindings_path);
@@ -51,12 +51,24 @@ const worker_source = `
     duckdb.scalar_function_set_bind(fn, (info) => {
       duckdb.scalar_function_set_bind_data(info, { token: 'bind_data' });
     });
+    let initCalls = 0;
+    duckdb.scalar_function_set_init(fn, (info) => {
+      initCalls++;
+      duckdb.scalar_function_init_set_state(info, { token: 'init_state' });
+    });
     let calls = 0;
+    const seenStates = new Set();
     duckdb.scalar_function_set_function(fn, (info, input, output) => {
       calls++;
       const bind_data = duckdb.scalar_function_get_bind_data(info);
       const extra_info = duckdb.scalar_function_get_extra_info(info);
-      if (bind_data.token !== 'bind_data' || extra_info.token !== 'extra_info') {
+      const init_state = duckdb.scalar_function_get_state(info);
+      seenStates.add(init_state);
+      if (
+        bind_data.token !== 'bind_data' ||
+        extra_info.token !== 'extra_info' ||
+        init_state.token !== 'init_state'
+      ) {
         throw new Error('reference corrupted in worker');
       }
       const rowCount = duckdb.data_chunk_get_size(input);
@@ -71,7 +83,7 @@ const worker_source = `
     }
     duckdb.disconnect_sync(connection);
     duckdb.close_sync(db);
-    parentPort.postMessage({ calls });
+    parentPort.postMessage({ calls, initCalls, seenStates: seenStates.size });
   })().catch((e) => {
     parentPort.postMessage({ error: String((e && e.message) || e) });
   });
@@ -79,6 +91,8 @@ const worker_source = `
 
 interface WorkerOutcome {
   calls?: number;
+  initCalls?: number;
+  seenStates?: number;
   error?: string;
 }
 
@@ -148,6 +162,8 @@ suite('worker threads', () => {
         for (const result of results) {
           expect(result.error).toBeUndefined();
           expect(result.calls).toBe(queries_per_worker * chunks_per_query);
+          expect(result.initCalls).toBeGreaterThanOrEqual(queries_per_worker);
+          expect(result.seenStates).toBe(result.initCalls);
         }
       } finally {
         if (timer) {


### PR DESCRIPTION
## Summary

Adds support for DuckDB 1.5 scalar function initialization APIs.

Relates to #380.

## Changes

- Exposes all seven scalar function init C API functions:
  - `scalar_function_get_state`
  - `scalar_function_set_init`
  - `scalar_function_init_set_error`
  - `scalar_function_init_set_state`
  - `scalar_function_init_get_client_context`
  - `scalar_function_init_get_bind_data`
  - `scalar_function_init_get_extra_info`
- Adds `ScalarFunctionInitInfo` and `ScalarFunctionInitFunction` TypeScript types.
- Adds scalar-specific runtime type tagging for init-info handles.
- Marshals init callbacks from DuckDB worker threads to the JavaScript thread.
- Manages per-worker JavaScript state using the existing thread-safe reference reaper.
- Adds coverage for state persistence, bind data, extra info, client context, error propagation, type safety, garbage collection, concurrency, and process teardown.
- Updates the C API implementation census.

## Validation

- Bindings build succeeded.
- C API declarations and implementations match all 546 header signatures.
- Bindings: 312 passed, 3 skipped.
- Stress tests: 7 passed.
- API: 161 passed, 1 skipped.
- N-API reference instrumentation passed without off-thread reference destruction or teardown leaks.

## Contribution note

I’d like to contribute to this project whenever I have some free time. For transparency, I used AI assistance while implementing this ticket, but I reviewed the changes and validated them with the project’s test suites.