### PR TITLE
Reject enum values that are not members

### DIFF
--- a/api/src/types/DuckDBEnumType.ts
+++ b/api/src/types/DuckDBEnumType.ts
@@ -15,15 +15,46 @@ export class DuckDBEnumType extends BaseDuckDBType<DuckDBTypeId.ENUM> {
   ) {
     super(DuckDBTypeId.ENUM, alias);
     this.values = values;
-    const valueIndexes: Record<string, number> = {};
+    // Null prototype: with a plain object literal, a lookup of an inherited key
+    // such as 'toString' or 'constructor' returns a function instead of
+    // undefined, so neither this map nor indexForValue could tell a member from
+    // an Object.prototype property.
+    const valueIndexes: Record<string, number> = Object.create(null);
     for (let i = 0; i < values.length; i++) {
       valueIndexes[values[i]] = i;
     }
     this.valueIndexes = valueIndexes;
     this.internalTypeId = internalTypeId;
   }
+  /**
+   * The index of the given value in this enum.
+   *
+   * Throws if the value is not a member: storing an unknown value would
+   * otherwise write index 0, silently substituting the enum's first member.
+   */
   public indexForValue(value: string): number {
-    return this.valueIndexes[value];
+    const index = this.valueIndexes[value];
+    if (index === undefined) {
+      throw new Error(
+        `${quotedString(value)} is not a member of ${this.toStringForError()}`
+      );
+    }
+    return index;
+  }
+  /**
+   * Like toString, but bounded: an enum can have millions of members, and all of
+   * them in an error message would bury the part that matters.
+   */
+  private toStringForError(): string {
+    if (this.alias) {
+      return this.alias;
+    }
+    const shown = 8;
+    if (this.values.length <= shown) {
+      return this.toString();
+    }
+    const listed = this.values.slice(0, shown).map(quotedString).join(', ');
+    return `ENUM(${listed}, and ${this.values.length - shown} more)`;
   }
   public toString(): string {
     return `ENUM(${this.values.map(quotedString).join(', ')})`;

--- a/api/test/enum-type.test.ts
+++ b/api/test/enum-type.test.ts
@@ -1,0 +1,141 @@
+import { assert, describe, expect, test } from 'vitest';
+import {
+  DuckDBDataChunk,
+  DuckDBEnum16Vector,
+  DuckDBEnum32Vector,
+  DuckDBEnum8Vector,
+  DuckDBEnumType,
+  ENUM,
+} from '../src';
+import { withConnection } from './util/testHelpers';
+
+/**
+ * An unknown enum member used to be looked up as undefined and written straight
+ * into the backing typed array, which coerced it to 0 — silently substituting the
+ * enum's first member. See duckdb/duckdb-node-neo#478.
+ */
+
+const color = ENUM(['red', 'green', 'blue']);
+const notAMember = `'chartreuse' is not a member of ENUM('red', 'green', 'blue')`;
+
+describe('DuckDBEnumType.indexForValue', () => {
+  test('returns the index of a member', () => {
+    assert.equal(color.indexForValue('red'), 0);
+    assert.equal(color.indexForValue('green'), 1);
+    assert.equal(color.indexForValue('blue'), 2);
+  });
+  test('rejects a value that is not a member', () => {
+    expect(() => color.indexForValue('chartreuse')).toThrowError(notAMember);
+  });
+  test('rejects a value differing only in case', () => {
+    expect(() => color.indexForValue('RED')).toThrowError(
+      `'RED' is not a member of ENUM('red', 'green', 'blue')`
+    );
+  });
+  // A plain object literal inherits from Object.prototype, so these used to
+  // resolve to functions rather than undefined and land on index 0.
+  for (const inherited of [
+    'toString',
+    'constructor',
+    '__proto__',
+    'hasOwnProperty',
+    'valueOf',
+  ]) {
+    test(`rejects the inherited property ${inherited}`, () => {
+      expect(() => color.indexForValue(inherited)).toThrowError(
+        `is not a member of`
+      );
+    });
+  }
+  test('valueIndexes holds only members', () => {
+    assert.deepEqual(Object.keys(color.valueIndexes), ['red', 'green', 'blue']);
+    assert.equal(Object.getPrototypeOf(color.valueIndexes), null);
+    assert.isUndefined(color.valueIndexes['toString']);
+  });
+  test('escapes quotes in the message', () => {
+    expect(() => ENUM(["it's"]).indexForValue("other's")).toThrowError(
+      `'other''s' is not a member of ENUM('it''s')`
+    );
+  });
+  test('names the type by its alias when it has one', () => {
+    expect(() => ENUM(['a', 'b'], 'mood').indexForValue('c')).toThrowError(
+      `'c' is not a member of mood`
+    );
+  });
+  test('truncates the member list for a large enum', () => {
+    const big = ENUM(Array.from({ length: 300 }, (_, i) => `v${i}`));
+    expect(() => big.indexForValue('nope')).toThrowError(
+      `'nope' is not a member of ENUM('v0', 'v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7', and 292 more)`
+    );
+  });
+});
+
+describe('members named like inherited properties', () => {
+  // Assigning to '__proto__' on a plain object hits the inherited setter instead
+  // of creating an own property, so an enum with a member of that name could not
+  // be indexed at all: writing '__proto__' stored the enum's first member.
+  test('round-trip through a vector', () => {
+    const proto = ENUM(['ok', '__proto__', 'toString']);
+    const chunk = DuckDBDataChunk.create([proto], 3);
+    const vector = chunk.getColumnVector(0);
+    vector.setItem(0, '__proto__');
+    vector.setItem(1, 'toString');
+    vector.setItem(2, 'ok');
+    assert.deepEqual(chunk.getColumnValues(0), ['__proto__', 'toString', 'ok']);
+  });
+});
+
+describe('enum vector setItem', () => {
+  // ENUM picks its backing width from the member count.
+  const widths: [string, DuckDBEnumType, unknown][] = [
+    ['ENUM8', color, DuckDBEnum8Vector],
+    [
+      'ENUM16',
+      ENUM(Array.from({ length: 300 }, (_, i) => `v${i}`)),
+      DuckDBEnum16Vector,
+    ],
+    [
+      'ENUM32',
+      ENUM(Array.from({ length: 70000 }, (_, i) => `v${i}`)),
+      DuckDBEnum32Vector,
+    ],
+  ];
+  for (const [name, type, vectorClass] of widths) {
+    describe(name, () => {
+      test('stores a member and rejects a non-member', () => {
+        const chunk = DuckDBDataChunk.create([type], 2);
+        const vector = chunk.getColumnVector(0);
+        assert.instanceOf(vector, vectorClass as never);
+        vector.setItem(0, type.values[1]);
+        assert.equal(vector.getItem(0), type.values[1]);
+        expect(() => vector.setItem(1, 'chartreuse')).toThrowError(
+          `is not a member of`
+        );
+      });
+      test('still accepts null', () => {
+        const chunk = DuckDBDataChunk.create([type], 1);
+        const vector = chunk.getColumnVector(0);
+        vector.setItem(0, null);
+        assert.isNull(vector.getItem(0));
+      });
+    });
+  }
+  test('setColumnValues reports the offending value', () => {
+    const chunk = DuckDBDataChunk.create([color], 2);
+    expect(() =>
+      chunk.setColumnValues(0, ['blue', 'chartreuse'])
+    ).toThrowError(notAMember);
+  });
+});
+
+describe('enum value creation', () => {
+  test('bindValue rejects a non-member', async () => {
+    await withConnection(async (connection) => {
+      const prepared = await connection.prepare('select ? as v');
+      expect(() =>
+        prepared.bindValue(1, 'chartreuse', color)
+      ).toThrowError(notAMember);
+      expect(() => prepared.bindValue(1, 'blue', color)).not.toThrow();
+    });
+  });
+});


### PR DESCRIPTION
Fixes #478.

`indexForValue` returned `valueIndexes[value]`, which is `undefined` for a string that isn't a member, and `setItem` assigned that straight into the backing typed array, where it coerced to `0`. Writing an unknown value silently stored the enum's first member.

```ts
const color = ENUM(['red', 'green', 'blue']);
const chunk = DuckDBDataChunk.create([color], 3);
const vector = chunk.getColumnVector(0);
vector.setItem(0, 'green');
vector.setItem(1, 'chartreuse'); // not a member
vector.setItem(2, 'RED');        // right member, wrong case
chunk.getColumnValues(0); // ["green", "red", "red"]
```

The case mismatch is the worst of it: `'RED'` reads back as `'red'`, which looks like the write succeeded and normalized the case. In a differently ordered enum the same write would produce an unrelated member. `setColumnValues` and the chunk appender go through the same path, so the wrong value reaches the table.

## What changed

**`indexForValue` throws on a non-member,** which also makes its declared `number` return type honest. The three enum vectors and `createValue` all go through it, so every path reports the same thing. `createValue` previously threw `A number was expected` — the N-API type error from passing `undefined` onward, which said nothing about the actual mistake.

**`valueIndexes` is built with a null prototype.** As a plain object literal it inherited from `Object.prototype`, so looking up `'toString'`, `'constructor'` or `'hasOwnProperty'` returned a *function* rather than `undefined` and would have slipped straight past the check above. The field is public, so anyone using it for a membership test had the same problem.

That also fixes a second instance of the same silent substitution, which I hit while testing the first: assigning to `'__proto__'` on a plain object hits the inherited setter instead of creating an own property, so an enum with a member of that name could not be indexed at all. On `main`, `ENUM(['ok', '__proto__'])` asked to store `'__proto__'` stores `'ok'`.

**Error messages are bounded.** An ENUM32 can have billions of members, so listing them all would bury the point. The type is named by its alias when it has one, otherwise up to eight members are listed and the rest summarized:

```
'chartreuse' is not a member of ENUM('red', 'green', 'blue')
'c' is not a member of mood
'nope' is not a member of ENUM('v0', 'v1', 'v2', 'v3', 'v4', 'v5', 'v6', 'v7', and 292 more)
'other''s' is not a member of ENUM('it''s')
```

## Breaking change

Writing an unknown enum member now throws instead of silently storing the first member. `indexForValue` throws rather than returning `undefined` — its type already said `number`, so callers handling `undefined` were working around a bug, but it is still a behavior change worth a release note.

## Testing

New `api/test/enum-type.test.ts`, 21 cases: index lookup, non-member, case mismatch, each of the five inherited property names, the shape of `valueIndexes`, quote escaping, alias and truncation in messages, the `__proto__`-member round-trip, and `setItem` / `setColumnValues` / `bindValue` across all three widths, including that `null` still writes NULL. 17 of the 21 fail on `main`.

Full suites pass: 187 API, 317 bindings.

## Related

Branched from `main` and touches no files in common with the #469 fix, so the two can land in either order. Both are breaking in the same way — previously silent wrong data now throws — so they likely want one combined release note.
