### PR TITLE
Survey the DuckDB C API V2 ahead of the 2.0 migration

### DIFF
--- a/bindings/scripts/checkFunctionSignatures.mjs
+++ b/bindings/scripts/checkFunctionSignatures.mjs
@@ -4,7 +4,25 @@ import path from 'path';
 function getFunctionSignaturesFromHeader(headerFilePath) {
   const sigs = [];
   const headerContents = fs.readFileSync(headerFilePath, { encoding: 'utf-8' });
-  const sigRegex = /^DUCKDB_C_API (?<sig>([^;]|[\r\n])*);$|^#ifndef (?<startif>DUCKDB_API_NO_DEPRECATED|DUCKDB_NO_EXTENSION_FUNCTIONS)$|^#endif$/gm;
+  // Declarations that are conditionally compiled get stamped with the guard they
+  // sit under, so the header, the type defs and the bindings agree about which
+  // ones are optional.
+  //
+  // The deprecated guard is spelled two ways. Through 1.5.x it is
+  // `#ifndef DUCKDB_API_NO_DEPRECATED`; from 2.0 the same declarations sit under
+  // `#if (DUCKDB_API_VERSION_BELOW(x, y, z) || DUCKDB_API_ALLOW_DEPRECATED)`,
+  // optionally ANDed with a DUCKDB_API_VERSION_AT_LEAST clause. Both are recognized
+  // and both stamp the legacy name, so the `// #ifndef DUCKDB_API_NO_DEPRECATED`
+  // markers in duckdb.d.ts and duckdb_node_bindings.cpp keep matching across the
+  // 2.0 upgrade without being rewritten.
+  //
+  // The negative lookahead skips the preamble that *sets* the switch
+  // (`#if !defined(DUCKDB_API_ALLOW_DEPRECATED)`), which guards a #define rather
+  // than declarations. 2.0 also wraps every declaration in a bare
+  // DUCKDB_API_VERSION_AT_LEAST guard; those are not stamped, and since the header
+  // keeps one guard per declaration rather than nesting them, the trailing #endif
+  // alternative still clears the stamp at the right point.
+  const sigRegex = /^DUCKDB_C_API (?<sig>([^;]|[\r\n])*);$|^#ifndef (?<startif>DUCKDB_API_NO_DEPRECATED|DUCKDB_NO_EXTENSION_FUNCTIONS)$|^#if (?!!defined)(?<startdeprecated>.*\bDUCKDB_API_ALLOW_DEPRECATED\b.*)$|^#endif$/gm;
   var ifndef = undefined;
   var match;
   while (match = sigRegex.exec(headerContents)) {
@@ -12,6 +30,8 @@ function getFunctionSignaturesFromHeader(headerFilePath) {
       sigs.push({ sig: match.groups.sig.replace(/\r\n/gm, ' ').replace(/\n/gm, ' ').replace(/  +/gm, ' '), ...(ifndef ? { ifndef } : {}) });
     } else if (match.groups.startif) {
       ifndef = match.groups.startif;
+    } else if (match.groups.startdeprecated) {
+      ifndef = 'DUCKDB_API_NO_DEPRECATED';
     } else {
       ifndef = undefined;
     }

--- a/tools/capi-coverage/capi_functions.py
+++ b/tools/capi-coverage/capi_functions.py
@@ -56,8 +56,18 @@ def capi_functions(path=None):
   functions = []
   section = None
   group = None
-  # Deprecated declarations sit inside `#ifndef DUCKDB_API_NO_DEPRECATED`. Track the
-  # full #if stack so nested unrelated conditionals pop correctly.
+  # Deprecated declarations sit behind a guard the header spells two ways. Through
+  # 1.5.x it is `#ifndef DUCKDB_API_NO_DEPRECATED`; from 2.0 the same declarations
+  # sit under `#if (DUCKDB_API_VERSION_BELOW(x, y, z) || DUCKDB_API_ALLOW_DEPRECATED)`,
+  # optionally ANDed with a DUCKDB_API_VERSION_AT_LEAST clause. Both forms are
+  # recognized so the flag survives the 2.0 upgrade, and so it keeps coming from the
+  # guard rather than falling through to the doc-comment text below.
+  #
+  # The `defined(` exclusion skips the preamble that *sets* the switch
+  # (`#if !defined(DUCKDB_API_ALLOW_DEPRECATED)` / `#ifdef DUCKDB_API_NO_DEPRECATED`);
+  # those guard a #define, not declarations.
+  #
+  # Track the full #if stack so nested unrelated conditionals pop correctly.
   if_stack = []
   deprecated_depth = 0
 
@@ -67,7 +77,10 @@ def capi_functions(path=None):
     stripped = line.strip()
 
     if stripped.startswith("#if"):
-      is_deprecated_guard = "DUCKDB_API_NO_DEPRECATED" in stripped
+      is_deprecated_guard = "defined(" not in stripped and (
+        stripped.startswith("#ifndef DUCKDB_API_NO_DEPRECATED")
+        or "DUCKDB_API_ALLOW_DEPRECATED" in stripped
+      )
       if_stack.append(is_deprecated_guard)
       if is_deprecated_guard:
         deprecated_depth += 1

--- a/tools/capi-v2/.gitignore
+++ b/tools/capi-v2/.gitignore
@@ -1,0 +1,4 @@
+.headers/
+libduckdb-v2/
+smoke_v2
+__pycache__

--- a/tools/capi-v2/.gitignore
+++ b/tools/capi-v2/.gitignore
@@ -2,3 +2,5 @@
 libduckdb-v2/
 smoke_v2
 __pycache__
+coexist_probe
+coexist_probe.duckdb

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -467,12 +467,15 @@ What this lands on:
   first. Those follow from how the V2 surface is laid out in the bindings package, so this waits on
   that rather than on 2.0.
 - **The signature check could be wired into `pnpm run build` — as a warning, never a failure**
-  (Jeff, 2026-09-05). It only warns today, and nothing invokes it, so a mismatch goes unnoticed. The
-  value of surfacing it during the build is as a reminder to add the accounting placeholders for
-  newly declared functions; the value of *not* failing is that a DuckDB upgrade stays a minimal
-  change — bump the header, add placeholders carrying a `TODO: <area>` reason, implement later. A
-  blocking check would invert that, forcing implementation before the version bump could land. Not
-  scheduled; recorded so the "should it gate CI?" question does not get reopened.
+  (Jeff, 2026-09-05). It only warns today, and nothing invokes it, so a mismatch goes unnoticed.
+
+  A DuckDB version bump is *just* the bump: nothing else is required to land it. If the new version
+  declares functions we have not accounted for, the check starts warning, and it keeps warning until
+  a separate later change adds the `// DUCKDB_C_API …` placeholders with a `TODO: <area>` reason.
+  Implementation is later still. So the warning is not a nag inside one change — it is a reminder
+  that persists across changes until someone picks the work up, which is precisely why it should not
+  fail: a blocking check would drag both of those later steps into the version bump. Not scheduled;
+  recorded so the "should it gate CI?" question does not get reopened.
 - **The fetch scripts need `duckdb_v2.h`.** `fetch_libduckdb_*.py` extracts `duckdb.h` and the
   library from each release zip; the release workflow already zips `duckdb_v2.h` beside `duckdb.h`,
   so this is one more entry in each `files` list.

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -466,9 +466,13 @@ What this lands on:
   `*Sigs.json` files or six, and — if any of those stay shared — which header's declarations come
   first. Those follow from how the V2 surface is laid out in the bindings package, so this waits on
   that rather than on 2.0.
-- **Worth wiring the check into `pnpm run build` while it is being touched.** It only warns and
-  nothing invokes it — not the build, not CI — which is thin cover for a surface about to double.
-  Independent of everything above, and doable now.
+- **The signature check could be wired into `pnpm run build` — as a warning, never a failure**
+  (Jeff, 2026-09-05). It only warns today, and nothing invokes it, so a mismatch goes unnoticed. The
+  value of surfacing it during the build is as a reminder to add the accounting placeholders for
+  newly declared functions; the value of *not* failing is that a DuckDB upgrade stays a minimal
+  change — bump the header, add placeholders carrying a `TODO: <area>` reason, implement later. A
+  blocking check would invert that, forcing implementation before the version bump could land. Not
+  scheduled; recorded so the "should it gate CI?" question does not get reopened.
 - **The fetch scripts need `duckdb_v2.h`.** `fetch_libduckdb_*.py` extracts `duckdb.h` and the
   library from each release zip; the release workflow already zips `duckdb_v2.h` beside `duckdb.h`,
   so this is one more entry in each `files` list.

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -623,6 +623,28 @@ Real choices, deliberately not made yet, each with the thing that should trigger
 | Whether to build the V2 bindings on `duckdb_cpp`, borrow its patterns, or ignore it | `duckdb_cpp` actually shipping in a release; it is not required either way |
 | Whether any conversion helpers are worth keeping native rather than reimplementing in TypeScript | Only if upstream ships some after all — otherwise TypeScript, which is the better choice regardless |
 
+## When 2.0 ships
+
+Everything here was measured on 2026-09-05 against a branch all three PRs describe as still moving.
+Before acting on any of it:
+
+1. **Re-run `compare_api.py --fetch`** and compare against the counts in this document — 546 V1
+   shipped, 548 V1 on branch, 527 V2, 314 exposed. Read the V1 drift block first: it should still say
+   0 removed, 2 added, 13 signature changes. Anything else there changes the headline finding.
+2. **Point `fetch_libduckdb_*.py` at the release and add `duckdb_v2.h` to each `files` list.** The
+   release zips carry both headers — verified from `.github/workflows/Main.yml`, which zips
+   `duckdb_v2.h` beside `duckdb.h`. `fetch_libduckdb_v2.py` here is preview-only, since the preview
+   ships tarballs rather than zips, and can be retired at that point.
+3. **Regenerate the three `*Sigs.json` files.** The guard handling is already 2.0-ready, so the only
+   diff should be the 2 added functions and the 13 `()` → `(void)` edits. Anything beyond that is
+   worth reading before accepting.
+4. **Re-check the three things the team hedged on**: whether any conversion helpers shipped after all
+   (the header had none, and no `static inline` helpers at all), whether `duckdb_cpp.hpp` *and*
+   `duckdb_cpp.cpp` are in the release artifacts, and whether V1's deprecation is the compile switch
+   this document predicts rather than an attribute.
+5. **Re-read the V2 module list.** V2 grew across three PRs and more were expected, so new modules
+   are likelier than changed ones — and a new module may close a gap this document records as open.
+
 ## Deprecation is a compile switch, not a warning
 
 Answered from the headers rather than by asking. 2.0's V1 header expresses deprecation as

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -37,6 +37,11 @@ cd tools/capi-v2 && cc -std=c11 -I libduckdb-v2 smoke_v2.c -L libduckdb-v2 -lduc
     -Wl,-rpath,@loader_path/libduckdb-v2 -o smoke_v2 && ./smoke_v2
 ```
 
+`smoke_v2.c` opens an in-memory database, runs a query and reads a chunk back through V2 — the
+shortest illustration of the calling convention the bindings have to adopt. `coexist_probe.c`
+builds the same way, and checks whether one database file opened through both V1 and V2 is
+detected.
+
 ## Headline findings
 
 **V1 survives 2.0 intact.** Comparing the V1 header we build against with the V1 header on the
@@ -47,9 +52,11 @@ V1 symbols alongside all 527 V2 symbols from one library. So DuckDB 2.0 is not a
 migration, and V1 and V2 can be mixed within one addon — which makes an incremental,
 module-by-module migration possible rather than a big-bang rewrite.
 
-The one thing that does break on day one is our own signature check: `checkFunctionSignatures.mjs`
-compares declaration text exactly, so those thirteen `(void)` edits will fail the build until
-`bindingsSigs.json` / `headerSigs.json` / `typeDefsSigs.json` are regenerated.
+The one thing that notices is our own signature check: `checkFunctionSignatures.mjs` compares
+declaration text exactly, so those thirteen `(void)` edits make it report a mismatch until
+`bindingsSigs.json` / `headerSigs.json` / `typeDefsSigs.json` are regenerated. It warns rather than
+exits non-zero, and nothing invokes it — not `pnpm run build`, not CI — so this is a manual step
+that will not announce itself.
 
 **The preview binaries exist, under a different naming scheme.** The install page only links the
 CLI, and `duckdb-binaries-<platform>.zip` (the 1.4/1.5 preview convention) 404s for
@@ -407,25 +414,107 @@ Ordered by what it would cost us:
 - `column_data_collection` — build a set of chunks and register it as a table via a replacement
   scan. Not an appender, but a bulk-load path with no V1 equivalent.
 
+## Migration approach
+
+Decided (Jeff, 2026-09-05). This settles the first two of the open questions below; the third stays
+open.
+
+### Bindings: V2 alongside V1, in the same package and binary
+
+`@duckdb/node-bindings` gains the V2 surface next to the V1 one, in the same addon. One `libduckdb`
+already exports both symbol sets, so this needs no second binary and no second native package. V1
+goes away only if and when the C API deprecates it, which is not expected soon.
+
+What this lands on:
+
+- **The accounting convention extends to V2.** Every C API function appears in
+  `duckdb_node_bindings.cpp` and `duckdb.d.ts` as a `// DUCKDB_C_API …` block followed by an
+  implementation or a reason. V2 declarations get the same treatment. Since every V2 name is
+  prefixed `duckdb_v2_`, the two surfaces separate cleanly by name — `capi-coverage/node_neo.py`
+  and `build_coverage.py` intersect against the canonical V1 list and are unaffected.
+- **`checkFunctionSignatures.mjs` needs to become two-header aware.** It reads one header, one
+  `.d.ts` and one `.cpp`, and compares the three lists for exact equality; a second header's worth of
+  declarations in the latter two would read as a mismatch. Worth wiring into `pnpm run build` at the
+  same time — it currently only warns, and nothing runs it, which is a thin guard for a surface that
+  is about to double.
+- **The fetch scripts need `duckdb_v2.h`.** `fetch_libduckdb_*.py` extracts `duckdb.h` and the
+  library from each release zip; the release workflow already zips `duckdb_v2.h` beside `duckdb.h`,
+  so this is one more entry in each `files` list.
+
+### Bindings shape: near 1:1, deviating where the language demands
+
+Same principle as V1 — mirror the C API, and deviate only for memory management, error handling and
+out parameters, as the V1 mapping already does. The places where "as feasible" will be tested:
+
+- **Multiple out-params.** V1's out-params are nearly all single, and collapse to a return value.
+  V2 has calls that produce two: `statement_bind` yields both a result schema and a parameter
+  schema, `result_step` yields both a chunk and a status. These need an object return, which is a
+  new shape for the bindings.
+- **Owned versus borrowed.** V2 documents this per out-param and enforces it — destroying a
+  borrowed handle aborts. So ownership becomes a property the accounting has to record per function,
+  since it decides whether the external gets a finalizer at all, and borrowed handles need their
+  parent pinned for their lifetime.
+- **The `_with_connection` / `_with_context` pairs.** 37 value constructors exist in both forms, and
+  the same split runs through data chunks, column data collections and the type constructors. A 1:1
+  mapping exposes both; whether the TS layer keeps them as two functions or one with a union-typed
+  first argument is the first real judgement call.
+- **`create_environment`.** The header says "call once at program start," which reads like
+  addon-owned state rather than something a caller threads through every open. V1 has one precedent
+  for this shape — `duckdb_open` is marked *consolidated into open* — so there is a convention to
+  follow either way.
+
+### API: one package, V2 classes under a `v2` subpath
+
+`@duckdb/node-api` gains a second set of classes for V2, exported from a `v2` path alongside the
+existing ones. Rejected alternatives: a separate `@duckdb/node-api-v2` package, which is
+unnecessary weight and would stop a consumer migrating one call site at a time; and reimplementing
+the existing V1 classes over the V2 bindings, which the differences between the two C APIs would
+make awkward — the survey's §8, §9 and §10 are the reason.
+
+Note that neither package has an `exports` map today; both use plain `main`/`types`. Adding one to
+get `@duckdb/node-api/v2` also closes the package, so any consumer currently deep-importing
+`@duckdb/node-api/lib/…` would break unless `./lib/*` is mapped through deliberately.
+
+### One hazard that partial migration creates
+
+Because the point of a `v2` subpath is to let a consumer migrate incrementally, both APIs will run
+in one process — and a database file opened through both is **not** detected. Measured against the
+preview build:
+
+```
+v1 open:                 ok
+v1 open again:           ok (no conflict reported)
+v2 open same file:       ok (NOT detected)
+v2 open twice (control): refused with RESOURCE_IN_USE (code 3001)
+```
+
+(`coexist_probe.c`, run against the preview build.)
+
+V2 detects its own double-open, because `duckdb_v2_open` rejects a file "already open under the same
+environment" — but a V1 database of the same file is not under that environment, and V1's own
+deduplication only happens through an explicit instance cache. So this is not a regression; it is a
+pre-existing footgun that partial migration makes much easier to reach, since the two halves of one
+app would each naturally open "their" database. Question 5 below.
+
 ## Open questions
 
 For us:
 
-1. Incremental or all-at-once? Both surfaces are in one library, so per-module migration behind a
-   stable `duckdb.d.ts` is possible — but mixed ownership models in one addon is its own risk.
-2. Does `@duckdb/node-bindings` stay a 1:1 C API mirror? V2's shape (out-params, error handles,
-   borrowed views) is further from idiomatic TypeScript than V1's, so a literal mirror may be the
-   wrong target for the first time.
-3. What replaces `DuckDBMaterializedResult` when every result is a live cursor holding a
-   transaction open?
+1. What replaces `DuckDBMaterializedResult` when every result is a live cursor holding a
+   transaction open? The V2 classes need an answer before the first of them is written.
+2. Do the `_with_connection` / `_with_context` pairs stay two functions in TypeScript, or collapse
+   into one with a union-typed first argument?
 
 For the DuckDB team:
 
-4. Is `duckdb_cpp.hpp` going to be shipped in the release headers? It is referenced in all three
+3. Is `duckdb_cpp.hpp` going to be shipped in the release headers? It is referenced in all three
    PRs but is not in `src/include/` on the branch. As a C++ addon we would rather consume that
    than hand-roll RAII over the C surface.
-5. Is an appender planned for V2, or is `column_data_collection` the intended replacement? If the
+4. Is an appender planned for V2, or is `column_data_collection` the intended replacement? If the
    latter, what is the intended path for appending to an *existing* table?
+5. Should a V2 environment and V1's instance cache share a file registry? Opening one file through
+   both APIs in one process is currently undetected (see above), and a client shipping both
+   surfaces at once cannot fix that from its side.
 6. Are the date/time/decimal/hugeint conversion helpers intentionally omitted?
 7. Is V1 expected to stay supported through the 2.x line, or is 2.0 the start of a deprecation
    window?

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -87,11 +87,14 @@ around new call sequences, and a third has no counterpart yet.
 **The appender is not in V2, and is not coming.** Node Neo exposes 31 appender functions and both
 packages have appender APIs and test suites. Nothing in `duckdb_v2.h` matches, and per the DuckDB
 team (maxxen, 2026-09-05) that is deliberate: "probably not, this can now be implemented client-side
-using columndatacollections and replacement scans/table functions." So this becomes work we own — a
-V2 `DuckDBAppender` built on `column_data_collection` plus `replacement_scan_set_collection`, rather
-than a thin wrapper over C functions. Note the shape difference that makes it more than a rename: a
-collection surfaced through a replacement scan is a *virtual table*, so appending to an *existing*
-table means an `INSERT INTO … SELECT * FROM` over it, not a direct append.
+using columndatacollections and replacement scans/table functions."
+
+So bulk append becomes ours to design rather than to wrap. The goal is the *scenario* — efficient
+bulk append — not the V1 shape: an explicit appender class is one option, helpers that drive an
+`INSERT INTO … SELECT * FROM` over a replacement-scanned collection are another, and that choice
+belongs to whoever builds this part of the V2 API rather than to this survey. Worth knowing going in:
+a collection surfaced through a replacement scan is a *virtual table*, which is why appending to an
+*existing* table is a statement rather than a direct append.
 
 **One class of hazard in our function-info handling goes away.** V2 gives every function family its
 own info-handle type (`duckdb_v2_scalar_function_bind_info_handle`,
@@ -398,7 +401,8 @@ Function registration also picks up a `function_signature` object (`add_paramete
 Ordered by what it would cost us:
 
 - **Appender** (31 exposed functions, `DuckDBAppender.ts`, two test suites). No counterpart, and
-  none planned — see the headline finding. We reimplement it over `column_data_collection`.
+  none planned — see the headline finding. The bulk-append scenario is ours to cover, in whatever
+  shape suits.
 - **Date / time / timestamp / hugeint / decimal conversion helpers** (19 exposed functions, all of
   them). `duckdb_from_date`, `duckdb_to_timestamp`, `duckdb_double_to_decimal` and the rest have no
   V2 equivalent, and still none as of the latest branch fetch — the header contains no `static
@@ -406,7 +410,8 @@ Ordered by what it would cost us:
   functions", and expects clients to implement them, though some may yet ship as inline functions in
   the header or as documentation (maxxen, 2026-09-05, hedged — worth re-checking near release). For
   us these are pure computation over plain structs, so TypeScript implementations are
-  straightforward, and would remove 19 native round-trips in the process.
+  straightforward, and would remove 19 native round-trips in the process. Not a concern: they were
+  exposed in V1 because they were in the C API, not because a native implementation was wanted.
 - **`duckdb_vector_size`**, and the malloc/free helpers.
 - **Profiling info** (not exposed today).
 - **Task / threading control** — `duckdb_execute_tasks` and friends (not exposed today).
@@ -520,8 +525,10 @@ Two things to know before planning around it:
   builds against `node_addon_api_except_all`, so C++ exceptions are enabled and the addon already
   converts them at the boundary. No build-configuration change needed.
 
-Not a decision yet — it turns on the tarball question below. Worth settling before the V2 bindings
-are far along, since retrofitting is more work than starting on it.
+Not required, and not a decision to make now: it is only worth evaluating once the thing actually
+ships. The outcome may well be that we borrow its patterns — the RAII shapes, the way it models
+owned versus borrowed — and roll our own, which costs nothing to decide late. If we do want to
+consume it directly, the tarball has to carry both files.
 
 ### Results: no materialized result class
 
@@ -588,20 +595,34 @@ Asked 2026-09-05; answered by maxxen the same day. Paraphrased, with what each o
 | Will V1 be deprecated and retired? When? | "v1 will be deprecated in 2.0, and probably removed entirely in 3.0 (likely another year out)." | Side-by-side is a ~1-year window, not indefinite. |
 | Will `duckdb_cpp` ship in 2.0? | Currently core-repo only; "most likely" added to the release tarballs soon, plus a proper CMake module for `FetchContent`. | Promising but uncommitted, and the CMake half does not help node-gyp. |
 
-## Open questions
+## The scope target
 
-Follow-ups these answers raise, roughly in the order they will matter:
+Everything Node Neo exposes through V1 today should be reachable through the V2 API well before V1
+is removed in 3.0 (Jeff, 2026-09-05). Not a 3.0 problem to plan around now — a definition of done
+for the V2 API.
 
-1. **Will the release tarball ship `duckdb_cpp.cpp`, not just `duckdb_cpp.hpp`?** The API is
-   header-plus-source, and node-gyp cannot consume the planned CMake module. Both files in the
-   tarball is what we need. *(DuckDB team.)*
-2. **Is 2.0's V1 deprecation documentation, or `DUCKDB_DEPRECATED` attributes on the declarations?**
+Concretely that is the 314 exposed V1 functions plus the API classes over them. Parity is not
+function-for-function, though, because the two surfaces do not correspond one to one: 30 V1 logical
+type accessors collapse into 5 V2 calls, 25 bind functions become one parameter array, 8 pending
+functions become `result_step`. The [coverage table](#the-two-surfaces-side-by-side) above is the checklist that
+survives that — every V1 group with something in the "in Neo" column needs its scenario answered in
+V2, whether by a mapped call, a restructured one, or something we build (the appender being the
+clearest case of the last).
+
+`compare_api.py` is the natural place to measure that as the V2 bindings land.
+
+## Deferred decisions
+
+Real choices, deliberately not made yet, each with the thing that should trigger it:
+
+| Decision | Trigger |
+|---|---|
+| What shape bulk append takes — an appender class, or helpers driving `INSERT INTO … SELECT * FROM` over a replacement-scanned collection | Building that part of the V2 API |
+| Whether to build the V2 bindings on `duckdb_cpp`, borrow its patterns, or ignore it | `duckdb_cpp` actually shipping in a release; it is not required either way |
+| Whether any conversion helpers are worth keeping native rather than reimplementing in TypeScript | Only if upstream ships some after all — otherwise TypeScript, which is the better choice regardless |
+
+## Still open
+
+1. **Is 2.0's V1 deprecation documentation, or `DUCKDB_DEPRECATED` attributes on the declarations?**
    If the latter, our build starts emitting a warning per V1 call — 314 of them — the moment we
-   upgrade, which is worth knowing before it happens rather than after. *(DuckDB team.)*
-3. **Which conversion helpers, specifically, survive?** The answer was hedged; the current header has
-   none, and no `static inline` helpers at all. Determines how much we reimplement. *(DuckDB team.)*
-4. **Do we build the V2 bindings on `duckdb_cpp` or on the raw C surface?** Turns on question 1.
-   Worth settling early — retrofitting is more work than starting on it. *(Us.)*
-5. **How much of the V2 API has to exist before 3.0?** Consumers need to finish migrating inside the
-   window, which makes the appender reimplementation and anything else V1-only into scheduled work
-   rather than open-ended. *(Us.)*
+   upgrade. Cheap to ask, unpleasant to discover. *(DuckDB team.)*

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -456,13 +456,19 @@ What this lands on:
   implementation or a reason. V2 declarations get the same treatment. Since every V2 name is
   prefixed `duckdb_v2_`, the two surfaces separate cleanly by name — `capi-coverage/node_neo.py`
   and `build_coverage.py` intersect against the canonical V1 list and are unaffected.
-- **`checkFunctionSignatures.mjs` needs to become two-header aware** — and its guard tracking needs
-  updating regardless of V2, because the 2.0 V1 header rewrote those guards; see
-  [Deprecation is a compile switch](#deprecation-is-a-compile-switch-not-a-warning). It reads one
-  header, one `.d.ts` and one `.cpp`, and compares the three lists for exact equality; a second
-  header's worth of declarations in the latter two would read as a mismatch. Worth wiring into
-  `pnpm run build` at the same time — it currently only warns, and nothing runs it, which is a thin
-  guard for a surface that is about to double.
+- **`checkFunctionSignatures.mjs` still needs to become two-header aware.** Its guard tracking is
+  already done — see [Deprecation is a compile switch](#deprecation-is-a-compile-switch-not-a-warning)
+  — but that was the V1-side half. The script still hardcodes one header
+  (`libduckdb/duckdb.h`), one `.d.ts` and one `.cpp`, and compares the three lists for *exact ordered
+  equality*. Reading `duckdb_v2.h` too is the easy part; the part that cannot be settled yet is where
+  the V2 accounting lives, because ordered equality means the answer has to be decided rather than
+  guessed: one `duckdb.d.ts` carrying both surfaces or a second file, one `.cpp` or two, three
+  `*Sigs.json` files or six, and — if any of those stay shared — which header's declarations come
+  first. Those follow from how the V2 surface is laid out in the bindings package, so this waits on
+  that rather than on 2.0.
+- **Worth wiring the check into `pnpm run build` while it is being touched.** It only warns and
+  nothing invokes it — not the build, not CI — which is thin cover for a surface about to double.
+  Independent of everything above, and doable now.
 - **The fetch scripts need `duckdb_v2.h`.** `fetch_libduckdb_*.py` extracts `duckdb.h` and the
   library from each release zip; the release workflow already zips `duckdb_v2.h` beside `duckdb.h`,
   so this is one more entry in each `files` list.
@@ -667,22 +673,26 @@ New in 2.0's V1 header: **every** declaration is now wrapped in a
 how a consumer pins an older surface, and it is the likeliest shape for V1's own retirement: a switch
 to flip, not a diagnostic to suppress.
 
-### Two consequences for our tooling
+### Two consequences for our tooling — both now handled
 
-The guard rewrite is invisible at the C level and load-bearing for the two things that parse these
-headers:
+The guard rewrite is invisible at the C level and was load-bearing for the two things that parse
+these headers. Both were fixed in this branch; recorded here because the reasoning is not obvious
+from the diff.
 
-1. **`checkFunctionSignatures.mjs` needs its guard tracking updated.** It recognizes exactly
+1. **`checkFunctionSignatures.mjs` guard tracking.** It recognized exactly
    `#ifndef DUCKDB_API_NO_DEPRECATED` and `#ifndef DUCKDB_NO_EXTENSION_FUNCTIONS`, and stamps each
    extracted signature with an `ifndef` field. The 1.5.5 header has 9 such blocks; the 2.0 header has
-   1, in the preamble, and guards declarations with `#if DUCKDB_API_VERSION_AT_LEAST(…)` instead. So
-   header signatures come out unstamped while the accounting comments in `duckdb_node_bindings.cpp`
-   and `duckdb.d.ts` still carry their `// #ifndef DUCKDB_API_NO_DEPRECATED` markers — a mismatch on
-   top of the thirteen `(void)` edits, and one that regenerating the `*Sigs.json` files alone will
-   not settle.
-2. **`capi-coverage`'s deprecated flag is now resting on prose.** `capi_functions.py` derives it from
+   1, in the preamble, and guards declarations with `#if DUCKDB_API_VERSION_AT_LEAST(…)` instead — so
+   header signatures came out unstamped while the accounting comments in `duckdb_node_bindings.cpp`
+   and `duckdb.d.ts` still carried their `// #ifndef DUCKDB_API_NO_DEPRECATED` markers, a mismatch on
+   top of the thirteen `(void)` edits that regenerating the `*Sigs.json` files alone would not have
+   settled. It now accepts both spellings and stamps both with the legacy name, so those markers need
+   no rewriting. Note this is only the V1-side fix: making the script read `duckdb_v2.h` as well is
+   still outstanding, and is discussed under [Migration approach](#migration-approach).
+2. **`capi-coverage`'s deprecated flag was resting on prose.** `capi_functions.py` derives it from
    three signals: guard depth, `DEPRECATION NOTICE` in the doc comment, and `**DEPRECATED**`. Against
-   the 2.0 header the guard signal contributes nothing, and the doc-text fallback carries all 48 on
-   its own. It still reports exactly the same 48 functions, so nothing is broken — but it is right
-   for the wrong reason, and would silently drop to zero if that prose were ever reworded. Worth
-   teaching it the new guard form while the reason is fresh.
+   the 2.0 header the guard signal contributed nothing, and the doc-text fallback carried all 48 on
+   its own — the same 48, so nothing was broken, but right for the wrong reason, and it would have
+   dropped to zero silently if that prose were ever reworded. It now recognizes the new guard form
+   too, so the guard carries all 48 against both headers and the fallback is back to being a
+   fallback.

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -1,0 +1,431 @@
+# DuckDB C API V2: survey and comparison with V1
+
+Working notes for migrating Node Neo to the C API that ships with DuckDB 2.0. Nothing here
+is a commitment; this is the fact-finding pass that a migration plan gets built on.
+
+Sources, as of 2026-09-05:
+
+- `duckdb_v2.h` on the [`v2.0-cyanoptera`](https://github.com/duckdb/duckdb/tree/v2.0-cyanoptera)
+  branch — 12,811 lines, 527 functions.
+- `duckdb.h` on the same branch — the V1 surface as it will ship in 2.0.
+- `bindings/libduckdb/duckdb.h` — the V1 surface Node Neo builds against today (DuckDB 1.5.5).
+- The three PRs that landed V2: [#24702](https://github.com/duckdb/duckdb/pull/24702) (part 1:
+  errors, environment, database, connection, context, SQL statements, streaming results, logical
+  types, values, data chunks, vectors), [#25184](https://github.com/duckdb/duckdb/pull/25184)
+  (part 2: scalar and aggregate functions, column data collections),
+  [#25340](https://github.com/duckdb/duckdb/pull/25340) (part 3: table, copy and cast functions,
+  file system, replacement scans, arrow, catalog, logging).
+
+Both PR descriptions carry the same caveat — nothing is set in stone, more follow-ups are
+expected — so treat every count below as a snapshot. `compare_api.py` re-derives all of them
+from the headers.
+
+Companion to [`../capi-coverage`](../capi-coverage/README.md), which measures Node Neo against the
+other five C-API clients. `compare_api.py` reuses that tool's `capi_functions.py` (the canonical
+V1 function list) and `node_neo.py` (our exposure of it, and the recorded reason for each
+non-exposure), so the two cannot drift apart on the V1 side. What is new here is parsing
+`duckdb_v2.h` — which groups functions under `MODULE:` banners rather than V1's `//----` rules —
+and diffing the V1 surface against itself across the 2.0 boundary.
+
+## Reproducing this
+
+```bash
+python3 tools/capi-v2/compare_api.py --fetch   # pull duckdb.h + duckdb_v2.h from the branch
+python3 tools/capi-v2/compare_api.py           # print the comparison report
+python3 tools/capi-v2/fetch_libduckdb_v2.py    # pull the 2.0 preview library for this platform
+cd tools/capi-v2 && cc -std=c11 -I libduckdb-v2 smoke_v2.c -L libduckdb-v2 -lduckdb \
+    -Wl,-rpath,@loader_path/libduckdb-v2 -o smoke_v2 && ./smoke_v2
+```
+
+## Headline findings
+
+**V1 survives 2.0 intact.** Comparing the V1 header we build against with the V1 header on the
+2.0 branch: zero functions removed, two added (`duckdb_create_timestamp_tz_ns`,
+`duckdb_get_timestamp_tz_ns`), and thirteen "signature changes" that are all the cosmetic
+`()` → `(void)`. Nothing is marked `DUCKDB_DEPRECATED`. The preview `libduckdb` exports all 546
+V1 symbols alongside all 527 V2 symbols from one library. So DuckDB 2.0 is not a forced
+migration, and V1 and V2 can be mixed within one addon — which makes an incremental,
+module-by-module migration possible rather than a big-bang rewrite.
+
+The one thing that does break on day one is our own signature check: `checkFunctionSignatures.mjs`
+compares declaration text exactly, so those thirteen `(void)` edits will fail the build until
+`bindingsSigs.json` / `headerSigs.json` / `typeDefsSigs.json` are regenerated.
+
+**The preview binaries exist, under a different naming scheme.** The install page only links the
+CLI, and `duckdb-binaries-<platform>.zip` (the 1.4/1.5 preview convention) 404s for
+`v2.0-cyanoptera`. The libraries are published as tarballs instead:
+
+```
+https://artifacts.duckdb.org/v2.0-cyanoptera/duckdb-shared-libs-<suffix>.tar.gz
+```
+
+All seven suffixes Node Neo targets are live: `osx-universal`, `linux-amd64`, `linux-arm64`,
+`linux-amd64-musl`, `linux-arm64-musl`, `windows-amd64`, `windows-arm64`. Each tarball contains
+`libduckdb.{dylib,so,dll}`, `duckdb.h`, `duckdb_v2.h`, `duckdb_extension.h` and
+`duckdb_extension_v2.h`. `fetch_libduckdb_v2.py` fetches one; it is deliberately separate from
+`bindings/scripts/fetch_libduckdb_*.py`, which points at GitHub releases and cannot reach these.
+Note the shape difference — tarball, not zip, and no `libduckdb/` prefix inside — so the existing
+fetch scripts need more than a URL swap when 2.0 releases. The release workflow already zips
+`duckdb_v2.h` next to `duckdb.h`, so the final release artifacts will carry both headers.
+
+**V2 is a redesign, not a rename.** Function-by-function translation does not exist for most of
+the surface. Roughly: a third of what Node Neo uses maps mechanically, a third needs restructuring
+around new call sequences, and a third has no counterpart yet.
+
+**The appender is not in V2.** Node Neo exposes 31 appender functions and both packages have
+appender APIs and test suites. Nothing in `duckdb_v2.h` matches. `column_data_collection` plus
+`replacement_scan_set_collection` covers bulk data creation, but not "insert these rows into an
+existing table", which is what the appender is for.
+
+**One class of hazard in our function-info handling goes away.** V2 gives every function family its
+own info-handle type (`duckdb_v2_scalar_function_bind_info_handle`,
+`duckdb_v2_table_function_exec_info_handle`, and so on), where V1 shares one `duckdb_function_info`
+across all of them. `type_tags.h` stays either way — a tag is the only thing that distinguishes one
+`Napi::External` from another at runtime — but the six function-info tags stop carrying extra load;
+see §12. And a `duckdb_cpp.hpp` "stable C++ API" over V2 is mentioned in all three PRs; it
+is not in `src/include/` on the branch and is not in the packaged headers, but as a C++ N-API
+addon we would be its natural consumer, so it is worth asking about before hand-writing RAII
+wrappers over the C surface.
+
+## The two surfaces, side by side
+
+| | V1 (1.5.5) | V1 (on 2.0) | V2 |
+|---|---:|---:|---:|
+| Functions | 546 | 548 | 527 |
+| Exposed by Node Neo | 314 | — | — |
+
+Node Neo's V1 coverage, by header section — this is the actual migration surface, not the 546:
+
+| V1 group | total | in Neo | V2 status |
+|---|---:|---:|---|
+| Open Connect | 17 | 12 | restructured (environment is new and mandatory) |
+| Configuration | 5 | 4 | restructured (`option` handles; enumeration now needs a database) |
+| Error Data | 5 | 0 | replaced by `error_info` |
+| Query Execution | 18 | 12 | restructured (parse → iterate → bind → execute → step) |
+| Safe Fetch Functions | 24 | 0 | gone (was deprecated) |
+| Helpers | 7 | 1 | mostly gone (no `duckdb_vector_size`, no malloc/free) |
+| Date Time Timestamp Helpers | 13 | 13 | **absent** |
+| Hugeint and Uhugeint Helpers | 4 | 4 | **absent** |
+| Decimal Helpers | 2 | 2 | **absent** |
+| Prepared Statements | 13 | 12 | restructured (4 functions; metadata moved to `schema`) |
+| Bind Values to Prepared Statements | 25 | 24 | replaced by parameter arrays at execute time |
+| Execute Prepared Statements | 2 | 2 | `prepared_statement_execute` |
+| Extract Statements | 4 | 3 | replaced by `parse_sql` + statement iterator |
+| Pending Result Interface | 8 | 7 | replaced by `result_step` + `result_wait` |
+| Value Interface | 77 | 74 | present, but every constructor needs a connection or context |
+| Logical Type Interface | 30 | 28 | collapsed into generic construct-by-name/id/text + `get_param` |
+| Data Chunk Interface | 7 | 6 | close mapping |
+| Vector Interface | 19 | 14 | restructured around `vector_view` |
+| Validity Mask Functions | 4 | 4 | `vector_flat_get_validity_mutable` + `vector_set_null` |
+| Scalar Functions | 33 | 26 | close mapping, per-phase info handles |
+| Selection Vector Interface | 3 | 0 | folded into `vector_view.sel` |
+| Aggregate Functions | 16 | 0 | present (49 functions) |
+| Table Functions (+ Bind/Init/exec) | 33 | 33 | close mapping, plus filter and projection pushdown |
+| Replacement Scans | 4 | 0 | present (15 functions) |
+| Profiling Info | 5 | 0 | **absent** |
+| Appender | 40 | 31 | **absent** |
+| Table Description | 8 | 0 | present as `catalog` |
+| Arrow Interface | 19 | 0 | present, redesigned (importer/exporter) |
+| Threading Information | 8 | 0 | **absent** |
+| Streaming Result Interface | 2 | 1 | subsumed — every result streams |
+| Cast Functions | 12 | 0 | present |
+| Expression Interface | 4 | 0 | present (9 functions) |
+| File System Interface | 16 | 0 | present |
+| Config Options Interface | 9 | 0 | folded into `option` |
+| Copy Functions | 36 | 0 | present (72 functions) |
+| Catalog Interface | 7 | 0 | present |
+| Logging | 6 | 0 | reduced to `context_log` |
+| Geometry Helpers | 1 | 1 | folded into logical type params |
+
+## Taxonomy of differences
+
+### 1. Naming
+
+Every function is `duckdb_v2_*`; every type is `duckdb_v2_*_handle`; every enum is
+`DUCKDB_V2_*`. Mechanical, but it means V1 and V2 can coexist in one translation unit, which is
+what makes incremental migration viable.
+
+### 2. Return convention
+
+Everything returns a status. Products go to out-params.
+
+```c
+/* V1 */ duckdb_logical_type duckdb_create_list_type(duckdb_logical_type type);
+/* V1 */ idx_t               duckdb_column_count(duckdb_result *result);
+/* V1 */ duckdb_state        duckdb_query(duckdb_connection, const char *, duckdb_result *);
+
+/* V2 */ DUCKDB_V2_ERROR duckdb_v2_schema_get_count(
+             duckdb_v2_schema_handle schema, idx_t *out_count, duckdb_v2_error_info_handle *err);
+```
+
+This affects essentially all 314 call sites in `duckdb_node_bindings.cpp`. It is the single
+largest mechanical cost of the migration, and it is exactly the kind of boilerplate a
+`duckdb_cpp.hpp` (or our own wrapper) would absorb.
+
+### 3. Error reporting
+
+V1 has three mechanisms — `duckdb_state`, `duckdb_result_error`/`duckdb_appender_error` per
+object, and the 1.5-era `duckdb_error_data`. Node Neo implements none of the third and reads
+errors off each object.
+
+V2 has one: a `DUCKDB_V2_ERROR` code plus an optional `duckdb_v2_error_info_handle` written to a
+trailing `err` out-param, which the caller owns and destroys. The codes are a real taxonomy
+(`IO_FILE_NOT_FOUND`, `INPUT_OUT_OF_RANGE`, `RESOURCE_IN_USE`, `TYPE_CONVERSION`, `QUERY_BINDER`,
+…) rather than `DuckDBSuccess`/`DuckDBError`, and `error_info_get_text` /
+`error_info_get_raw_message` split the formatted message from the raw one.
+
+Upside for the API package: `DuckDBError` could finally carry a typed code instead of a string.
+
+### 4. Strings
+
+V1 returns `const char *` (borrowed) or `char *` (owned, freed with `duckdb_free`), and takes
+null-terminated input.
+
+V2 uses `duckdb_v2_str { const char *ptr; idx_t len; }` — a borrowed view, never owning,
+explicitly not null-terminated and possibly containing interior nulls. `duckdb_v2_identifier_t`
+is the same layout, tagging a string as a case-insensitively-matched SQL identifier.
+
+For rendering, V2 uses caller-supplied buffers with a size-query pass:
+`logical_type_to_text(type, NULL, 0, &length, err)` reports the length,
+`logical_type_to_text(type, buf, capacity, &length, err)` writes it. Nothing is allocated on the
+caller's behalf.
+
+This is a good fit for N-API — `Napi::String::New(env, ptr, len)` is a direct match, and it
+removes our `duckdb_free` bookkeeping — but every string-handling helper in
+`conversion_helpers.h` needs rewriting.
+
+Separately, `duckdb_v2_bytes` is the transparent 16-byte in-vector storage for VARCHAR / BLOB /
+BIT / BIGNUM, replacing `duckdb_string_t` and its `duckdb_string_is_inlined` /
+`duckdb_string_t_data` accessors with directly-readable union fields.
+
+### 5. Ownership
+
+V1's convention is implicit and per-function. V2 documents owned versus borrowed on every
+out-param, and the distinction is enforced: `schema_get_field` hands back a **borrowed** logical
+type that must not be destroyed, while `logical_type_get_param` hands back an **owned** value that
+must be. Getting this wrong aborts the process — the first draft of `smoke_v2.c` did exactly that.
+
+`externals.h` currently attaches a finalizer per external. Under V2 that model needs to know, per
+handle, whether this particular handle owns its resource, and borrowed handles need their parent's
+lifetime pinned. This is the subtlest part of the migration and the easiest to get quietly wrong.
+
+### 6. New required root: the environment
+
+```c
+duckdb_v2_create_environment(&env, &err);
+duckdb_v2_open(env, path, options, option_count, &db, &err);
+```
+
+There is no `duckdb_v2_open` without an environment. Databases under one environment share a
+cache, so the environment subsumes `duckdb_instance_cache` — which has no V2 counterpart — and
+makes what was opt-in (`DuckDBInstanceCache`) structural. Destroying an environment while a
+database is still open returns `ERROR_RESOURCE_IN_USE`.
+
+### 7. Configuration
+
+V1: build a `duckdb_config` blob of string key/value pairs, pass it to `duckdb_open_ext`.
+
+V2: build individual `duckdb_v2_option_handle`s and pass an array to `duckdb_v2_open`; set them
+later per-database (`database_option_set`) or per-connection with a scope
+(`connection_option_set(conn, option, scope, err)`). An option handle resolved through a get also
+carries description, default, target scope and aliases — richer than V1's
+`duckdb_get_config_flag`.
+
+One regression for us: V1 enumerates available options with no database open
+(`duckdb_config_count` / `duckdb_get_config_flag`), which is what `configurationOptionDescriptions.ts`
+relies on. V2 enumerates via `database_option_get_count` / `database_option_get_by_index`, so a
+database is required.
+
+### 8. Query execution
+
+The biggest restructuring. V1:
+
+```c
+duckdb_query(conn, sql, &result);                      /* materialized */
+duckdb_prepare(conn, sql, &stmt);
+duckdb_bind_int32(stmt, 1, 42);                        /* one call per parameter, by index */
+duckdb_execute_prepared(stmt, &result);
+duckdb_pending_prepared(stmt, &pending);               /* or, for async */
+duckdb_pending_execute_task(pending);                  /* pump until ready */
+```
+
+V2:
+
+```c
+duckdb_v2_parse_sql(conn, sql, &iterator, &err);       /* also replaces extract_statements */
+duckdb_v2_statement_iterator_next(iterator, &stmt, &err);
+duckdb_v2_statement_bind(conn, stmt, &schema, &parameters, &err);   /* optional: metadata */
+duckdb_v2_statement_execute(conn, stmt, names, values, count, &result, &err);
+```
+
+Three consequences:
+
+- **Parameters are arrays at execute time.** Two parallel arrays of `duckdb_v2_identifier_t` names
+  and `duckdb_v2_value_handle` values, replacing all 25 `duckdb_bind_*` functions. Named and
+  positional parameters unify. Our `DuckDBPreparedStatement` bind-then-execute shape does not
+  survive as-is; the value-based path (`duckdb_bind_value`) is the closest existing thing.
+- **Every result streams.** There is no materialized result and no `duckdb_row_count`.
+  `duckdb_v2_result_step` returns `CHUNK`, `WAITING`, `FINISHED` or `CANCELLED`. A result is a
+  live cursor: while it is open the connection refuses new queries with `ERROR_RESOURCE_IN_USE`,
+  its transaction stays open, and side-effecting statements only take effect once drained. That is
+  a real behavioral change for `DuckDBMaterializedResult` and for how the API package holds
+  results across awaits.
+- **The pending-result interface is gone, and `WAITING` replaces it.** This is arguably better
+  suited to us than V1's task pump: `result_step` returning `WAITING` is a natural yield point,
+  with `result_wait` as the blocking fallback on a worker thread.
+
+Result metadata moves from per-column calls (`duckdb_column_name`, `duckdb_column_type`) to a
+`duckdb_v2_schema_handle` obtained once, with `schema_get_field` returning name and type together.
+`duckdb_v2_prepared_statement_*` is only four functions, because everything else moved to the
+statement and schema.
+
+### 9. Logical types
+
+V1 has a constructor and a family of accessors per kind — `duckdb_create_list_type`,
+`duckdb_create_struct_type`, `duckdb_decimal_width`, `duckdb_struct_type_child_name`,
+`duckdb_enum_dictionary_value`, and so on: 30 functions, 28 of which we expose.
+
+V2 has three constructors and two accessors:
+
+```c
+duckdb_v2_connection_create_type_from_id(conn, type_id, param_names, param_values, count, &type, &err);
+duckdb_v2_connection_create_type_from_name(conn, qname, param_names, param_values, count, &type, &err);
+duckdb_v2_connection_create_type_from_text(conn, str("STRUCT(a INTEGER, b VARCHAR)"), &type, &err);
+
+duckdb_v2_logical_type_get_param_count(type, &count, &err);
+duckdb_v2_logical_type_get_param(type, index, &out_name, &out_value, &err);
+```
+
+Type structure is expressed as **value parameters**: DECIMAL has 2 (width, scale as UTINYINT);
+LIST 1 (element type, as a TYPE value); ARRAY 2; MAP 2; STRUCT one per field, named; UNION one per
+member; ENUM one per dictionary entry, as VARCHAR. Child types cross the boundary wrapped as TYPE
+values, unwrapped with `value_get_type`.
+
+This is a much smaller surface, and it generalizes to extension types for free — but `DuckDBType.ts`
+and the `types/` tree are built directly on the V1 per-kind accessors, so this is a rewrite rather
+than a retarget. Also note that construction now requires a connection or context, where V1's
+`duckdb_create_list_type` needed neither.
+
+### 10. Values
+
+Reading is a close mapping (`value_get_int`, `value_get_varchar`, `value_get_child`, …).
+
+Creating is not: **every constructor except `value_create_null` requires a connection or a
+context**, in `_with_connection` / `_with_context` pairs. `duckdb_create_int32(42)` becomes
+`duckdb_v2_value_create_int_with_connection(conn, 42, &value, &err)`.
+
+`createValue.ts` and `DuckDBValue` construct values with no connection in hand. Threading a
+connection (or context) through that layer is a design change in the API package, not just the
+bindings.
+
+The context variant matters for UDFs: inside a bind or exec callback we hold a
+`duckdb_v2_context_handle`, not a connection, and the header is explicit that catalog-touching
+context calls belong in bind-phase callbacks rather than exec-phase worker callbacks.
+
+### 11. Vectors
+
+V1: `duckdb_vector_get_data` plus `duckdb_vector_get_validity`, with flat vectors assumed.
+
+V2: one unified view.
+
+```c
+struct duckdb_v2_vector_view {
+    const void            *data;
+    const uint64_t        *validity;
+    const duckdb_v2_sel_t *sel;
+    idx_t                  count;
+};
+```
+
+Non-flat vector types become first-class — dictionary, constant and sequence vectors, with
+`vector_flatten` when a reader wants flat storage anyway. The header commits to storage-tier
+mappings that V1 left implicit: DECIMAL width ≤ 4 stores int16, ≤ 9 int32, ≤ 18 int64, ≤ 38
+int128; ENUM stores uint8 / uint16 / uint32 by dictionary size. `DuckDBVector.ts` already encodes
+those rules, so this is confirmation rather than change.
+
+Handling `sel` is new work — `getRowsFromChunks` and friends index `data` directly today — but it
+is also an opportunity: reading a dictionary vector without flattening it is strictly less copying
+than what V1 forces.
+
+`duckdb_vector_size()` has no V2 counterpart, and there is no `DUCKDB_V2_VECTOR_SIZE` constant.
+
+### 12. User-defined functions
+
+The closest-mapping area, and the one that narrows a real bug class for us.
+
+V1 passes one opaque `duckdb_function_info` to exec, and one `duckdb_bind_info` / `duckdb_init_info`
+to bind and init, across scalar, table, aggregate and cast functions. So our six function-info tags
+— `ScalarFunctionBindInfoTypeTag`, `TableFunctionInfoTypeTag` and the rest — wrap only three
+underlying C types between them, and the tag is the *only* thing separating a scalar bind info from
+a table one. The structs behind those handles are unrelated and get `reinterpret_cast` without a
+check, so a mix-up corrupts memory rather than failing.
+
+V2 gives each phase of each family its own handle type — 30 distinct `*_info_handle` types — so the
+C type system separates them and those tags become ordinary externals tags like the other sixteen.
+
+To be clear about what this does *not* do: `type_tags.h` stays. Every external we hand to JS needs a
+tag, because N-API gives us no other way to tell one `Napi::External` from another at runtime. What
+changes is that the function-info tags stop being load-bearing against memory corruption, so the
+special-case reasoning around them can go. If anything the tag count goes up, since V2 splits each
+family into more phases.
+
+New capability worth noting: table functions gain **filter pushdown** (claim-based, via the
+expression interface) and projection pushdown, alongside progress reporting. Scalar functions gain
+a bind phase that can set the return type from argument types.
+
+Function registration also picks up a `function_signature` object (`add_parameter`,
+`set_varargs`, `set_return_type`) and named parameters with defaults.
+
+## Not in V2 (yet)
+
+Ordered by what it would cost us:
+
+- **Appender** (31 exposed functions, `DuckDBAppender.ts`, two test suites). No counterpart.
+- **Date / time / timestamp / hugeint / decimal conversion helpers** (19 exposed functions, all of
+  them). `duckdb_from_date`, `duckdb_to_timestamp`, `duckdb_double_to_decimal` and the rest have
+  no V2 equivalent. These are pure computation, so we could reimplement them in TypeScript or keep
+  calling the V1 versions, but it is worth asking whether their absence is deliberate.
+- **`duckdb_vector_size`**, and the malloc/free helpers.
+- **Profiling info** (not exposed today).
+- **Task / threading control** — `duckdb_execute_tasks` and friends (not exposed today).
+- **Instance cache** — subsumed by the environment, but the mapping is not one-to-one
+  (`DuckDBInstanceCache` in the API package is a public type).
+
+## What we would gain
+
+- Typed error codes instead of message-string matching.
+- Per-family function info handles, so the function-info type tags stop guarding against memory
+  corruption and become ordinary externals tags.
+- Dictionary and constant vector reading without a flatten.
+- `WAITING`-based streaming that fits an async binding better than the pending-result pump.
+- Table function filter and projection pushdown.
+- Catalog / table description, cast functions, copy functions, replacement scans, file system and
+  expression interfaces — all present in V1 too, all unexposed by us today, all with a smaller and
+  more consistent surface in V2.
+- `qname` (qualified-name parsing, rendering, comparison) and `identifier_render_quoted`, which
+  would replace hand-rolled quoting in `sql.ts`.
+- `column_data_collection` — build a set of chunks and register it as a table via a replacement
+  scan. Not an appender, but a bulk-load path with no V1 equivalent.
+
+## Open questions
+
+For us:
+
+1. Incremental or all-at-once? Both surfaces are in one library, so per-module migration behind a
+   stable `duckdb.d.ts` is possible — but mixed ownership models in one addon is its own risk.
+2. Does `@duckdb/node-bindings` stay a 1:1 C API mirror? V2's shape (out-params, error handles,
+   borrowed views) is further from idiomatic TypeScript than V1's, so a literal mirror may be the
+   wrong target for the first time.
+3. What replaces `DuckDBMaterializedResult` when every result is a live cursor holding a
+   transaction open?
+
+For the DuckDB team:
+
+4. Is `duckdb_cpp.hpp` going to be shipped in the release headers? It is referenced in all three
+   PRs but is not in `src/include/` on the branch. As a C++ addon we would rather consume that
+   than hand-roll RAII over the C surface.
+5. Is an appender planned for V2, or is `column_data_collection` the intended replacement? If the
+   latter, what is the intended path for appending to an *existing* table?
+6. Are the date/time/decimal/hugeint conversion helpers intentionally omitted?
+7. Is V1 expected to stay supported through the 2.x line, or is 2.0 the start of a deprecation
+   window?

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -456,11 +456,13 @@ What this lands on:
   implementation or a reason. V2 declarations get the same treatment. Since every V2 name is
   prefixed `duckdb_v2_`, the two surfaces separate cleanly by name — `capi-coverage/node_neo.py`
   and `build_coverage.py` intersect against the canonical V1 list and are unaffected.
-- **`checkFunctionSignatures.mjs` needs to become two-header aware.** It reads one header, one
-  `.d.ts` and one `.cpp`, and compares the three lists for exact equality; a second header's worth of
-  declarations in the latter two would read as a mismatch. Worth wiring into `pnpm run build` at the
-  same time — it currently only warns, and nothing runs it, which is a thin guard for a surface that
-  is about to double.
+- **`checkFunctionSignatures.mjs` needs to become two-header aware** — and its guard tracking needs
+  updating regardless of V2, because the 2.0 V1 header rewrote those guards; see
+  [Deprecation is a compile switch](#deprecation-is-a-compile-switch-not-a-warning). It reads one
+  header, one `.d.ts` and one `.cpp`, and compares the three lists for exact equality; a second
+  header's worth of declarations in the latter two would read as a mismatch. Worth wiring into
+  `pnpm run build` at the same time — it currently only warns, and nothing runs it, which is a thin
+  guard for a surface that is about to double.
 - **The fetch scripts need `duckdb_v2.h`.** `fetch_libduckdb_*.py` extracts `duckdb.h` and the
   library from each release zip; the release workflow already zips `duckdb_v2.h` beside `duckdb.h`,
   so this is one more entry in each `files` list.
@@ -621,8 +623,44 @@ Real choices, deliberately not made yet, each with the thing that should trigger
 | Whether to build the V2 bindings on `duckdb_cpp`, borrow its patterns, or ignore it | `duckdb_cpp` actually shipping in a release; it is not required either way |
 | Whether any conversion helpers are worth keeping native rather than reimplementing in TypeScript | Only if upstream ships some after all — otherwise TypeScript, which is the better choice regardless |
 
-## Still open
+## Deprecation is a compile switch, not a warning
 
-1. **Is 2.0's V1 deprecation documentation, or `DUCKDB_DEPRECATED` attributes on the declarations?**
-   If the latter, our build starts emitting a warning per V1 call — 314 of them — the moment we
-   upgrade. Cheap to ask, unpleasant to discover. *(DuckDB team.)*
+Answered from the headers rather than by asking. 2.0's V1 header expresses deprecation as
+*conditional inclusion*, the way `DUCKDB_API_NO_DEPRECATED` always did — so a deprecated V1 will not
+put a warning on any of our 314 call sites:
+
+- `DUCKDB_DEPRECATED` (the `__attribute__((deprecated))` macro) is defined in both headers and
+  applied to nothing.
+- Deprecated declarations sit inside `#if (DUCKDB_API_VERSION_BELOW(1, 0, 0) ||
+  DUCKDB_API_ALLOW_DEPRECATED)`. `DUCKDB_API_ALLOW_DEPRECATED` defaults to 1, and back-derives from
+  the legacy `DUCKDB_API_NO_DEPRECATED` for consumers who define that instead. `duckdb_v2.h` carries
+  the same switch under `DUCKDB_V2_API_ALLOW_DEPRECATED`, with the same default and the same
+  back-derivation.
+- Node Neo defines neither switch, so the defaults apply and everything compiles in. If 2.0 marks V1
+  deprecated wholesale, the fix is at most defining `DUCKDB_API_ALLOW_DEPRECATED 1` explicitly.
+
+New in 2.0's V1 header: **every** declaration is now wrapped in a
+`DUCKDB_API_VERSION_AT_LEAST(major, minor, patch)` guard, with the targeted version defaulting to
+1.5.6 and settable by defining all three of `DUCKDB_API_VERSION_MAJOR` / `_MINOR` / `_PATCH`. That is
+how a consumer pins an older surface, and it is the likeliest shape for V1's own retirement: a switch
+to flip, not a diagnostic to suppress.
+
+### Two consequences for our tooling
+
+The guard rewrite is invisible at the C level and load-bearing for the two things that parse these
+headers:
+
+1. **`checkFunctionSignatures.mjs` needs its guard tracking updated.** It recognizes exactly
+   `#ifndef DUCKDB_API_NO_DEPRECATED` and `#ifndef DUCKDB_NO_EXTENSION_FUNCTIONS`, and stamps each
+   extracted signature with an `ifndef` field. The 1.5.5 header has 9 such blocks; the 2.0 header has
+   1, in the preamble, and guards declarations with `#if DUCKDB_API_VERSION_AT_LEAST(…)` instead. So
+   header signatures come out unstamped while the accounting comments in `duckdb_node_bindings.cpp`
+   and `duckdb.d.ts` still carry their `// #ifndef DUCKDB_API_NO_DEPRECATED` markers — a mismatch on
+   top of the thirteen `(void)` edits, and one that regenerating the `*Sigs.json` files alone will
+   not settle.
+2. **`capi-coverage`'s deprecated flag is now resting on prose.** `capi_functions.py` derives it from
+   three signals: guard depth, `DEPRECATION NOTICE` in the doc comment, and `**DEPRECATED**`. Against
+   the 2.0 header the guard signal contributes nothing, and the doc-text fallback carries all 48 on
+   its own. It still reports exactly the same 48 functions, so nothing is broken — but it is right
+   for the wrong reason, and would silently drop to zero if that prose were ever reworded. Worth
+   teaching it the new guard form while the reason is fresh.

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -416,8 +416,7 @@ Ordered by what it would cost us:
 
 ## Migration approach
 
-Decided (Jeff, 2026-09-05). This settles the first two of the open questions below; the third stays
-open.
+Decided (Jeff, 2026-09-05). Everything still open is a question for the DuckDB team, not for us.
 
 ### Bindings: V2 alongside V1, in the same package and binary
 
@@ -482,6 +481,35 @@ Neither package has an `exports` map today; both use plain `main`/`types`. Addin
 already exports only what is meant to be referenced externally, and deep references were never
 supported; if something turns out to be needed, the answer is to export it explicitly.
 
+### Results: no materialized result class
+
+The V2 C API has no materialized result, so the V2 API layer does not have one either.
+`DuckDBMaterializedResult` is a thin subclass adding exactly three members — `rowCount`,
+`chunkCount` and `getChunk(i)` — each backed by a V1-only function (`duckdb_row_count`,
+`duckdb_result_chunk_count`, `duckdb_result_get_chunk`) with no V2 counterpart. `createResult`'s
+branch on `duckdb_result_is_streaming` likewise has nothing left to decide, since every V2 result
+streams. Both go away.
+
+Materializing stays available as helpers over the streaming result — which is what we already do.
+`DuckDBResultReader` accumulates chunks through `readAll()` / `readUntil(n)`, tracks
+`currentRowCount` and `done`, and layers `getRows` / `getColumns` and the converters on top, all
+over the streaming `DuckDBResult` base rather than over the materialized subclass. That pattern
+carries over unchanged in shape.
+
+One knock-on: `rowsChanged` is a synchronous getter today, straight from `duckdb_rows_changed`. V2
+reports it out of `duckdb_v2_result_drain(result, &out_rows_changed, err)`, which consumes the
+stream — so it becomes an async, state-changing call rather than a property.
+
+### Value construction: keep both the connection and context forms
+
+Keep `_with_connection` and `_with_context` as two functions rather than collapsing them into one
+with a union-typed first argument. That follows the 1:1 principle, gives tighter types, and the two
+forms likely belong to different scenarios in practice: a connection is what an external caller
+holds, while a context is what arrives inside a bind / init / exec scope — and the header is
+explicit that catalog-touching context calls belong in bind-phase callbacks rather than exec-phase
+worker callbacks. Worth staying flexible: if the implementation turns up a concrete reason to
+collapse them, revisit.
+
 ### A known limitation to document: one file, both APIs
 
 Because the point of a `v2` subpath is to let a consumer migrate incrementally, both APIs will run
@@ -507,23 +535,13 @@ partial migration makes it easier to reach than it is today — the two halves o
 naturally open "their" database — so the `v2` path's docs should say that a file should be opened
 through one API or the other, not both.
 
-## Open questions
+## Open questions for the DuckDB team
 
-For us:
-
-1. What replaces `DuckDBMaterializedResult` when every result is a live cursor holding a
-   transaction open? The V2 classes need an answer before the first of them is written.
-2. Do the `_with_connection` / `_with_context` pairs stay two functions in TypeScript, or collapse
-   into one with a union-typed first argument? The same question covers data chunks, column data
-   collections and the type constructors.
-
-For the DuckDB team:
-
-3. Is `duckdb_cpp.hpp` going to be shipped in the release headers? It is referenced in all three
+1. Is `duckdb_cpp.hpp` going to be shipped in the release headers? It is referenced in all three
    PRs but is not in `src/include/` on the branch. As a C++ addon we would rather consume that
    than hand-roll RAII over the C surface.
-4. Is an appender planned for V2, or is `column_data_collection` the intended replacement? If the
+2. Is an appender planned for V2, or is `column_data_collection` the intended replacement? If the
    latter, what is the intended path for appending to an *existing* table?
-5. Are the date/time/decimal/hugeint conversion helpers intentionally omitted?
-6. Is V1 expected to stay supported through the 2.x line, or is 2.0 the start of a deprecation
+3. Are the date/time/decimal/hugeint conversion helpers intentionally omitted?
+4. Is V1 expected to stay supported through the 2.x line, or is 2.0 the start of a deprecation
    window?

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -446,22 +446,28 @@ What this lands on:
 Same principle as V1 — mirror the C API, and deviate only for memory management, error handling and
 out parameters, as the V1 mapping already does. The places where "as feasible" will be tested:
 
-- **Multiple out-params.** V1's out-params are nearly all single, and collapse to a return value.
-  V2 has calls that produce two: `statement_bind` yields both a result schema and a parameter
-  schema, `result_step` yields both a chunk and a status. These need an object return, which is a
-  new shape for the bindings.
-- **Owned versus borrowed.** V2 documents this per out-param and enforces it — destroying a
-  borrowed handle aborts. So ownership becomes a property the accounting has to record per function,
-  since it decides whether the external gets a finalizer at all, and borrowed handles need their
-  parent pinned for their lifetime.
+- **Multiple out-params — precedented, just more common.** V1 already has this and already answers
+  it: `duckdb_get_config_flag(index, out_name, out_description)` maps to
+  `get_config_flag(index): ConfigFlag`, an object return. V2 needs the same treatment more often —
+  `statement_bind` yields a result schema and a parameter schema, `result_step` a chunk and a status
+  — but the shape is established, not new.
+- **Owned versus borrowed — also precedented, and the mechanism already exists.** `externals.h`
+  carries both `CreateExternalFor<X>` and `CreateExternalFor<X>WithoutFinalizer` for data chunks and
+  logical types, plus holder structs for connections and databases. What changes under V2 is
+  pervasiveness and enforcement: the C API documents ownership per out-param and aborts if a
+  borrowed handle is destroyed, so this becomes something the accounting should record per function
+  rather than something inferred per call site.
 - **The `_with_connection` / `_with_context` pairs.** 37 value constructors exist in both forms, and
   the same split runs through data chunks, column data collections and the type constructors. A 1:1
   mapping exposes both; whether the TS layer keeps them as two functions or one with a union-typed
-  first argument is the first real judgement call.
-- **`create_environment`.** The header says "call once at program start," which reads like
-  addon-owned state rather than something a caller threads through every open. V1 has one precedent
-  for this shape — `duckdb_open` is marked *consolidated into open* — so there is a convention to
-  follow either way.
+  first argument is the open judgement call.
+- **`create_environment` maps onto the instance-cache pattern.** Not addon-owned state: the
+  precedent is `DuckDBInstanceCache`, which the bindings expose 1:1 as `create_instance_cache()`
+  while the API layer supplies a lazily-created `singleton` that `DuckDBInstance.fromCache()` routes
+  through — and nothing stops a caller constructing more than one. A V2 environment gets the same
+  shape: constructible for advanced use, with one auto-created default that ordinary opens go
+  through. The one difference is that V1's cache is optional (`DuckDBInstance.create` bypasses it)
+  whereas `duckdb_v2_open` requires an environment, so the default is implicit rather than opt-in.
 
 ### API: one package, V2 classes under a `v2` subpath
 
@@ -471,11 +477,12 @@ unnecessary weight and would stop a consumer migrating one call site at a time; 
 the existing V1 classes over the V2 bindings, which the differences between the two C APIs would
 make awkward — the survey's §8, §9 and §10 are the reason.
 
-Note that neither package has an `exports` map today; both use plain `main`/`types`. Adding one to
-get `@duckdb/node-api/v2` also closes the package, so any consumer currently deep-importing
-`@duckdb/node-api/lib/…` would break unless `./lib/*` is mapped through deliberately.
+Neither package has an `exports` map today; both use plain `main`/`types`. Adding one to get
+`@duckdb/node-api/v2` also closes the package to deep imports — which is intended. `index.ts`
+already exports only what is meant to be referenced externally, and deep references were never
+supported; if something turns out to be needed, the answer is to export it explicitly.
 
-### One hazard that partial migration creates
+### A known limitation to document: one file, both APIs
 
 Because the point of a `v2` subpath is to let a consumer migrate incrementally, both APIs will run
 in one process — and a database file opened through both is **not** detected. Measured against the
@@ -492,9 +499,13 @@ v2 open twice (control): refused with RESOURCE_IN_USE (code 3001)
 
 V2 detects its own double-open, because `duckdb_v2_open` rejects a file "already open under the same
 environment" — but a V1 database of the same file is not under that environment, and V1's own
-deduplication only happens through an explicit instance cache. So this is not a regression; it is a
-pre-existing footgun that partial migration makes much easier to reach, since the two halves of one
-app would each naturally open "their" database. Question 5 below.
+deduplication only happens through an explicit instance cache.
+
+Not a blocker (Jeff, 2026-09-05): the same footgun exists today, since V1's plain `duckdb_open`
+never deduplicated either. It needs documenting rather than solving. Worth writing down because
+partial migration makes it easier to reach than it is today — the two halves of one app would each
+naturally open "their" database — so the `v2` path's docs should say that a file should be opened
+through one API or the other, not both.
 
 ## Open questions
 
@@ -503,7 +514,8 @@ For us:
 1. What replaces `DuckDBMaterializedResult` when every result is a live cursor holding a
    transaction open? The V2 classes need an answer before the first of them is written.
 2. Do the `_with_connection` / `_with_context` pairs stay two functions in TypeScript, or collapse
-   into one with a union-typed first argument?
+   into one with a union-typed first argument? The same question covers data chunks, column data
+   collections and the type constructors.
 
 For the DuckDB team:
 
@@ -512,9 +524,6 @@ For the DuckDB team:
    than hand-roll RAII over the C surface.
 4. Is an appender planned for V2, or is `column_data_collection` the intended replacement? If the
    latter, what is the intended path for appending to an *existing* table?
-5. Should a V2 environment and V1's instance cache share a file registry? Opening one file through
-   both APIs in one process is currently undetected (see above), and a client shipping both
-   surfaces at once cannot fix that from its side.
-6. Are the date/time/decimal/hugeint conversion helpers intentionally omitted?
-7. Is V1 expected to stay supported through the 2.x line, or is 2.0 the start of a deprecation
+5. Are the date/time/decimal/hugeint conversion helpers intentionally omitted?
+6. Is V1 expected to stay supported through the 2.x line, or is 2.0 the start of a deprecation
    window?

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -44,13 +44,18 @@ detected.
 
 ## Headline findings
 
-**V1 survives 2.0 intact.** Comparing the V1 header we build against with the V1 header on the
-2.0 branch: zero functions removed, two added (`duckdb_create_timestamp_tz_ns`,
-`duckdb_get_timestamp_tz_ns`), and thirteen "signature changes" that are all the cosmetic
-`()` → `(void)`. Nothing is marked `DUCKDB_DEPRECATED`. The preview `libduckdb` exports all 546
-V1 symbols alongside all 527 V2 symbols from one library. So DuckDB 2.0 is not a forced
-migration, and V1 and V2 can be mixed within one addon — which makes an incremental,
-module-by-module migration possible rather than a big-bang rewrite.
+**V1 keeps working in 2.0, but the clock is now running.** Comparing the V1 header we build against
+with the V1 header on the 2.0 branch: zero functions removed, two added
+(`duckdb_create_timestamp_tz_ns`, `duckdb_get_timestamp_tz_ns`), and thirteen "signature changes"
+that are all the cosmetic `()` → `(void)`. Nothing in the header carries `DUCKDB_DEPRECATED` — the
+macro is defined but never applied. The preview `libduckdb` exports all 546 V1 symbols alongside all
+527 V2 symbols from one library, so V1 and V2 can be mixed inside one addon, and an incremental,
+module-by-module migration is possible rather than a big-bang rewrite.
+
+What the header does not show is the schedule. Per the DuckDB team (maxxen, 2026-09-05): **V1 is
+deprecated in 2.0 and probably removed entirely in 3.0, likely about a year out.** So 2.0 is not a
+forced migration, but it is the start of a fixed window rather than an open-ended coexistence — see
+[Migration approach](#migration-approach).
 
 The one thing that notices is our own signature check: `checkFunctionSignatures.mjs` compares
 declaration text exactly, so those thirteen `(void)` edits make it report a mismatch until
@@ -79,20 +84,25 @@ fetch scripts need more than a URL swap when 2.0 releases. The release workflow 
 the surface. Roughly: a third of what Node Neo uses maps mechanically, a third needs restructuring
 around new call sequences, and a third has no counterpart yet.
 
-**The appender is not in V2.** Node Neo exposes 31 appender functions and both packages have
-appender APIs and test suites. Nothing in `duckdb_v2.h` matches. `column_data_collection` plus
-`replacement_scan_set_collection` covers bulk data creation, but not "insert these rows into an
-existing table", which is what the appender is for.
+**The appender is not in V2, and is not coming.** Node Neo exposes 31 appender functions and both
+packages have appender APIs and test suites. Nothing in `duckdb_v2.h` matches, and per the DuckDB
+team (maxxen, 2026-09-05) that is deliberate: "probably not, this can now be implemented client-side
+using columndatacollections and replacement scans/table functions." So this becomes work we own — a
+V2 `DuckDBAppender` built on `column_data_collection` plus `replacement_scan_set_collection`, rather
+than a thin wrapper over C functions. Note the shape difference that makes it more than a rename: a
+collection surfaced through a replacement scan is a *virtual table*, so appending to an *existing*
+table means an `INSERT INTO … SELECT * FROM` over it, not a direct append.
 
 **One class of hazard in our function-info handling goes away.** V2 gives every function family its
 own info-handle type (`duckdb_v2_scalar_function_bind_info_handle`,
 `duckdb_v2_table_function_exec_info_handle`, and so on), where V1 shares one `duckdb_function_info`
 across all of them. `type_tags.h` stays either way — a tag is the only thing that distinguishes one
 `Napi::External` from another at runtime — but the six function-info tags stop carrying extra load;
-see §12. And a `duckdb_cpp.hpp` "stable C++ API" over V2 is mentioned in all three PRs; it
-is not in `src/include/` on the branch and is not in the packaged headers, but as a C++ N-API
-addon we would be its natural consumer, so it is worth asking about before hand-writing RAII
-wrappers over the C surface.
+see §12. Separately, the `duckdb_cpp` "stable C++ API" over V2, mentioned in all three PRs, turns out
+to live at `tools/cpp/` rather than `src/include/`, which is why it is not in the packaged headers.
+The team expects to add it to the release tarballs "soon", along with a CMake module for
+`FetchContent` (maxxen, 2026-09-05). As a C++ N-API addon we are its natural consumer — see
+[Migration approach](#migration-approach) for what that would take.
 
 ## The two surfaces, side by side
 
@@ -387,11 +397,16 @@ Function registration also picks up a `function_signature` object (`add_paramete
 
 Ordered by what it would cost us:
 
-- **Appender** (31 exposed functions, `DuckDBAppender.ts`, two test suites). No counterpart.
+- **Appender** (31 exposed functions, `DuckDBAppender.ts`, two test suites). No counterpart, and
+  none planned — see the headline finding. We reimplement it over `column_data_collection`.
 - **Date / time / timestamp / hugeint / decimal conversion helpers** (19 exposed functions, all of
-  them). `duckdb_from_date`, `duckdb_to_timestamp`, `duckdb_double_to_decimal` and the rest have
-  no V2 equivalent. These are pure computation, so we could reimplement them in TypeScript or keep
-  calling the V1 versions, but it is worth asking whether their absence is deliberate.
+  them). `duckdb_from_date`, `duckdb_to_timestamp`, `duckdb_double_to_decimal` and the rest have no
+  V2 equivalent, and still none as of the latest branch fetch — the header contains no `static
+  inline` helpers at all. The omission is deliberate: the team is "trying to avoid *convenience*
+  functions", and expects clients to implement them, though some may yet ship as inline functions in
+  the header or as documentation (maxxen, 2026-09-05, hedged — worth re-checking near release). For
+  us these are pure computation over plain structs, so TypeScript implementations are
+  straightforward, and would remove 19 native round-trips in the process.
 - **`duckdb_vector_size`**, and the malloc/free helpers.
 - **Profiling info** (not exposed today).
 - **Task / threading control** — `duckdb_execute_tasks` and friends (not exposed today).
@@ -421,8 +436,13 @@ Decided (Jeff, 2026-09-05). Everything still open is a question for the DuckDB t
 ### Bindings: V2 alongside V1, in the same package and binary
 
 `@duckdb/node-bindings` gains the V2 surface next to the V1 one, in the same addon. One `libduckdb`
-already exports both symbol sets, so this needs no second binary and no second native package. V1
-goes away only if and when the C API deprecates it, which is not expected soon.
+already exports both symbol sets, so this needs no second binary and no second native package.
+
+The schedule for retiring V1 is now known: deprecated in 2.0, probably removed in 3.0, roughly a
+year out (maxxen, 2026-09-05). Side-by-side is exactly the shape a year-long transition wants — but
+it is a window, not an open-ended arrangement, so the V2 API needs to be complete enough for
+consumers to finish migrating before 3.0, and our own V1 removal has a target rather than a
+condition.
 
 What this lands on:
 
@@ -481,6 +501,28 @@ Neither package has an `exports` map today; both use plain `main`/`types`. Addin
 already exports only what is meant to be referenced externally, and deep references were never
 supported; if something turns out to be needed, the answer is to export it explicitly.
 
+### The C++ API over V2: worth consuming, with two caveats
+
+`duckdb_cpp` is the obvious thing for a C++ N-API addon to build on: it throws instead of returning
+error codes, and its handles are move-only with documented owning/borrowed semantics — exactly the
+boilerplate §2 and §5 describe. Consuming it would not change the TypeScript surface at all; it
+changes how `duckdb_node_bindings.cpp` is written, so it is orthogonal to the 1:1 mapping decision.
+
+Two things to know before planning around it:
+
+- **It is not header-only**, despite the description. `tools/cpp/duckdb_cpp.hpp` is 5,703 lines of
+  declarations that do not include `duckdb_v2.h` at all, and `tools/cpp/duckdb_cpp.cpp` is 5,742
+  lines of implementation that includes both `duckdb_v2.h` and `duckdb_extension_v2.h`. Consuming it
+  means adding that `.cpp` to `sources` in `binding.gyp` — fine in itself, but it means the release
+  tarball has to ship the source file too, not just the header. The CMake module the team mentions
+  does not help us: node-gyp is not CMake, and `FetchContent` has no equivalent here.
+- **Exceptions are fine.** `duckdb_cpp` reports every failure by throwing, and `binding.gyp` already
+  builds against `node_addon_api_except_all`, so C++ exceptions are enabled and the addon already
+  converts them at the boundary. No build-configuration change needed.
+
+Not a decision yet — it turns on the tarball question below. Worth settling before the V2 bindings
+are far along, since retrofitting is more work than starting on it.
+
 ### Results: no materialized result class
 
 The V2 C API has no materialized result, so the V2 API layer does not have one either.
@@ -535,13 +577,31 @@ partial migration makes it easier to reach than it is today — the two halves o
 naturally open "their" database — so the `v2` path's docs should say that a file should be opened
 through one API or the other, not both.
 
-## Open questions for the DuckDB team
+## Answers from the DuckDB team
 
-1. Is `duckdb_cpp.hpp` going to be shipped in the release headers? It is referenced in all three
-   PRs but is not in `src/include/` on the branch. As a C++ addon we would rather consume that
-   than hand-roll RAII over the C surface.
-2. Is an appender planned for V2, or is `column_data_collection` the intended replacement? If the
-   latter, what is the intended path for appending to an *existing* table?
-3. Are the date/time/decimal/hugeint conversion helpers intentionally omitted?
-4. Is V1 expected to stay supported through the 2.x line, or is 2.0 the start of a deprecation
-   window?
+Asked 2026-09-05; answered by maxxen the same day. Paraphrased, with what each one lands on.
+
+| Question | Answer | Lands on |
+|---|---|---|
+| Will there be an appender equivalent? | "Probably not" — implement client-side over column data collections plus replacement scans / table functions; `duckdb_cpp` has an example. | We own a V2 appender. Not a wrapper — a collection behind a replacement scan is a virtual table, so appending to an existing table is `INSERT INTO … SELECT * FROM`. |
+| What about the V1 date/time/decimal/hugeint conversion helpers? | Some may be; the team is "trying to avoid *convenience* functions" and expects clients to implement them, but they may ship as inline header functions or as docs. | We implement them in TypeScript. Hedged, so re-check near release. |
+| Will V1 be deprecated and retired? When? | "v1 will be deprecated in 2.0, and probably removed entirely in 3.0 (likely another year out)." | Side-by-side is a ~1-year window, not indefinite. |
+| Will `duckdb_cpp` ship in 2.0? | Currently core-repo only; "most likely" added to the release tarballs soon, plus a proper CMake module for `FetchContent`. | Promising but uncommitted, and the CMake half does not help node-gyp. |
+
+## Open questions
+
+Follow-ups these answers raise, roughly in the order they will matter:
+
+1. **Will the release tarball ship `duckdb_cpp.cpp`, not just `duckdb_cpp.hpp`?** The API is
+   header-plus-source, and node-gyp cannot consume the planned CMake module. Both files in the
+   tarball is what we need. *(DuckDB team.)*
+2. **Is 2.0's V1 deprecation documentation, or `DUCKDB_DEPRECATED` attributes on the declarations?**
+   If the latter, our build starts emitting a warning per V1 call — 314 of them — the moment we
+   upgrade, which is worth knowing before it happens rather than after. *(DuckDB team.)*
+3. **Which conversion helpers, specifically, survive?** The answer was hedged; the current header has
+   none, and no `static inline` helpers at all. Determines how much we reimplement. *(DuckDB team.)*
+4. **Do we build the V2 bindings on `duckdb_cpp` or on the raw C surface?** Turns on question 1.
+   Worth settling early — retrofitting is more work than starting on it. *(Us.)*
+5. **How much of the V2 API has to exist before 3.0?** Consumers need to finish migrating inside the
+   window, which makes the appender reimplementation and anything else V1-only into scheduled work
+   rather than open-ended. *(Us.)*

--- a/tools/capi-v2/coexist_probe.c
+++ b/tools/capi-v2/coexist_probe.c
@@ -1,0 +1,91 @@
+/* Does opening one database file through both V1 and V2 in a single process get
+ * detected?
+ *
+ * This matters because the plan is to ship both surfaces from one bindings
+ * package so consumers can migrate a call site at a time -- which means both
+ * APIs running in one process, each opening "its" database.
+ *
+ *   python3 tools/capi-v2/fetch_libduckdb_v2.py
+ *   cc -std=c11 -I libduckdb-v2 coexist_probe.c -L libduckdb-v2 -lduckdb \
+ *      -Wl,-rpath,@loader_path/libduckdb-v2 -o coexist_probe && ./coexist_probe
+ *
+ * Measured against the 2.0 preview (2026-09-05):
+ *
+ *   v1 open:                 ok
+ *   v1 open again:           ok (no conflict reported)
+ *   v2 open same file:       ok (NOT detected)
+ *   v2 open twice (control): refused with RESOURCE_IN_USE (code 3001)
+ *
+ * duckdb_v2_open rejects a file "already open under the same environment", and a
+ * V1 database is not under that environment. V1 in turn only deduplicates through
+ * an explicit instance cache. So the cross-API case falls between the two.
+ */
+
+#include "duckdb.h"
+#include "duckdb_v2.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static duckdb_v2_str str(const char *s) {
+	duckdb_v2_str v;
+	v.ptr = s;
+	v.len = strlen(s);
+	return v;
+}
+
+int main(void) {
+	const char *path = "coexist_probe.duckdb";
+	remove(path);
+
+	duckdb_database v1_db;
+	if (duckdb_open(path, &v1_db) != DuckDBSuccess) {
+		printf("v1 open failed\n");
+		return 1;
+	}
+	printf("v1 open:                 ok\n");
+
+	/* V1's own behavior, for reference: plain open does not deduplicate. */
+	duckdb_database v1_db_again;
+	printf("v1 open again:           %s\n",
+	       duckdb_open(path, &v1_db_again) == DuckDBSuccess ? "ok (no conflict reported)" : "refused");
+
+	/* The same file through V2, under its own environment. */
+	duckdb_v2_error_info_handle err = NULL;
+	duckdb_v2_environment_handle env = NULL;
+	duckdb_v2_database_handle v2_db = NULL;
+	duckdb_v2_create_environment(&env, &err);
+
+	DUCKDB_V2_ERROR error = duckdb_v2_open(env, str(path), NULL, 0, &v2_db, &err);
+	duckdb_v2_str text = {NULL, 0};
+	if (err) {
+		duckdb_v2_error_info_get_text(err, &text);
+	}
+	printf("v2 open same file:       %s (code %d) %.*s\n",
+	       error == DUCKDB_V2_ERROR_NONE ? "ok (NOT detected)" : "refused", (int)error,
+	       (int)text.len, text.ptr ? text.ptr : "");
+	if (err) {
+		duckdb_v2_error_info_destroy(&err);
+	}
+
+	/* Control: V2 does detect the same file twice within one environment. */
+	if (error == DUCKDB_V2_ERROR_NONE) {
+		duckdb_v2_database_handle v2_db_again = NULL;
+		DUCKDB_V2_ERROR control = duckdb_v2_open(env, str(path), NULL, 0, &v2_db_again, &err);
+		printf("v2 open twice (control): %s (code %d)\n",
+		       control == DUCKDB_V2_ERROR_NONE ? "ok" : "refused with RESOURCE_IN_USE", (int)control);
+		if (err) {
+			duckdb_v2_error_info_destroy(&err);
+		}
+		if (control == DUCKDB_V2_ERROR_NONE) {
+			duckdb_v2_close(&v2_db_again);
+		}
+	}
+
+	duckdb_v2_close(&v2_db);
+	duckdb_v2_destroy_environment(&env);
+	duckdb_close(&v1_db);
+	duckdb_close(&v1_db_again);
+	remove(path);
+	return 0;
+}

--- a/tools/capi-v2/compare_api.py
+++ b/tools/capi-v2/compare_api.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+"""Compare the DuckDB C API V1 and V2 surfaces, and Node Neo's coverage of them.
+
+Companion to ../capi-coverage, which measures Node Neo against the other five
+C-API clients. This one measures V1 against V2, for the DuckDB 2.0 migration. The
+V1 side -- the canonical function list and Node Neo's exposure of it -- is reused
+from that tool rather than re-derived, so both stay in agreement.
+
+The V2 API is still in flux on the duckdb v2.0-cyanoptera branch, so nothing here
+is hard-coded; every count comes from the headers.
+
+    python3 tools/capi-v2/compare_api.py --fetch      # download the 2.0-branch headers
+    python3 tools/capi-v2/compare_api.py              # print the report
+    python3 tools/capi-v2/compare_api.py --json DIR   # also write the inventories
+
+Headers are cached in .headers/ next to this script (gitignored).
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+
+here = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(here, "..", "capi-coverage"))
+
+from capi_functions import capi_functions  # noqa: E402
+from node_neo import node_neo_coverage  # noqa: E402
+
+branch = "v2.0-cyanoptera"
+raw_url = "https://raw.githubusercontent.com/duckdb/duckdb/{branch}/src/include/{name}"
+cache_dir = os.path.join(here, ".headers")
+
+# V2 declarations look the same as V1's, but V2 wraps them across lines more often.
+declaration_rule = re.compile(r"^DUCKDB_C_API\s+((?:[^;])*?);", re.M | re.S)
+name_rule = re.compile(r"([A-Za-z_][A-Za-z0-9_]*)\s*\(")
+
+# V2 groups functions under banner comments inside a block comment, rather than V1's
+# //---- rules:
+#     /* ====...
+#      * MODULE: vector
+#      * ====... */
+module_rule = re.compile(r"^ \* MODULE: (.*)$")
+
+
+def fetch_headers():
+  os.makedirs(cache_dir, exist_ok=True)
+  for name in ("duckdb.h", "duckdb_v2.h"):
+    url = raw_url.format(branch=branch, name=name)
+    print(f"fetching: {url}")
+    urllib.request.urlretrieve(url, os.path.join(cache_dir, name))
+
+
+def declarations(path):
+  """Map function name -> normalized declaration, in header order."""
+  text = open(path, encoding="utf-8").read()
+  out = {}
+  for match in declaration_rule.finditer(text):
+    declaration = re.sub(r"\s+", " ", match.group(1)).strip()
+    name = name_rule.search(declaration)
+    if name:
+      out[name.group(1)] = declaration
+  return out
+
+
+def v2_modules(path):
+  """Map V2 module name -> function names."""
+  text = open(path, encoding="utf-8").read()
+  lines = text.split("\n")
+  banners = [
+    (i + 1, match.group(1).strip())
+    for i, line in enumerate(lines)
+    for match in [module_rule.match(line)]
+    if match
+  ]
+
+  modules = {}
+  for match in declaration_rule.finditer(text):
+    line_no = text.count("\n", 0, match.start()) + 1
+    name = name_rule.search(re.sub(r"\s+", " ", match.group(1)).strip()).group(1)
+    module = "(preamble)"
+    for at, title in banners:
+      if at <= line_no:
+        module = title
+      else:
+        break
+    modules.setdefault(module, []).append(name)
+  return modules
+
+
+def v1_drift(shipped, on_branch, exposed):
+  """What changed in the V1 surface itself between 1.5.5 and 2.0."""
+  removed = sorted(set(shipped) - set(on_branch))
+  added = sorted(set(on_branch) - set(shipped))
+  changed = sorted(
+    name for name in set(shipped) & set(on_branch)
+    if shipped[name] != on_branch[name]
+  )
+
+  print(f"\nV1 drift into 2.0: {len(removed)} removed, {len(added)} added, "
+        f"{len(changed)} signature changes")
+  for name in removed:
+    print(f"  removed  {name}{'   [exposed by Neo]' if name in exposed else ''}")
+  for name in added:
+    print(f"  added    {name}")
+  for name in changed:
+    print(f"  changed  {name}{'   [exposed by Neo]' if name in exposed else ''}")
+    print(f"             was: {shipped[name]}")
+    print(f"             now: {on_branch[name]}")
+
+
+def main():
+  parser = argparse.ArgumentParser(
+    description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+  )
+  parser.add_argument("--fetch", action="store_true",
+                      help=f"download duckdb.h and duckdb_v2.h from {branch}")
+  parser.add_argument("--json", metavar="DIR", help="write inventories as JSON into DIR")
+  args = parser.parse_args()
+
+  if args.fetch:
+    fetch_headers()
+
+  v2_path = os.path.join(cache_dir, "duckdb_v2.h")
+  v1_branch_path = os.path.join(cache_dir, "duckdb.h")
+  if not os.path.exists(v2_path):
+    sys.exit(f"missing {v2_path}; run with --fetch first")
+
+  # The V1 side comes from capi-coverage, so the two tools cannot disagree.
+  v1_functions = capi_functions()
+  binding, _wrapper, reason, _symbol = node_neo_coverage()
+  exposed = {name for name, is_exposed in binding.items() if is_exposed}
+
+  # capi_functions keeps the trailing semicolon; declarations() does not.
+  v1_shipped = {
+    f["function"]: f["declaration"].rstrip(";").strip() for f in v1_functions
+  }
+  v1_on_branch = declarations(v1_branch_path) if os.path.exists(v1_branch_path) else {}
+  v2 = declarations(v2_path)
+
+  deprecated = sum(1 for f in v1_functions if f["deprecated"])
+  print(f"V1 (shipped, bindings/libduckdb/duckdb.h): {len(v1_shipped)} functions "
+        f"({deprecated} deprecated)")
+  if v1_on_branch:
+    print(f"V1 (on {branch}):                  {len(v1_on_branch)} functions")
+  print(f"V2 (duckdb_v2.h on {branch}):      {len(v2)} functions")
+  print(f"Node Neo exposes:                          {len(exposed)} of "
+        f"{len(v1_shipped)} V1 functions")
+
+  if v1_on_branch:
+    v1_drift(v1_shipped, v1_on_branch, exposed)
+
+  groups = {}
+  for function in v1_functions:
+    groups.setdefault(function["group"], []).append(function["function"])
+
+  print(f"\n{'V1 group':<38} {'total':>6} {'in Neo':>7}")
+  print("-" * 53)
+  for title, names in groups.items():
+    print(f"{title:<38} {len(names):6d} "
+          f"{sum(1 for n in names if n in exposed):7d}")
+
+  modules = v2_modules(v2_path)
+  print(f"\n{'V2 module':<38} {'total':>6}")
+  print("-" * 46)
+  for title, names in modules.items():
+    print(f"{title:<38} {len(names):6d}")
+
+  print("\nWhy Node Neo skips the rest of V1:")
+  tally = {}
+  for name in set(v1_shipped) - exposed:
+    key = reason.get(name) or "(no reason recorded)"
+    tally[key] = tally.get(key, 0) + 1
+  for key, count in sorted(tally.items(), key=lambda item: -item[1]):
+    print(f"  {count:3d}  {key}")
+
+  if args.json:
+    os.makedirs(args.json, exist_ok=True)
+    inventories = [
+      ("v1_functions.json", v1_shipped),
+      ("v2_functions.json", v2),
+      ("v1_groups.json", groups),
+      ("v2_modules.json", modules),
+      ("neo_coverage.json", {"exposed": sorted(exposed), "reasons": reason}),
+    ]
+    for name, payload in inventories:
+      with open(os.path.join(args.json, name), "w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=1)
+    print(f"\nwrote inventories to {args.json}")
+
+
+if __name__ == "__main__":
+  main()

--- a/tools/capi-v2/fetch_libduckdb_v2.py
+++ b/tools/capi-v2/fetch_libduckdb_v2.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Fetch the DuckDB 2.0 preview shared library + headers for a platform.
+
+The 2.0 preview is not a GitHub release, so bindings/scripts/fetch_libduckdb_*.py
+cannot reach it. Preview artifacts live under artifacts.duckdb.org keyed by the
+release branch, and ship as tarballs rather than the release zips:
+
+    https://artifacts.duckdb.org/v2.0-cyanoptera/duckdb-shared-libs-<suffix>.tar.gz
+
+Each tarball contains libduckdb.{dylib,so,dll}, duckdb.h, duckdb_v2.h,
+duckdb_extension.h and duckdb_extension_v2.h.
+
+    python3 tools/capi-v2/fetch_libduckdb_v2.py                  # host platform
+    python3 tools/capi-v2/fetch_libduckdb_v2.py linux-amd64      # a named one
+"""
+
+import os
+import platform
+import sys
+import tarfile
+import urllib.request
+
+BRANCH = "v2.0-cyanoptera"
+URL = "https://artifacts.duckdb.org/{branch}/duckdb-shared-libs-{suffix}.tar.gz"
+
+# The suffixes published for the preview, one per platform Node Neo targets.
+SUFFIXES = [
+    "osx-universal",
+    "linux-amd64",
+    "linux-arm64",
+    "linux-amd64-musl",
+    "linux-arm64-musl",
+    "windows-amd64",
+    "windows-arm64",
+]
+
+OUT = os.path.join(os.path.dirname(os.path.abspath(__file__)), "libduckdb-v2")
+
+
+def host_suffix():
+    system, machine = platform.system(), platform.machine().lower()
+    if system == "Darwin":
+        return "osx-universal"
+    arch = "arm64" if machine in ("arm64", "aarch64") else "amd64"
+    if system == "Linux":
+        return f"linux-{arch}"
+    if system == "Windows":
+        return f"windows-{arch}"
+    sys.exit(f"unrecognized platform {system}/{machine}; pass a suffix explicitly")
+
+
+def main():
+    suffix = sys.argv[1] if len(sys.argv) > 1 else host_suffix()
+    if suffix not in SUFFIXES:
+        sys.exit(f"unknown suffix {suffix!r}; expected one of: {', '.join(SUFFIXES)}")
+
+    url = URL.format(branch=BRANCH, suffix=suffix)
+    os.makedirs(OUT, exist_ok=True)
+    archive = os.path.join(OUT, f"duckdb-shared-libs-{suffix}.tar.gz")
+
+    print(f"fetching: {url}")
+    # artifacts.duckdb.org rejects urllib's default User-Agent with a 403.
+    request = urllib.request.Request(url, headers={"User-Agent": "duckdb-node-neo/capi-v2-survey"})
+    with urllib.request.urlopen(request) as response, open(archive, "wb") as f:
+        while chunk := response.read(1 << 20):
+            f.write(chunk)
+    with tarfile.open(archive) as tar:
+        for member in tar.getmembers():
+            print(f"extracting: {member.name}")
+        tar.extractall(OUT)
+    print(f"\n{OUT}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/capi-v2/smoke_v2.c
+++ b/tools/capi-v2/smoke_v2.c
@@ -1,0 +1,123 @@
+/* A minimal end-to-end exercise of the DuckDB C API V2, used to confirm that the
+ * 2.0 preview library works and to show the shape of the calling convention Node
+ * Neo's bindings will have to adopt.
+ *
+ *   python3 tools/capi-v2/fetch_libduckdb_v2.py
+ *   cc -std=c11 -I libduckdb-v2 smoke_v2.c -L libduckdb-v2 -lduckdb \
+ *      -Wl,-rpath,@loader_path/libduckdb-v2 -o smoke_v2 && ./smoke_v2
+ *
+ * Note what V1 does in one call and V2 spreads across several: opening needs an
+ * environment, querying goes through a statement iterator, and a result is always
+ * a stream. Every call returns a status and writes its product to an out-param.
+ */
+
+#include "duckdb_v2.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static duckdb_v2_str str(const char *s) {
+	duckdb_v2_str v;
+	v.ptr = s;
+	v.len = s ? strlen(s) : 0;
+	return v;
+}
+
+/* Every V2 call reports through a return code plus an optional error handle that
+ * carries the message. The handle is owned by the caller even on the paths that
+ * abandon the operation. */
+#define CHECK(expr)                                                                                                    \
+	do {                                                                                                               \
+		DUCKDB_V2_ERROR error = (expr);                                                                                \
+		if (error != DUCKDB_V2_ERROR_NONE) {                                                                           \
+			duckdb_v2_str text = {NULL, 0};                                                                            \
+			if (err) {                                                                                                 \
+				duckdb_v2_error_info_get_text(err, &text);                                                             \
+			}                                                                                                          \
+			printf("FAIL %s -> %d: %.*s\n", #expr, (int)error, (int)text.len, text.ptr ? text.ptr : "");                \
+			if (err) {                                                                                                 \
+				duckdb_v2_error_info_destroy(&err);                                                                    \
+			}                                                                                                          \
+			return 1;                                                                                                  \
+		}                                                                                                              \
+	} while (0)
+
+int main(void) {
+	duckdb_v2_error_info_handle err = NULL;
+	duckdb_v2_environment_handle env = NULL;
+	duckdb_v2_database_handle db = NULL;
+	duckdb_v2_connection_handle conn = NULL;
+	duckdb_v2_statement_iterator_handle iterator = NULL;
+	duckdb_v2_sql_statement_handle statement = NULL;
+	duckdb_v2_result_handle result = NULL;
+	duckdb_v2_schema_handle schema = NULL;
+
+	CHECK(duckdb_v2_create_environment(&env, &err));
+	CHECK(duckdb_v2_open(env, str(":memory:"), NULL, 0, &db, &err));
+	CHECK(duckdb_v2_connect(db, &conn, &err));
+
+	/* SQL text is parsed into a statement iterator, replacing both duckdb_query
+	 * and duckdb_extract_statements. */
+	CHECK(duckdb_v2_parse_sql(conn, "select 42 as answer, 'hi' as greeting, [1,2,3] as lst", &iterator, &err));
+	CHECK(duckdb_v2_statement_iterator_next(iterator, &statement, &err));
+	CHECK(duckdb_v2_statement_execute(conn, statement, NULL, NULL, 0, &result, &err));
+
+	/* Column names and types arrive together as a schema rather than as
+	 * per-column duckdb_column_name / duckdb_column_type calls. */
+	CHECK(duckdb_v2_result_get_schema(result, &schema, &err));
+	idx_t column_count = 0;
+	CHECK(duckdb_v2_schema_get_count(schema, &column_count, &err));
+	printf("columns: %llu\n", (unsigned long long)column_count);
+	for (idx_t i = 0; i < column_count; i++) {
+		duckdb_v2_identifier_t name = {NULL, 0};
+		duckdb_v2_logical_type_handle type = NULL;
+		/* Both are borrowed from the schema, and neither may be destroyed. */
+		CHECK(duckdb_v2_schema_get_field(schema, i, &name, &type, &err));
+		char text[256];
+		idx_t length = 0;
+		CHECK(duckdb_v2_logical_type_to_text(type, text, sizeof(text), &length, &err));
+		printf("  [%llu] %.*s : %s\n", (unsigned long long)i, (int)name.len, name.ptr, text);
+	}
+
+	/* Results are always streamed. WAITING means the query has produced nothing
+	 * yet, which is where an async binding would yield instead of blocking in
+	 * result_wait. This replaces the pending-result interface. */
+	idx_t rows = 0;
+	while (1) {
+		duckdb_v2_data_chunk_handle chunk = NULL;
+		DUCKDB_V2_RESULT_STEP_STATUS status;
+		CHECK(duckdb_v2_result_step(result, &chunk, &status, &err));
+		if (status == DUCKDB_V2_RESULT_STEP_STATUS_WAITING) {
+			CHECK(duckdb_v2_result_wait(result, &err));
+			continue;
+		}
+		if (status != DUCKDB_V2_RESULT_STEP_STATUS_CHUNK) {
+			break;
+		}
+		idx_t size = 0;
+		CHECK(duckdb_v2_data_chunk_get_size(chunk, &size, &err));
+		rows += size;
+
+		duckdb_v2_vector_handle vector = NULL;
+		CHECK(duckdb_v2_data_chunk_get_vector(chunk, 0, &vector, &err));
+		/* One view carries data, validity, selection and count together, so a
+		 * reader no longer has to special-case flat versus dictionary vectors. */
+		duckdb_v2_vector_view view;
+		CHECK(duckdb_v2_vector_get_view(vector, &view, &err));
+		printf("chunk rows=%llu answer[0]=%d\n", (unsigned long long)size, ((const int32_t *)view.data)[0]);
+
+		duckdb_v2_data_chunk_destroy(&chunk);
+	}
+	printf("total rows: %llu\n", (unsigned long long)rows);
+
+	duckdb_v2_schema_destroy(&schema);
+	duckdb_v2_result_destroy(&result);
+	duckdb_v2_sql_statement_destroy(&statement);
+	duckdb_v2_statement_iterator_destroy(&iterator);
+	duckdb_v2_disconnect(&conn);
+	duckdb_v2_close(&db);
+	duckdb_v2_destroy_environment(&env);
+
+	printf("OK\n");
+	return 0;
+}


### PR DESCRIPTION
Surveys the DuckDB C API V2 ahead of the 2.0 migration, and adds the tooling to keep the survey honest as V2 keeps moving. Docs and tooling only — nothing here touches `bindings/src` or `api/src`.

Sits in `tools/capi-v2/`, next to `tools/capi-coverage/`, and reuses that tool's modules for the V1 side (`capi_functions.py` for the canonical function list, `node_neo.py` for our exposure of it), so the two cannot disagree about V1.

## What's here

- **`README.md`** — the survey. A taxonomy of the V1→V2 differences, Node Neo's coverage per V1 group with the V2 status of each, what V2 does not cover, the decided migration approach, and a "When 2.0 ships" checklist.
- **`compare_api.py`** — re-derives every count in the survey from the headers. All three C-API-V2 PRs describe the API as still moving, so nothing is hard-coded.
- **`fetch_libduckdb_v2.py`** — fetches the 2.0 preview library, published as `duckdb-shared-libs-<suffix>.tar.gz` under `artifacts.duckdb.org` rather than as a GitHub release, and so out of reach of `bindings/scripts/fetch_libduckdb_*.py`.
- **`smoke_v2.c`** — open, query and read a result through V2. Verified against the preview build.
- **`coexist_probe.c`** — checks whether one database file opened through both V1 and V2 is detected.

## Findings that shape the plan

**V1 keeps working in 2.0.** Zero functions removed, two added, and thirteen cosmetic `()` → `(void)` edits. One `libduckdb` exports all 546 V1 symbols alongside all 527 V2 symbols, so both surfaces can be mixed in one addon and the migration can be incremental. Per the DuckDB team, V1 is deprecated in 2.0 and probably removed in 3.0, about a year out — so it's a fixed window rather than open-ended.

**V2 is a redesign, not a rename.** Of the 314 V1 functions Node Neo exposes, roughly a third maps mechanically, a third needs restructuring (query execution becomes parse → iterate → bind → execute → step; results always stream; logical types collapse into construct-by-name/id/text plus generic `get_param`; every value constructor takes a connection or context), and a third has no counterpart.

**No appender in V2, and none planned** — the bulk-append scenario is ours to cover, over column data collections plus replacement scans.

## The two script changes

`bindings/scripts/checkFunctionSignatures.mjs` and `tools/capi-coverage/capi_functions.py` both key on the guard wrapping deprecated declarations, which 2.0 respells: `#ifndef DUCKDB_API_NO_DEPRECATED` becomes `#if (DUCKDB_API_VERSION_BELOW(x, y, z) || DUCKDB_API_ALLOW_DEPRECATED)`. Both now accept either spelling, and `checkFunctionSignatures.mjs` stamps both with the legacy name so the `// #ifndef DUCKDB_API_NO_DEPRECATED` markers in `duckdb.d.ts` and `duckdb_node_bindings.cpp` need no rewriting.

Worth landing now because `capi_functions.py` was reporting the right 48 for the wrong reason against a 2.0 header — the guard signal contributed nothing and the `DEPRECATION NOTICE` doc-text fallback carried all of them alone, so a rewording upstream would have silently zeroed the column.

Verified against 1.5.5: byte-identical `headerSigs` / `typeDefsSigs` / `bindingsSigs`, both checks still passing, and `capi_coverage.csv` unaffected. Against the 2.0 header: 48 stamped and zero guard-stamp differences, leaving only the genuine content drift the tool should report.

## Reviewing

```bash
python3 tools/capi-v2/compare_api.py --fetch
python3 tools/capi-v2/compare_api.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
