### PR TITLE
Expose scalar function in api layer

### DIFF
--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -905,6 +905,11 @@ const rows = reader.getRows();
 // [ [ 5 ] ]
 ```
 
+An optional `initFunction` can set state once per DuckDB worker thread with
+`info.setState(...)`. The main function can read that object from `info.state`.
+The init info also exposes the scalar function's client context, bind data, and
+extra info, and can report errors with `info.setError(...)`.
+
 ### Table Functions
 
 ```ts

--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -923,9 +923,19 @@ connection.registerScalarFunction(
       output.flush();
     },
     returnType: INTEGER,
+    volatile: true,
   })
 );
+const reader = await connection.runAndReadAll(
+  'select my_counter() from range(3)'
+);
+const rows = reader.getRows();
+// [ [ 0 ], [ 1 ], [ 2 ] ]
 ```
+
+Marking the function `volatile` is required whenever its result depends on init
+state rather than only on its arguments: without it, DuckDB may treat the call as
+constant and evaluate it just once.
 
 Note that this is per-thread state, unlike a table function's `initData`, which is
 shared across the scan. Init info also exposes the client context, bind data, and

--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -905,10 +905,32 @@ const rows = reader.getRows();
 // [ [ 5 ] ]
 ```
 
-An optional `initFunction` can set state once per DuckDB worker thread with
-`info.setState(...)`. The main function can read that object from `info.state`.
-The init info also exposes the scalar function's client context, bind data, and
-extra info, and can report errors with `info.setError(...)`.
+An optional `initFunction` runs once per DuckDB worker thread, giving each thread
+its own state:
+
+```ts
+connection.registerScalarFunction(
+  DuckDBScalarFunction.create({
+    name: 'my_counter',
+    initFunction: (initInfo) => {
+      initInfo.setState({ next: 0 });
+    },
+    mainFunction: (functionInfo, input, output) => {
+      const state = functionInfo.state as { next: number };
+      for (let rowIndex = 0; rowIndex < input.rowCount; rowIndex++) {
+        output.setItem(rowIndex, state.next++);
+      }
+      output.flush();
+    },
+    returnType: INTEGER,
+  })
+);
+```
+
+Note that this is per-thread state, unlike a table function's `initData`, which is
+shared across the scan. Init info also exposes the client context, bind data, and
+extra info, and reports errors with `setError`. Callbacks are always run on the JS
+thread, so they are serialized even when DuckDB evaluates in parallel.
 
 ### Table Functions
 

--- a/api/src/DuckDBScalarFunction.ts
+++ b/api/src/DuckDBScalarFunction.ts
@@ -1,11 +1,16 @@
 import duckdb from '@duckdb/node-bindings';
 import { DuckDBDataChunk } from './DuckDBDataChunk';
+import { DuckDBScalarFunctionBindInfo } from './DuckDBScalarFunctionBindInfo';
 import { DuckDBScalarFunctionInfo } from './DuckDBScalarFunctionInfo';
+import { DuckDBScalarFunctionInitInfo } from './DuckDBScalarFunctionInitInfo';
 import { DuckDBType } from './DuckDBType';
 import { DuckDBVector } from './DuckDBVector';
-import { DuckDBScalarFunctionBindInfo } from './DuckDBScalarFunctionBindInfo';
 
 export type DuckDBScalarBindFunction = (bindInfo: DuckDBScalarFunctionBindInfo) => void;
