### PR TITLE
Reject integers that don't fit instead of wrapping them

### DIFF
--- a/api/src/vectors/DuckDBBigIntVector.ts
+++ b/api/src/vectors/DuckDBBigIntVector.ts
@@ -45,6 +45,10 @@ export class DuckDBBigIntVector extends DuckDBVector<bigint> {
   }
   public override setItem(itemIndex: number, value: bigint | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (BigInt.asIntN(64, value) !== value) {
+        throw new Error(`bigint out of int64 range`);
+      }
       this.items[itemIndex] = value;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBDateVector.ts
+++ b/api/src/vectors/DuckDBDateVector.ts
@@ -47,6 +47,13 @@ export class DuckDBDateVector extends DuckDBVector<DuckDBDateValue> {
   }
   public override setItem(itemIndex: number, value: DuckDBDateValue | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (!Number.isInteger(value.days)) {
+        throw new Error(`number is not an integer`);
+      }
+      if (value.days < -2147483648 || value.days > 2147483647) {
+        throw new Error(`number out of int32 range`);
+      }
       this.items[itemIndex] = value.days;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBIntegerVector.ts
+++ b/api/src/vectors/DuckDBIntegerVector.ts
@@ -42,6 +42,13 @@ export class DuckDBIntegerVector extends DuckDBVector<number> {
   }
   public setItem(itemIndex: number, value: number | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (!Number.isInteger(value)) {
+        throw new Error(`number is not an integer`);
+      }
+      if (value < -2147483648 || value > 2147483647) {
+        throw new Error(`number out of int32 range`);
+      }
       this.items[itemIndex] = value;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBSmallIntVector.ts
+++ b/api/src/vectors/DuckDBSmallIntVector.ts
@@ -42,6 +42,13 @@ export class DuckDBSmallIntVector extends DuckDBVector<number> {
   }
   public override setItem(itemIndex: number, value: number | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (!Number.isInteger(value)) {
+        throw new Error(`number is not an integer`);
+      }
+      if (value < -32768 || value > 32767) {
+        throw new Error(`number out of int16 range`);
+      }
       this.items[itemIndex] = value;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBTimeNSVector.ts
+++ b/api/src/vectors/DuckDBTimeNSVector.ts
@@ -50,6 +50,10 @@ export class DuckDBTimeNSVector extends DuckDBVector<DuckDBTimeNSValue> {
   }
   public override setItem(itemIndex: number, value: DuckDBTimeNSValue | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (BigInt.asIntN(64, value.nanos) !== value.nanos) {
+        throw new Error(`bigint out of int64 range`);
+      }
       this.items[itemIndex] = value.nanos;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBTimeTZVector.ts
+++ b/api/src/vectors/DuckDBTimeTZVector.ts
@@ -50,6 +50,10 @@ export class DuckDBTimeTZVector extends DuckDBVector<DuckDBTimeTZValue> {
   }
   public override setItem(itemIndex: number, value: DuckDBTimeTZValue | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (BigInt.asUintN(64, value.bits) !== value.bits) {
+        throw new Error(`bigint out of uint64 range`);
+      }
       this.items[itemIndex] = value.bits;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBTimeVector.ts
+++ b/api/src/vectors/DuckDBTimeVector.ts
@@ -50,6 +50,10 @@ export class DuckDBTimeVector extends DuckDBVector<DuckDBTimeValue> {
   }
   public override setItem(itemIndex: number, value: DuckDBTimeValue | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (BigInt.asIntN(64, value.micros) !== value.micros) {
+        throw new Error(`bigint out of int64 range`);
+      }
       this.items[itemIndex] = value.micros;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBTimestampMillisecondsVector.ts
+++ b/api/src/vectors/DuckDBTimestampMillisecondsVector.ts
@@ -55,6 +55,10 @@ export class DuckDBTimestampMillisecondsVector extends DuckDBVector<DuckDBTimest
     value: DuckDBTimestampMillisecondsValue | null
   ) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (BigInt.asIntN(64, value.millis) !== value.millis) {
+        throw new Error(`bigint out of int64 range`);
+      }
       this.items[itemIndex] = value.millis;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBTimestampNanosecondsVector.ts
+++ b/api/src/vectors/DuckDBTimestampNanosecondsVector.ts
@@ -55,6 +55,10 @@ export class DuckDBTimestampNanosecondsVector extends DuckDBVector<DuckDBTimesta
     value: DuckDBTimestampNanosecondsValue | null
   ) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (BigInt.asIntN(64, value.nanos) !== value.nanos) {
+        throw new Error(`bigint out of int64 range`);
+      }
       this.items[itemIndex] = value.nanos;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBTimestampSecondsVector.ts
+++ b/api/src/vectors/DuckDBTimestampSecondsVector.ts
@@ -55,6 +55,10 @@ export class DuckDBTimestampSecondsVector extends DuckDBVector<DuckDBTimestampSe
     value: DuckDBTimestampSecondsValue | null
   ) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (BigInt.asIntN(64, value.seconds) !== value.seconds) {
+        throw new Error(`bigint out of int64 range`);
+      }
       this.items[itemIndex] = value.seconds;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBTimestampTZVector.ts
+++ b/api/src/vectors/DuckDBTimestampTZVector.ts
@@ -53,6 +53,10 @@ export class DuckDBTimestampTZVector extends DuckDBVector<DuckDBTimestampTZValue
     value: DuckDBTimestampTZValue | null
   ) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (BigInt.asIntN(64, value.micros) !== value.micros) {
+        throw new Error(`bigint out of int64 range`);
+      }
       this.items[itemIndex] = value.micros;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBTimestampVector.ts
+++ b/api/src/vectors/DuckDBTimestampVector.ts
@@ -53,6 +53,10 @@ export class DuckDBTimestampVector extends DuckDBVector<DuckDBTimestampValue> {
     value: DuckDBTimestampValue | null
   ) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (BigInt.asIntN(64, value.micros) !== value.micros) {
+        throw new Error(`bigint out of int64 range`);
+      }
       this.items[itemIndex] = value.micros;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBTinyIntVector.ts
+++ b/api/src/vectors/DuckDBTinyIntVector.ts
@@ -42,6 +42,13 @@ export class DuckDBTinyIntVector extends DuckDBVector<number> {
   }
   public override setItem(itemIndex: number, value: number | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (!Number.isInteger(value)) {
+        throw new Error(`number is not an integer`);
+      }
+      if (value < -128 || value > 127) {
+        throw new Error(`number out of int8 range`);
+      }
       this.items[itemIndex] = value;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBUBigIntVector.ts
+++ b/api/src/vectors/DuckDBUBigIntVector.ts
@@ -45,6 +45,10 @@ export class DuckDBUBigIntVector extends DuckDBVector<bigint> {
   }
   public override setItem(itemIndex: number, value: bigint | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (BigInt.asUintN(64, value) !== value) {
+        throw new Error(`bigint out of uint64 range`);
+      }
       this.items[itemIndex] = value;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBUIntegerVector.ts
+++ b/api/src/vectors/DuckDBUIntegerVector.ts
@@ -42,6 +42,13 @@ export class DuckDBUIntegerVector extends DuckDBVector<number> {
   }
   public override setItem(itemIndex: number, value: number | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (!Number.isInteger(value)) {
+        throw new Error(`number is not an integer`);
+      }
+      if (value < 0 || value > 4294967295) {
+        throw new Error(`number out of uint32 range`);
+      }
       this.items[itemIndex] = value;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBUSmallIntVector.ts
+++ b/api/src/vectors/DuckDBUSmallIntVector.ts
@@ -42,6 +42,13 @@ export class DuckDBUSmallIntVector extends DuckDBVector<number> {
   }
   public override setItem(itemIndex: number, value: number | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (!Number.isInteger(value)) {
+        throw new Error(`number is not an integer`);
+      }
+      if (value < 0 || value > 65535) {
+        throw new Error(`number out of uint16 range`);
+      }
       this.items[itemIndex] = value;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/DuckDBUTinyIntVector.ts
+++ b/api/src/vectors/DuckDBUTinyIntVector.ts
@@ -42,6 +42,13 @@ export class DuckDBUTinyIntVector extends DuckDBVector<number> {
   }
   public override setItem(itemIndex: number, value: number | null) {
     if (value != null) {
+      // Checked inline for bulk-write throughput; see dataAccessors.ts.
+      if (!Number.isInteger(value)) {
+        throw new Error(`number is not an integer`);
+      }
+      if (value < 0 || value > 255) {
+        throw new Error(`number out of uint8 range`);
+      }
       this.items[itemIndex] = value;
       this.validity.setItemValid(itemIndex, true);
     } else {

--- a/api/src/vectors/dataAccessors.ts
+++ b/api/src/vectors/dataAccessors.ts
@@ -170,39 +170,131 @@ export function makeGetBoolean(): (dataView: DataView, offset: number) => boolea
 
 export const getBoolean = makeGetBoolean();
 
+// Range checks for fixed-width integers
+
+// Writing a number to a DataView applies the JS ToInt32 and ToUint32 operations,
+// which wrap out-of-range values modulo the type's width and truncate fractional
+// ones; writing a bigint wraps in the same way. Doing that for data values would
+// silently store something other than what the caller supplied, so the setters
+// below check first. See duckdb/duckdb-node-neo#469.
+//
+// The vectors backed by a typed array rather than a DataView repeat these checks
+// inline instead of calling them: they sit in the inner loop of every bulk write,
+// and calling across a module boundary there costs about 20% of write throughput.
+// Keep the two in sync; api/test/integer-ranges.test.ts checks every bound.
+
+function checkUInt8(value: number): number {
+  if (!Number.isInteger(value)) {
+    throw new Error(`number is not an integer`);
+  }
+  if (value < 0 || value > 255) {
+    throw new Error(`number out of uint8 range`);
+  }
+  return value;
+}
+
+function checkInt16(value: number): number {
+  if (!Number.isInteger(value)) {
+    throw new Error(`number is not an integer`);
+  }
+  if (value < -32768 || value > 32767) {
+    throw new Error(`number out of int16 range`);
+  }
+  return value;
+}
+
+function checkUInt16(value: number): number {
+  if (!Number.isInteger(value)) {
+    throw new Error(`number is not an integer`);
+  }
+  if (value < 0 || value > 65535) {
+    throw new Error(`number out of uint16 range`);
+  }
+  return value;
+}
+
+function checkInt32(value: number): number {
+  if (!Number.isInteger(value)) {
+    throw new Error(`number is not an integer`);
+  }
+  if (value < -2147483648 || value > 2147483647) {
+    throw new Error(`number out of int32 range`);
+  }
+  return value;
+}
+
+function checkUInt32(value: number): number {
+  if (!Number.isInteger(value)) {
+    throw new Error(`number is not an integer`);
+  }
+  if (value < 0 || value > 4294967295) {
+    throw new Error(`number out of uint32 range`);
+  }
+  return value;
+}
+
+function checkInt64(value: bigint): bigint {
+  if (BigInt.asIntN(64, value) !== value) {
+    throw new Error(`bigint out of int64 range`);
+  }
+  return value;
+}
+
+function checkUInt64(value: bigint): bigint {
+  if (BigInt.asUintN(64, value) !== value) {
+    throw new Error(`bigint out of uint64 range`);
+  }
+  return value;
+}
+
+function checkInt128(value: bigint): bigint {
+  if (BigInt.asIntN(128, value) !== value) {
+    throw new Error(`bigint out of int128 range`);
+  }
+  return value;
+}
+
+function checkUInt128(value: bigint): bigint {
+  if (BigInt.asUintN(128, value) !== value) {
+    throw new Error(`bigint out of uint128 range`);
+  }
+  return value;
+}
+
 // function setInt8(dataView: DataView, offset: number, value: number) {
 //   dataView.setInt8(offset, value);
 // }
 
 export function setUInt8(dataView: DataView, offset: number, value: number) {
-  dataView.setUint8(offset, value);
+  dataView.setUint8(offset, checkUInt8(value));
 }
 
 export function setInt16(dataView: DataView, offset: number, value: number) {
-  dataView.setInt16(offset, value, littleEndian);
+  dataView.setInt16(offset, checkInt16(value), littleEndian);
 }
 
 export function setUInt16(dataView: DataView, offset: number, value: number) {
-  dataView.setUint16(offset, value, littleEndian);
+  dataView.setUint16(offset, checkUInt16(value), littleEndian);
 }
 
 export function setInt32(dataView: DataView, offset: number, value: number) {
-  dataView.setInt32(offset, value, littleEndian);
+  dataView.setInt32(offset, checkInt32(value), littleEndian);
 }
 
 export function setUInt32(dataView: DataView, offset: number, value: number) {
-  dataView.setUint32(offset, value, littleEndian);
+  dataView.setUint32(offset, checkUInt32(value), littleEndian);
 }
 
 export function setInt64(dataView: DataView, offset: number, value: bigint) {
-  dataView.setBigInt64(offset, value, littleEndian);
+  dataView.setBigInt64(offset, checkInt64(value), littleEndian);
 }
 
 export function setUInt64(dataView: DataView, offset: number, value: bigint) {
-  dataView.setBigUint64(offset, value, littleEndian);
+  dataView.setBigUint64(offset, checkUInt64(value), littleEndian);
 }
 
 export function setInt128(dataView: DataView, offset: number, value: bigint) {
+  checkInt128(value);
   const lower = BigInt.asUintN(64, value);
   const upper = BigInt.asIntN(64, value >> BigInt(64));
   dataView.setBigUint64(offset, lower, littleEndian);
@@ -210,6 +302,7 @@ export function setInt128(dataView: DataView, offset: number, value: bigint) {
 }
 
 export function setUInt128(dataView: DataView, offset: number, value: bigint) {
+  checkUInt128(value);
   const lower = BigInt.asUintN(64, value);
   const upper = BigInt.asUintN(64, value >> BigInt(64));
   dataView.setBigUint64(offset, lower, littleEndian);

--- a/api/test/integer-ranges.test.ts
+++ b/api/test/integer-ranges.test.ts
@@ -1,0 +1,185 @@
+import { assert, describe, expect, test } from 'vitest';
+import {
+  BIGINT,
+  DuckDBDataChunk,
+  DuckDBType,
+  DuckDBValue,
+  HUGEINT,
+  INTEGER,
+  SMALLINT,
+  TINYINT,
+  UBIGINT,
+  UHUGEINT,
+  UINTEGER,
+  USMALLINT,
+  UTINYINT,
+} from '../src';
+import { withConnection } from './util/testHelpers';
+
+/**
+ * Writing a number to a typed array, or a bigint to a DataView, wraps values that
+ * don't fit rather than reporting them. Vectors used to do that silently, storing
+ * a value other than the one supplied. See duckdb/duckdb-node-neo#469.
+ */
+
+interface VectorCase {
+  name: string;
+  type: DuckDBType;
+  min: DuckDBValue;
+  max: DuckDBValue;
+  aboveMax: DuckDBValue;
+  belowMin: DuckDBValue;
+  rangeError: string;
+}
+
+function numberCase(
+  name: string,
+  type: DuckDBType,
+  min: number,
+  max: number
+): VectorCase {
+  return {
+    name,
+    type,
+    min,
+    max,
+    aboveMax: max + 1,
+    belowMin: min - 1,
+    rangeError: `number out of ${name} range`,
+  };
+}
+
+function bigintCase(
+  name: string,
+  type: DuckDBType,
+  min: bigint,
+  max: bigint
+): VectorCase {
+  return {
+    name,
+    type,
+    min,
+    max,
+    aboveMax: max + 1n,
+    belowMin: min - 1n,
+    rangeError: `bigint out of ${name} range`,
+  };
+}
+
+const numberVectors: VectorCase[] = [
+  numberCase('int8', TINYINT, -128, 127),
+  numberCase('uint8', UTINYINT, 0, 255),
+  numberCase('int16', SMALLINT, -32768, 32767),
+  numberCase('uint16', USMALLINT, 0, 65535),
+  numberCase('int32', INTEGER, -2147483648, 2147483647),
+  numberCase('uint32', UINTEGER, 0, 4294967295),
+];
+
+const bigintVectors: VectorCase[] = [
+  bigintCase('int64', BIGINT, -(2n ** 63n), 2n ** 63n - 1n),
+  bigintCase('uint64', UBIGINT, 0n, 2n ** 64n - 1n),
+  bigintCase('int128', HUGEINT, -(2n ** 127n), 2n ** 127n - 1n),
+  bigintCase('uint128', UHUGEINT, 0n, 2n ** 128n - 1n),
+];
+
+// A chunk owns the memory its vectors are views over, and a vector holds no
+// reference back to its chunk, so the chunk has to stay reachable for as long as
+// the vector is used. Each test below keeps it in a local.
+function chunkFor(type: DuckDBType) {
+  return DuckDBDataChunk.create([type], 2);
+}
+
+describe('vector setItem range checks', () => {
+  for (const vectorCase of [...numberVectors, ...bigintVectors]) {
+    describe(vectorCase.name, () => {
+      test('min and max round-trip', () => {
+        const chunk = chunkFor(vectorCase.type);
+        const vector = chunk.getColumnVector(0);
+        vector.setItem(0, vectorCase.min);
+        vector.setItem(1, vectorCase.max);
+        assert.equal(vector.getItem(0), vectorCase.min);
+        assert.equal(vector.getItem(1), vectorCase.max);
+      });
+      test('above max', () => {
+        const chunk = chunkFor(vectorCase.type);
+        const vector = chunk.getColumnVector(0);
+        expect(() => vector.setItem(0, vectorCase.aboveMax)).toThrowError(
+          vectorCase.rangeError
+        );
+      });
+      test('below min', () => {
+        const chunk = chunkFor(vectorCase.type);
+        const vector = chunk.getColumnVector(0);
+        expect(() => vector.setItem(0, vectorCase.belowMin)).toThrowError(
+          vectorCase.rangeError
+        );
+      });
+    });
+  }
+
+  // Only the number-backed vectors can be handed a non-integer.
+  for (const vectorCase of numberVectors) {
+    describe(`${vectorCase.name} non-integers`, () => {
+      for (const [name, input] of [
+        ['fractional', 1.5],
+        ['NaN', NaN],
+        ['Infinity', Infinity],
+        ['-Infinity', -Infinity],
+      ] as const) {
+        test(name, () => {
+          const chunk = chunkFor(vectorCase.type);
+          const vector = chunk.getColumnVector(0);
+          expect(() => vector.setItem(0, input)).toThrowError(
+            'number is not an integer'
+          );
+        });
+      }
+    });
+  }
+
+  test('setColumnValues reports an out-of-range value', () => {
+    const chunk = DuckDBDataChunk.create([UINTEGER], 2);
+    expect(() => chunk.setColumnValues(0, [42, 2 ** 32 + 1])).toThrowError(
+      'number out of uint32 range'
+    );
+  });
+});
+
+describe('appender and prepared statement range checks', () => {
+  // The report in duckdb/duckdb-node-neo#469.
+  test('appendUInteger rejects values that do not fit', async () => {
+    await withConnection(async (connection) => {
+      await connection.run('create table t (a uinteger, b uinteger)');
+      const appender = await connection.createAppender('t');
+      expect(() => appender.appendUInteger(2 ** 32 + 1)).toThrowError(
+        'number out of uint32 range'
+      );
+      expect(() => appender.appendUInteger(-1)).toThrowError(
+        'number out of uint32 range'
+      );
+      expect(() => appender.appendUInteger(1.5)).toThrowError(
+        'number is not an integer'
+      );
+      expect(() => appender.appendUInteger(4294967295)).not.toThrow();
+    });
+  });
+
+  test('bindUInteger rejects values that do not fit', async () => {
+    await withConnection(async (connection) => {
+      const prepared = await connection.prepare('select ?::uinteger as v');
+      expect(() => prepared.bindUInteger(1, 2 ** 32 + 1)).toThrowError(
+        'number out of uint32 range'
+      );
+      expect(() => prepared.bindUInteger(1, 4294967295)).not.toThrow();
+    });
+  });
+
+  test('bindValue rejects values that do not fit the given type', async () => {
+    await withConnection(async (connection) => {
+      const prepared = await connection.prepare('select ? as v');
+      expect(() => prepared.bindValue(1, 2 ** 32 + 1, UINTEGER)).toThrowError(
+        'number out of uint32 range'
+      );
+    });
+  });
+});

--- a/bindings/src/conversion_helpers.h
+++ b/bindings/src/conversion_helpers.h
@@ -2,7 +2,10 @@
 
 #include "napi_setup.h"
 #include "duckdb.h"
+#include <cmath>
 #include <cstddef>
+#include <limits>
+#include <string>
 
 // Napi helpers
 
@@ -10,6 +13,52 @@ inline Napi::Reference<Napi::Value> MakeValueRef(Napi::Value value) {
   return value.IsUndefined()
     ? Napi::Reference<Napi::Value>() 
     : Napi::Reference<Napi::Value>::New(value, 1);
+}
+
+// Conversion from JS numbers to fixed-width integers
+
+// Napi's Int32Value and Uint32Value implement the JS ToInt32 and ToUint32
+// operations, which wrap out-of-range values modulo 2^32 and truncate fractional
+// ones. Using them for data values would silently store something other than what
+// the caller supplied, so convert through these instead, which reject any input
+// that doesn't fit exactly. (The BigInt conversions below reject in the same way,
+// via their lossless flags.) The struct-from-object converters pass a value_name so
+// the error names the offending field, as "micros out of int64 range" already does.
+template <typename T>
+inline T GetIntegerFromNumber(Napi::Env env, Napi::Number number, const char *type_name, const char *value_name) {
+  auto value = number.DoubleValue();
+  if (!std::isfinite(value) || value != std::trunc(value)) {
+    throw Napi::Error::New(env, std::string(value_name) + " is not an integer");
+  }
+  if (value < static_cast<double>(std::numeric_limits<T>::min()) ||
+      value > static_cast<double>(std::numeric_limits<T>::max())) {
+    throw Napi::Error::New(env, std::string(value_name) + " out of " + type_name + " range");
+  }
+  return static_cast<T>(value);
+}
+
+inline int8_t GetInt8FromNumber(Napi::Env env, Napi::Number number, const char *value_name = "number") {
+  return GetIntegerFromNumber<int8_t>(env, number, "int8", value_name);
+}
+
+inline int16_t GetInt16FromNumber(Napi::Env env, Napi::Number number, const char *value_name = "number") {
+  return GetIntegerFromNumber<int16_t>(env, number, "int16", value_name);
+}
+
+inline int32_t GetInt32FromNumber(Napi::Env env, Napi::Number number, const char *value_name = "number") {
+  return GetIntegerFromNumber<int32_t>(env, number, "int32", value_name);
+}
+
+inline uint8_t GetUInt8FromNumber(Napi::Env env, Napi::Number number, const char *value_name = "number") {
+  return GetIntegerFromNumber<uint8_t>(env, number, "uint8", value_name);
+}
+
+inline uint16_t GetUInt16FromNumber(Napi::Env env, Napi::Number number, const char *value_name = "number") {
+  return GetIntegerFromNumber<uint16_t>(env, number, "uint16", value_name);
+}
+
+inline uint32_t GetUInt32FromNumber(Napi::Env env, Napi::Number number, const char *value_name = "number") {
+  return GetIntegerFromNumber<uint32_t>(env, number, "uint32", value_name);
 }
 
 // Conversion betweeen structs and objects
@@ -20,8 +69,8 @@ inline Napi::Object MakeDateObject(Napi::Env env, duckdb_date date) {
   return date_obj;
 }
 
-inline duckdb_date GetDateFromObject(Napi::Object date_obj) {
-  auto days = date_obj.Get("days").As<Napi::Number>().Int32Value();
+inline duckdb_date GetDateFromObject(Napi::Env env, Napi::Object date_obj) {
+  auto days = GetInt32FromNumber(env, date_obj.Get("days").As<Napi::Number>(), "days");
   return { days };
 }
 
@@ -33,10 +82,10 @@ inline Napi::Object MakeDatePartsObject(Napi::Env env, duckdb_date_struct date_p
   return date_parts_obj;
 }
 
-inline duckdb_date_struct GetDatePartsFromObject(Napi::Object date_parts_obj) {
-  int32_t year = date_parts_obj.Get("year").As<Napi::Number>().Int32Value();
-  int8_t month = date_parts_obj.Get("month").As<Napi::Number>().Int32Value();
-  int8_t day = date_parts_obj.Get("day").As<Napi::Number>().Int32Value();
+inline duckdb_date_struct GetDatePartsFromObject(Napi::Env env, Napi::Object date_parts_obj) {
+  int32_t year = GetInt32FromNumber(env, date_parts_obj.Get("year").As<Napi::Number>(), "year");
+  int8_t month = GetInt8FromNumber(env, date_parts_obj.Get("month").As<Napi::Number>(), "month");
+  int8_t day = GetInt8FromNumber(env, date_parts_obj.Get("day").As<Napi::Number>(), "day");
   return { year, month, day };
 }
 
@@ -64,11 +113,11 @@ inline Napi::Object MakeTimePartsObject(Napi::Env env, duckdb_time_struct time_p
   return time_parts_obj;
 }
 
-inline duckdb_time_struct GetTimePartsFromObject(Napi::Object time_parts_obj) {
-  int8_t hour = time_parts_obj.Get("hour").As<Napi::Number>().Int32Value();
-  int8_t min = time_parts_obj.Get("min").As<Napi::Number>().Int32Value();
-  int8_t sec = time_parts_obj.Get("sec").As<Napi::Number>().Int32Value();
-  int32_t micros = time_parts_obj.Get("micros").As<Napi::Number>().Int32Value();
+inline duckdb_time_struct GetTimePartsFromObject(Napi::Env env, Napi::Object time_parts_obj) {
+  int8_t hour = GetInt8FromNumber(env, time_parts_obj.Get("hour").As<Napi::Number>(), "hour");
+  int8_t min = GetInt8FromNumber(env, time_parts_obj.Get("min").As<Napi::Number>(), "min");
+  int8_t sec = GetInt8FromNumber(env, time_parts_obj.Get("sec").As<Napi::Number>(), "sec");
+  int32_t micros = GetInt32FromNumber(env, time_parts_obj.Get("micros").As<Napi::Number>(), "micros");
   return { hour, min, sec, micros };
 }
 
@@ -178,9 +227,9 @@ inline Napi::Object MakeTimestampPartsObject(Napi::Env env, duckdb_timestamp_str
   return timestamp_parts_obj;
 }
 
-inline duckdb_timestamp_struct GetTimestampPartsFromObject(Napi::Object timestamp_parts_obj) {
-  auto date = GetDatePartsFromObject(timestamp_parts_obj.Get("date").As<Napi::Object>());
-  auto time = GetTimePartsFromObject(timestamp_parts_obj.Get("time").As<Napi::Object>());
+inline duckdb_timestamp_struct GetTimestampPartsFromObject(Napi::Env env, Napi::Object timestamp_parts_obj) {
+  auto date = GetDatePartsFromObject(env, timestamp_parts_obj.Get("date").As<Napi::Object>());
+  auto time = GetTimePartsFromObject(env, timestamp_parts_obj.Get("time").As<Napi::Object>());
   return { date, time };
 }
 
@@ -193,8 +242,8 @@ inline Napi::Object MakeIntervalObject(Napi::Env env, duckdb_interval interval) 
 }
 
 inline duckdb_interval GetIntervalFromObject(Napi::Env env, Napi::Object interval_obj) {
-  int32_t months = interval_obj.Get("months").As<Napi::Number>().Int32Value();
-  int32_t days = interval_obj.Get("days").As<Napi::Number>().Int32Value();
+  int32_t months = GetInt32FromNumber(env, interval_obj.Get("months").As<Napi::Number>(), "months");
+  int32_t days = GetInt32FromNumber(env, interval_obj.Get("days").As<Napi::Number>(), "days");
   bool lossless;
   int64_t micros = interval_obj.Get("micros").As<Napi::BigInt>().Int64Value(&lossless);
   if (!lossless) {
@@ -328,8 +377,8 @@ inline Napi::Object MakeDecimalObject(Napi::Env env, duckdb_decimal decimal) {
 }
 
 inline duckdb_decimal GetDecimalFromObject(Napi::Env env, Napi::Object decimal_obj) {
-  uint8_t width = decimal_obj.Get("width").As<Napi::Number>().Uint32Value();
-  uint8_t scale = decimal_obj.Get("scale").As<Napi::Number>().Uint32Value();
+  uint8_t width = GetUInt8FromNumber(env, decimal_obj.Get("width").As<Napi::Number>(), "width");
+  uint8_t scale = GetUInt8FromNumber(env, decimal_obj.Get("scale").As<Napi::Number>(), "scale");
   auto value = GetHugeIntFromBigInt(env, decimal_obj.Get("value").As<Napi::BigInt>());
   return { width, scale, value };
 }

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -858,7 +858,7 @@ private:
   Napi::Value from_date(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto date_obj = info[0].As<Napi::Object>();
-    auto date = GetDateFromObject(date_obj);
+    auto date = GetDateFromObject(env, date_obj);
     auto date_parts = duckdb_from_date(date);
     return MakeDatePartsObject(env, date_parts);
   }
@@ -868,7 +868,7 @@ private:
   Napi::Value to_date(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto date_parts_obj = info[0].As<Napi::Object>();
-    auto date_parts = GetDatePartsFromObject(date_parts_obj);
+    auto date_parts = GetDatePartsFromObject(env, date_parts_obj);
     auto date = duckdb_to_date(date_parts);
     return MakeDateObject(env, date);
   }
@@ -878,7 +878,7 @@ private:
   Napi::Value is_finite_date(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto date_obj = info[0].As<Napi::Object>();
-    auto date = GetDateFromObject(date_obj);
+    auto date = GetDateFromObject(env, date_obj);
     auto is_finite = duckdb_is_finite_date(date);
     return Napi::Boolean::New(env, is_finite);
   }
@@ -918,7 +918,7 @@ private:
   Napi::Value to_time(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto time_parts_obj = info[0].As<Napi::Object>();
-    auto time_parts = GetTimePartsFromObject(time_parts_obj);
+    auto time_parts = GetTimePartsFromObject(env, time_parts_obj);
     auto time = duckdb_to_time(time_parts);
     return MakeTimeObject(env, time);
   }
@@ -938,7 +938,7 @@ private:
   Napi::Value to_timestamp(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto timestamp_parts_obj = info[0].As<Napi::Object>();
-    auto timestamp_parts = GetTimestampPartsFromObject(timestamp_parts_obj);
+    auto timestamp_parts = GetTimestampPartsFromObject(env, timestamp_parts_obj);
     auto timestamp = duckdb_to_timestamp(timestamp_parts);
     return MakeTimestampObject(env, timestamp);
   }
@@ -1222,7 +1222,7 @@ private:
     auto env = info.Env();
     auto prepared_statement = GetPreparedStatementFromExternal(env, info[0]);
     auto index = info[1].As<Napi::Number>().Uint32Value();
-    auto value = info[2].As<Napi::Number>().Int32Value();
+    auto value = GetInt8FromNumber(env, info[2].As<Napi::Number>());
     if (duckdb_bind_int8(prepared_statement, index, value)) {
       throw Napi::Error::New(env, "Failed to bind int8");
     }
@@ -1235,7 +1235,7 @@ private:
     auto env = info.Env();
     auto prepared_statement = GetPreparedStatementFromExternal(env, info[0]);
     auto index = info[1].As<Napi::Number>().Uint32Value();
-    auto value = info[2].As<Napi::Number>().Int32Value();
+    auto value = GetInt16FromNumber(env, info[2].As<Napi::Number>());
     if (duckdb_bind_int16(prepared_statement, index, value)) {
       throw Napi::Error::New(env, "Failed to bind int16");
     }
@@ -1248,7 +1248,7 @@ private:
     auto env = info.Env();
     auto prepared_statement = GetPreparedStatementFromExternal(env, info[0]);
     auto index = info[1].As<Napi::Number>().Uint32Value();
-    auto value = info[2].As<Napi::Number>().Int32Value();
+    auto value = GetInt32FromNumber(env, info[2].As<Napi::Number>());
     if (duckdb_bind_int32(prepared_statement, index, value)) {
       throw Napi::Error::New(env, "Failed to bind int32");
     }
@@ -1317,7 +1317,7 @@ private:
     auto env = info.Env();
     auto prepared_statement = GetPreparedStatementFromExternal(env, info[0]);
     auto index = info[1].As<Napi::Number>().Uint32Value();
-    auto value = info[2].As<Napi::Number>().Uint32Value();
+    auto value = GetUInt8FromNumber(env, info[2].As<Napi::Number>());
     if (duckdb_bind_uint8(prepared_statement, index, value)) {
       throw Napi::Error::New(env, "Failed to bind uint8");
     }
@@ -1330,7 +1330,7 @@ private:
     auto env = info.Env();
     auto prepared_statement = GetPreparedStatementFromExternal(env, info[0]);
     auto index = info[1].As<Napi::Number>().Uint32Value();
-    auto value = info[2].As<Napi::Number>().Uint32Value();
+    auto value = GetUInt16FromNumber(env, info[2].As<Napi::Number>());
     if (duckdb_bind_uint16(prepared_statement, index, value)) {
       throw Napi::Error::New(env, "Failed to bind uint16");
     }
@@ -1343,7 +1343,7 @@ private:
     auto env = info.Env();
     auto prepared_statement = GetPreparedStatementFromExternal(env, info[0]);
     auto index = info[1].As<Napi::Number>().Uint32Value();
-    auto value = info[2].As<Napi::Number>().Uint32Value();
+    auto value = GetUInt32FromNumber(env, info[2].As<Napi::Number>());
     if (duckdb_bind_uint32(prepared_statement, index, value)) {
       throw Napi::Error::New(env, "Failed to bind uint32");
     }
@@ -1399,7 +1399,7 @@ private:
     auto env = info.Env();
     auto prepared_statement = GetPreparedStatementFromExternal(env, info[0]);
     auto index = info[1].As<Napi::Number>().Uint32Value();
-    auto value = GetDateFromObject(info[2].As<Napi::Object>());
+    auto value = GetDateFromObject(env, info[2].As<Napi::Object>());
     if (duckdb_bind_date(prepared_statement, index, value)) {
       throw Napi::Error::New(env, "Failed to bind date");
     }
@@ -1669,7 +1669,7 @@ private:
   // function create_int8(input: number): Value
   Napi::Value create_int8(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto input = info[0].As<Napi::Number>().Int32Value();
+    auto input = GetInt8FromNumber(env, info[0].As<Napi::Number>());
     auto value = duckdb_create_int8(input);
     return CreateExternalForValue(env, value);
   }
@@ -1678,7 +1678,7 @@ private:
   // function create_uint8(input: number): Value
   Napi::Value create_uint8(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto input = info[0].As<Napi::Number>().Uint32Value();
+    auto input = GetUInt8FromNumber(env, info[0].As<Napi::Number>());
     auto value = duckdb_create_uint8(input);
     return CreateExternalForValue(env, value);
   }
@@ -1687,7 +1687,7 @@ private:
   // function create_int16(input: number): Value
   Napi::Value create_int16(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto input = info[0].As<Napi::Number>().Int32Value();
+    auto input = GetInt16FromNumber(env, info[0].As<Napi::Number>());
     auto value = duckdb_create_int16(input);
     return CreateExternalForValue(env, value);
   }
@@ -1696,7 +1696,7 @@ private:
   // function create_uint16(input: number): Value
   Napi::Value create_uint16(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto input = info[0].As<Napi::Number>().Uint32Value();
+    auto input = GetUInt16FromNumber(env, info[0].As<Napi::Number>());
     auto value = duckdb_create_uint16(input);
     return CreateExternalForValue(env, value);
   }
@@ -1705,7 +1705,7 @@ private:
   // function create_int32(input: number): Value
   Napi::Value create_int32(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto input = info[0].As<Napi::Number>().Int32Value();
+    auto input = GetInt32FromNumber(env, info[0].As<Napi::Number>());
     auto value = duckdb_create_int32(input);
     return CreateExternalForValue(env, value);
   }
@@ -1714,7 +1714,7 @@ private:
   // function create_uint32(input: number): Value
   Napi::Value create_uint32(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto input = info[0].As<Napi::Number>().Uint32Value();
+    auto input = GetUInt32FromNumber(env, info[0].As<Napi::Number>());
     auto value = duckdb_create_uint32(input);
     return CreateExternalForValue(env, value);
   }
@@ -1808,7 +1808,7 @@ private:
   // function create_date(input: Date_): Value
   Napi::Value create_date(const Napi::CallbackInfo& info) {
     auto env = info.Env();
-    auto input = GetDateFromObject(info[0].As<Napi::Object>());
+    auto input = GetDateFromObject(env, info[0].As<Napi::Object>());
     auto value = duckdb_create_date(input);
     return CreateExternalForValue(env, value);
   }
@@ -2382,7 +2382,7 @@ private:
   Napi::Value create_enum_value(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto logical_type = GetLogicalTypeFromExternal(env, info[0]);
-    auto input_value = info[1].As<Napi::Number>().Uint32Value();
+    auto input_value = GetUInt32FromNumber(env, info[1].As<Napi::Number>());
     auto value = duckdb_create_enum_value(logical_type, input_value);
     if (!value) {
       throw Napi::Error::New(env, "Failed to create enum value");
@@ -3938,7 +3938,7 @@ private:
   Napi::Value append_int8(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto appender = GetAppenderFromExternal(env, info[0]);
-    auto int8_value = info[1].As<Napi::Number>().Int32Value();
+    auto int8_value = GetInt8FromNumber(env, info[1].As<Napi::Number>());
     if (duckdb_append_int8(appender, int8_value)) {
       throw Napi::Error::New(env, duckdb_appender_error(appender));
     }
@@ -3950,7 +3950,7 @@ private:
   Napi::Value append_int16(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto appender = GetAppenderFromExternal(env, info[0]);
-    auto int16_value = info[1].As<Napi::Number>().Int32Value();
+    auto int16_value = GetInt16FromNumber(env, info[1].As<Napi::Number>());
     if (duckdb_append_int16(appender, int16_value)) {
       throw Napi::Error::New(env, duckdb_appender_error(appender));
     }
@@ -3962,7 +3962,7 @@ private:
   Napi::Value append_int32(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto appender = GetAppenderFromExternal(env, info[0]);
-    auto int32_value = info[1].As<Napi::Number>().Int32Value();
+    auto int32_value = GetInt32FromNumber(env, info[1].As<Napi::Number>());
     if (duckdb_append_int32(appender, int32_value)) {
       throw Napi::Error::New(env, duckdb_appender_error(appender));
     }
@@ -4003,7 +4003,7 @@ private:
   Napi::Value append_uint8(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto appender = GetAppenderFromExternal(env, info[0]);
-    auto uint8_value = info[1].As<Napi::Number>().Uint32Value();
+    auto uint8_value = GetUInt8FromNumber(env, info[1].As<Napi::Number>());
     if (duckdb_append_uint8(appender, uint8_value)) {
       throw Napi::Error::New(env, duckdb_appender_error(appender));
     }
@@ -4015,7 +4015,7 @@ private:
   Napi::Value append_uint16(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto appender = GetAppenderFromExternal(env, info[0]);
-    auto uint16_value = info[1].As<Napi::Number>().Uint32Value();
+    auto uint16_value = GetUInt16FromNumber(env, info[1].As<Napi::Number>());
     if (duckdb_append_uint16(appender, uint16_value)) {
       throw Napi::Error::New(env, duckdb_appender_error(appender));
     }
@@ -4027,7 +4027,7 @@ private:
   Napi::Value append_uint32(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto appender = GetAppenderFromExternal(env, info[0]);
-    auto uint32_value = info[1].As<Napi::Number>().Uint32Value();
+    auto uint32_value = GetUInt32FromNumber(env, info[1].As<Napi::Number>());
     if (duckdb_append_uint32(appender, uint32_value)) {
       throw Napi::Error::New(env, duckdb_appender_error(appender));
     }
@@ -4092,7 +4092,7 @@ private:
   Napi::Value append_date(const Napi::CallbackInfo& info) {
     auto env = info.Env();
     auto appender = GetAppenderFromExternal(env, info[0]);
-    auto date_value = GetDateFromObject(info[1].As<Napi::Object>());
+    auto date_value = GetDateFromObject(env, info[1].As<Napi::Object>());
     if (duckdb_append_date(appender, date_value)) {
       throw Napi::Error::New(env, duckdb_appender_error(appender));
     }

--- a/bindings/test/number_ranges.test.ts
+++ b/bindings/test/number_ranges.test.ts
@@ -1,0 +1,282 @@
+import duckdb, {
+  Appender,
+  PreparedStatement,
+  Value,
+} from '@duckdb/node-bindings';
+import { expect, suite, test } from 'vitest';
+import { withConnection } from './utils/withConnection';
+
+/**
+ * The number-typed integer entry points used to convert their input with N-API's
+ * Int32Value or Uint32Value, which wrap out-of-range values modulo 2^32 and
+ * truncate fractional ones. That silently stored a value other than the one
+ * supplied; now it throws instead. See duckdb/duckdb-node-neo#469.
+ */
+
+interface IntegerType {
+  name: string;
+  sqlType: string;
+  min: number;
+  max: number;
+  create: (input: number) => Value;
+  get: (value: Value) => number;
+  bind: (prepared: PreparedStatement, index: number, value: number) => void;
+  append: (appender: Appender, value: number) => void;
+}
+
+const integerTypes: IntegerType[] = [
+  {
+    name: 'int8',
+    sqlType: 'tinyint',
+    min: -128,
+    max: 127,
+    create: (input) => duckdb.create_int8(input),
+    get: (value) => duckdb.get_int8(value),
+    bind: (prepared, index, value) => duckdb.bind_int8(prepared, index, value),
+    append: (appender, value) => duckdb.append_int8(appender, value),
+  },
+  {
+    name: 'uint8',
+    sqlType: 'utinyint',
+    min: 0,
+    max: 255,
+    create: (input) => duckdb.create_uint8(input),
+    get: (value) => duckdb.get_uint8(value),
+    bind: (prepared, index, value) => duckdb.bind_uint8(prepared, index, value),
+    append: (appender, value) => duckdb.append_uint8(appender, value),
+  },
+  {
+    name: 'int16',
+    sqlType: 'smallint',
+    min: -32768,
+    max: 32767,
+    create: (input) => duckdb.create_int16(input),
+    get: (value) => duckdb.get_int16(value),
+    bind: (prepared, index, value) => duckdb.bind_int16(prepared, index, value),
+    append: (appender, value) => duckdb.append_int16(appender, value),
+  },
+  {
+    name: 'uint16',
+    sqlType: 'usmallint',
+    min: 0,
+    max: 65535,
+    create: (input) => duckdb.create_uint16(input),
+    get: (value) => duckdb.get_uint16(value),
+    bind: (prepared, index, value) => duckdb.bind_uint16(prepared, index, value),
+    append: (appender, value) => duckdb.append_uint16(appender, value),
+  },
+  {
+    name: 'int32',
+    sqlType: 'integer',
+    min: -2147483648,
+    max: 2147483647,
+    create: (input) => duckdb.create_int32(input),
+    get: (value) => duckdb.get_int32(value),
+    bind: (prepared, index, value) => duckdb.bind_int32(prepared, index, value),
+    append: (appender, value) => duckdb.append_int32(appender, value),
+  },
+  {
+    name: 'uint32',
+    sqlType: 'uinteger',
+    min: 0,
+    max: 4294967295,
+    create: (input) => duckdb.create_uint32(input),
+    get: (value) => duckdb.get_uint32(value),
+    bind: (prepared, index, value) => duckdb.bind_uint32(prepared, index, value),
+    append: (appender, value) => duckdb.append_uint32(appender, value),
+  },
+];
+
+/** Values rejected for every integer type, whatever its range. */
+const nonIntegers = [
+  { name: 'fractional', input: 1.5 },
+  { name: 'NaN', input: NaN },
+  { name: 'Infinity', input: Infinity },
+  { name: '-Infinity', input: -Infinity },
+];
+
+for (const integerType of integerTypes) {
+  const { name, sqlType, min, max } = integerType;
+  const outOfRange = [
+    { name: 'above max', input: max + 1 },
+    { name: 'below min', input: min - 1 },
+  ];
+
+  suite(name, () => {
+    suite(`create_${name}`, () => {
+      test('min', () => {
+        expect(integerType.get(integerType.create(min))).toBe(min);
+      });
+      test('max', () => {
+        expect(integerType.get(integerType.create(max))).toBe(max);
+      });
+      for (const { name: caseName, input } of outOfRange) {
+        test(caseName, () => {
+          expect(() => integerType.create(input)).toThrowError(
+            `number out of ${name} range`
+          );
+        });
+      }
+      for (const { name: caseName, input } of nonIntegers) {
+        test(caseName, () => {
+          expect(() => integerType.create(input)).toThrowError(
+            'number is not an integer'
+          );
+        });
+      }
+    });
+
+    suite(`bind_${name}`, () => {
+      async function withPrepared(
+        fn: (prepared: PreparedStatement) => void
+      ): Promise<void> {
+        await withConnection(async (connection) => {
+          const prepared = await duckdb.prepare(
+            connection,
+            `select ?::${sqlType} as v`
+          );
+          fn(prepared);
+        });
+      }
+      test('min and max', async () => {
+        await withPrepared((prepared) => {
+          expect(() => integerType.bind(prepared, 1, min)).not.toThrow();
+          expect(() => integerType.bind(prepared, 1, max)).not.toThrow();
+        });
+      });
+      for (const { name: caseName, input } of outOfRange) {
+        test(caseName, async () => {
+          await withPrepared((prepared) => {
+            expect(() => integerType.bind(prepared, 1, input)).toThrowError(
+              `number out of ${name} range`
+            );
+          });
+        });
+      }
+      for (const { name: caseName, input } of nonIntegers) {
+        test(caseName, async () => {
+          await withPrepared((prepared) => {
+            expect(() => integerType.bind(prepared, 1, input)).toThrowError(
+              'number is not an integer'
+            );
+          });
+        });
+      }
+    });
+
+    suite(`append_${name}`, () => {
+      async function withAppender(
+        fn: (appender: Appender) => void
+      ): Promise<void> {
+        await withConnection(async (connection) => {
+          await duckdb.query(connection, `create table t(v ${sqlType})`);
+          const appender = duckdb.appender_create_ext(
+            connection,
+            'memory',
+            'main',
+            't'
+          );
+          fn(appender);
+        });
+      }
+      test('min and max', async () => {
+        await withAppender((appender) => {
+          expect(() => integerType.append(appender, min)).not.toThrow();
+          duckdb.appender_end_row(appender);
+          expect(() => integerType.append(appender, max)).not.toThrow();
+          duckdb.appender_end_row(appender);
+        });
+      });
+      for (const { name: caseName, input } of outOfRange) {
+        test(caseName, async () => {
+          await withAppender((appender) => {
+            expect(() => integerType.append(appender, input)).toThrowError(
+              `number out of ${name} range`
+            );
+          });
+        });
+      }
+      for (const { name: caseName, input } of nonIntegers) {
+        test(caseName, async () => {
+          await withAppender((appender) => {
+            expect(() => integerType.append(appender, input)).toThrowError(
+              'number is not an integer'
+            );
+          });
+        });
+      }
+    });
+  });
+}
+
+/**
+ * The struct-from-object converters had the same defect: they read their numeric
+ * fields with Int32Value or Uint32Value, so an out-of-range field wrapped rather
+ * than reporting itself. These report the offending field by name, matching the
+ * existing "micros out of int64 range" style.
+ */
+suite('struct fields', () => {
+  test('date days', async () => {
+    await withConnection(async (connection) => {
+      await duckdb.query(connection, 'create table t(v date)');
+      const appender = duckdb.appender_create_ext(
+        connection,
+        'memory',
+        'main',
+        't'
+      );
+      expect(() => duckdb.append_date(appender, { days: 2 ** 31 })).toThrowError(
+        'days out of int32 range'
+      );
+      expect(() => duckdb.append_date(appender, { days: 1.5 })).toThrowError(
+        'days is not an integer'
+      );
+      // 2**31 - 1 is the date infinity sentinel and must still be accepted.
+      expect(() =>
+        duckdb.append_date(appender, { days: 2 ** 31 - 1 })
+      ).not.toThrow();
+    });
+  });
+  test('interval months and days', () => {
+    expect(() =>
+      duckdb.create_interval({ months: 2 ** 31, days: 0, micros: 0n })
+    ).toThrowError('months out of int32 range');
+    expect(() =>
+      duckdb.create_interval({ months: 0, days: -(2 ** 31) - 1, micros: 0n })
+    ).toThrowError('days out of int32 range');
+    expect(() =>
+      duckdb.create_interval({ months: 2 ** 31 - 1, days: 0, micros: 0n })
+    ).not.toThrow();
+  });
+  test('date parts', () => {
+    expect(() =>
+      duckdb.to_date({ year: 2024, month: 300, day: 1 })
+    ).toThrowError('month out of int8 range');
+    expect(() =>
+      duckdb.to_date({ year: 2024, month: 1, day: 300 })
+    ).toThrowError('day out of int8 range');
+    expect(() => duckdb.to_date({ year: 2024, month: 1, day: 1 })).not.toThrow();
+  });
+  test('time parts', () => {
+    expect(() =>
+      duckdb.to_time({ hour: 200, min: 0, sec: 0, micros: 0 })
+    ).toThrowError('hour out of int8 range');
+    expect(() =>
+      duckdb.to_time({ hour: 0, min: 0, sec: 0, micros: 2 ** 31 })
+    ).toThrowError('micros out of int32 range');
+    expect(() =>
+      duckdb.to_time({ hour: 12, min: 34, sec: 56, micros: 789123 })
+    ).not.toThrow();
+  });
+  test('decimal width and scale', () => {
+    expect(() =>
+      duckdb.create_decimal({ width: 256, scale: 0, value: 0n })
+    ).toThrowError('width out of uint8 range');
+    expect(() =>
+      duckdb.create_decimal({ width: 4, scale: -1, value: 0n })
+    ).toThrowError('scale out of uint8 range');
+    expect(() =>
+      duckdb.create_decimal({ width: 4, scale: 1, value: 1234n })
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
Fixes #469.

The number-typed integer entry points converted their input with N-API's `Int32Value` / `Uint32Value`, which implement JS `ToInt32` / `ToUint32`: out-of-range values wrap modulo 2^32 and fractional ones truncate. Nothing complained, so the wrong value simply landed in the table.

```ts
appender.appendUInteger(2 ** 32 + 1); // stored 1
appender.appendTinyInt(131);          // stored -125
appender.appendUInteger(-1);          // stored 4294967295
appender.appendDate(new DuckDBDateValue(2 ** 31)); // stored 5877642-06-23 (BC)
```

The issue reported `appendUInteger`, but the defect was broader: every fixed-width integer type, on three separate write paths.

## What changed

**Bindings.** `GetInt8FromNumber` … `GetUInt32FromNumber` in `conversion_helpers.h` reject non-finite, fractional, and out-of-range input, the way the existing BigInt conversions already reject values that don't round-trip. Applied to the data-value call sites in `append_*`, `bind_*`, `create_*`, and `create_enum_value`, and to the numeric fields of the struct-from-object converters, which had the same defect — `to_date({ year, month: 300, day: 1 })` wrapped twice, once through `ToInt32` and again narrowing to `int8_t`. Those converters name the offending field (`days out of int32 range`), following the existing `micros out of int64 range`. The `Uint32Value` calls for indexes, counts, and capacities are deliberately untouched.

**API.** The vectors had the same defect on a path that never crosses the binding, since writing a number to a typed array or a bigint to a `DataView` wraps identically — so `DuckDBDataChunk.setColumnValues`, the bulk-write API, corrupted data just as quietly. Every vector `setItem` that writes a fixed-width integer now checks first, and the `DataView` setters in `dataAccessors.ts` cover hugeint, decimal, interval, and uuid in one place.

## Performance

The typed-array vectors repeat the checks inline rather than calling the shared ones. `setItem` is the inner loop of every bulk write, and a cross-module call there is not inlined by V8 — that alone cost about 20% of write throughput. The bigint checks use `BigInt.asIntN` identity rather than comparisons against hoisted bounds, which is roughly twice as fast.

What remains, measured against the built package (best of several runs, 2048-row chunks):

| | before | after | |
|---|---|---|---|
| `setColumnValues` uint32 | 288 M rows/s | 252 M rows/s | −13% |
| `setColumnValues` bigint | 138 M rows/s | 118 M rows/s | −14% |

That is the price of not silently corrupting data on the bulk path. Worth a look if it seems too steep.

The duplication between the inlined guards and the shared ones in `dataAccessors.ts` is the tradeoff; both sides carry a comment, and `api/test/integer-ranges.test.ts` asserts every bound on every vector so the two can't drift unnoticed.

## Breaking change

This turns silently wrong data into a thrown error. Code that was accidentally relying on the wrap — most likely without knowing it — will start failing. Worth calling out in the release notes.

## Testing

- `bindings/test/number_ranges.test.ts` — min/max round-trip plus out-of-range and non-integer rejection across `create` / `bind` / `append` for all six types, and the struct-field converters (date days, interval months/days, date parts, time parts, decimal width/scale), including that `2**31 - 1` still works as the date infinity sentinel.
- `api/test/integer-ranges.test.ts` — every vector's bounds, `setColumnValues`, and the issue's own repro.

Bindings 449 → 454 test files' worth of cases (+137 tests), API +58 tests. Both packages typecheck and the addon rebuilds clean.

## Not included

#478 — enum vectors silently store the first member when handed a string that isn't a member. Same defect class, found while reviewing this, but it needs its own decision about whether an unknown member should throw, so it's filed separately rather than folded in here.