+
+export type DuckDBScalarInitFunction = (
+  initInfo: DuckDBScalarFunctionInitInfo,
+) => void;
 
 export type DuckDBScalarMainFunction = (
   functionInfo: DuckDBScalarFunctionInfo,
@@ -23,6 +28,7 @@ export class DuckDBScalarFunction {
   public static create({
     name,
     bindFunction,
+    initFunction,
     mainFunction,
     returnType,
     parameterTypes,
@@ -33,6 +39,7 @@ export class DuckDBScalarFunction {
   }: {
     name: string;
     bindFunction?: DuckDBScalarBindFunction;
+    initFunction?: DuckDBScalarInitFunction;
     mainFunction: DuckDBScalarMainFunction;
     returnType: DuckDBType;
     parameterTypes?: readonly DuckDBType[];
@@ -45,6 +52,9 @@ export class DuckDBScalarFunction {
     scalarFunction.setName(name);
     if (bindFunction) {
       scalarFunction.setBindFunction(bindFunction);
+    }
+    if (initFunction) {
+      scalarFunction.setInitFunction(initFunction);
     }
     scalarFunction.setMainFunction(mainFunction);
     scalarFunction.setReturnType(returnType);
@@ -80,6 +90,12 @@ export class DuckDBScalarFunction {
     duckdb.scalar_function_set_bind(this.scalar_function, (info) => {
       const bindInfo = new DuckDBScalarFunctionBindInfo(info);
       bindFunction(bindInfo);
+    });
+  }
+
+  public setInitFunction(initFunction: DuckDBScalarInitFunction) {
+    duckdb.scalar_function_set_init(this.scalar_function, (info) => {
+      initFunction(new DuckDBScalarFunctionInitInfo(info));
     });
   }
 

--- a/api/src/DuckDBScalarFunctionInfo.ts
+++ b/api/src/DuckDBScalarFunctionInfo.ts
@@ -17,6 +17,12 @@ export class DuckDBScalarFunctionInfo {
   public getExtraInfo(): object | undefined {
     return duckdb.scalar_function_get_extra_info(this.function_info);
   }
+  public get state(): object | undefined {
+    return this.getState();
+  }
+  public getState(): object | undefined {
+    return duckdb.scalar_function_get_state(this.function_info);
+  }
   public setError(error: string) {
     duckdb.scalar_function_set_error(this.function_info, error);
   }

--- a/api/src/DuckDBScalarFunctionInitInfo.ts
+++ b/api/src/DuckDBScalarFunctionInitInfo.ts
@@ -1,0 +1,35 @@
+import duckdb from '@duckdb/node-bindings';
+import { DuckDBClientContext } from './DuckDBClientContext';
+
+export class DuckDBScalarFunctionInitInfo {
+  private readonly init_info: duckdb.ScalarFunctionInitInfo;
+  constructor(init_info: duckdb.ScalarFunctionInitInfo) {
+    this.init_info = init_info;
+  }
+  public get clientContext(): DuckDBClientContext {
+    return this.getClientContext();
+  }
+  public getClientContext(): DuckDBClientContext {
+    return new DuckDBClientContext(
+      duckdb.scalar_function_init_get_client_context(this.init_info),
+    );
+  }
+  public get extraInfo(): object | undefined {
+    return this.getExtraInfo();
+  }
+  public getExtraInfo(): object | undefined {
+    return duckdb.scalar_function_init_get_extra_info(this.init_info);
+  }
+  public get bindData(): object | undefined {
+    return this.getBindData();
+  }
+  public getBindData(): object | undefined {
+    return duckdb.scalar_function_init_get_bind_data(this.init_info);
+  }
+  public setState(state: object) {
+    duckdb.scalar_function_init_set_state(this.init_info, state);
+  }
+  public setError(error: string) {
+    duckdb.scalar_function_init_set_error(this.init_info, error);
+  }
+}

--- a/api/src/duckdb.ts
+++ b/api/src/duckdb.ts
@@ -23,6 +23,7 @@ export * from './DuckDBResultReader';
 export * from './DuckDBScalarFunction';
 export * from './DuckDBScalarFunctionBindInfo';
 export * from './DuckDBScalarFunctionInfo';
+export * from './DuckDBScalarFunctionInitInfo';
 export * from './DuckDBTableFunction';
 export * from './DuckDBTableFunctionBindInfo';
 export * from './DuckDBTableFunctionInfo';

--- a/api/test/scalar-functions.test.ts
+++ b/api/test/scalar-functions.test.ts
@@ -1,5 +1,6 @@
 import { assert, beforeAll, describe, test } from 'vitest';
 import {
+  BIGINT,
   DuckDBValue,
   INTEGER,
   VARCHAR,
@@ -131,6 +132,96 @@ describe('scalar functions', () => {
           })}`,
         ],
       });
+    });
+  });
+
+  test('scalar function (init state)', async () => {
+    await withConnection(async (connection) => {
+      await connection.run('set threads = 1');
+      const extraInfo = { start: 5n };
+      const bindData = { limit: 5005n };
+      let initCalls = 0;
+      let mainCalls = 0;
+      const seenStates = new Set<object>();
+      connection.registerScalarFunction(
+        DuckDBScalarFunction.create({
+          name: 'my_counter',
+          bindFunction: (info) => {
+            info.setBindData(bindData);
+          },
+          initFunction: (info) => {
+            initCalls++;
+            assert.strictEqual(info.extraInfo, extraInfo);
+            assert.strictEqual(info.bindData, bindData);
+            assert.isAbove(info.clientContext.connectionId, 0);
+            info.setState({ next: extraInfo.start });
+          },
+          mainFunction: (info, input, output) => {
+            mainCalls++;
+            const state = info.state as { next: bigint };
+            seenStates.add(state);
+            for (let rowIndex = 0; rowIndex < input.rowCount; rowIndex++) {
+              output.setItem(rowIndex, state.next);
+              state.next++;
+            }
+            output.flush();
+          },
+          returnType: BIGINT,
+          parameterTypes: [BIGINT],
+          volatile: true,
+          extraInfo,
+        }),
+      );
+      const reader = await connection.runAndReadAll(`
+        select count(*) as row_count, min(value) as min_value, max(value) as max_value
+        from (select my_counter(i) as value from range(5000) r(i))
+      `);
+      assert.deepEqual(reader.getRows(), [[5000n, 5n, 5004n]]);
+      assert.equal(initCalls, 1);
+      assert.isAbove(mainCalls, 1);
+      assert.equal(seenStates.size, 1);
+    });
+  });
+
+  test('scalar function (error handling: exception in init func)', async () => {
+    await withConnection(async (connection) => {
+      connection.registerScalarFunction(
+        DuckDBScalarFunction.create({
+          name: 'my_func',
+          initFunction: () => {
+            throw new Error('my_init_error');
+          },
+          mainFunction: (_info, _input, _output) => {},
+          returnType: VARCHAR,
+        }),
+      );
+      try {
+        await connection.run('select my_func()');
+        assert.fail('should throw');
+      } catch (err) {
+        assert.deepEqual(err, new Error('Invalid Input Error: my_init_error'));
+      }
+    });
+  });
+
+  test('scalar function (error handling: setError in init func)', async () => {
+    await withConnection(async (connection) => {
+      connection.registerScalarFunction(
+        DuckDBScalarFunction.create({
+          name: 'my_func',
+          initFunction: (info) => {
+            info.setError('my_init_error');
+          },
+          mainFunction: (_info, _input, _output) => {},
+          returnType: VARCHAR,
+        }),
+      );
+      try {
+        await connection.run('select my_func()');
+        assert.fail('should throw');
+      } catch (err) {
+        assert.deepEqual(err, new Error('Invalid Input Error: my_init_error'));
+      }
     });
   });
 


### PR DESCRIPTION
## Summary

Exposes scalar function initialization through the high-level `@duckdb/node-api` layer, building on the bindings support added in #466.

Closes #380.

## Changes

- Added the `DuckDBScalarFunctionInitInfo` wrapper.
- Added optional `initFunction` support to `DuckDBScalarFunction.create`.
- Added `DuckDBScalarFunction.setInitFunction`.
- Exposed the following initialization data:
  - Client context
  - Bind data
  - Extra info
- Added `setState` and `setError` to scalar init info.
- Added `state` and `getState` to `DuckDBScalarFunctionInfo`.
- Exported the new API types from the package entry point.
- Documented scalar function initialization and per-worker state.
- Added tests covering:
  - Initialization state across multiple execution chunks
  - Bind data, extra info, and client context access
  - State retrieval from the main function
  - Exceptions thrown during initialization
  - Errors reported using `setError`

## Validation

- API TypeScript build passes.
- Full API test suite passes: 164 passed, 1 skipped.
- The C API coverage analyzer confirms that all seven scalar-function initialization bindings are reachable through the API layer.