### PR TITLE
Reject a data chunk DuckDB refuses to create

### DIFF
--- a/api/src/DuckDBDataChunk.ts
+++ b/api/src/DuckDBDataChunk.ts
@@ -14,9 +14,22 @@ export class DuckDBDataChunk {
     types: readonly DuckDBType[],
     rowCount?: number
   ): DuckDBDataChunk {
-    const chunk = new DuckDBDataChunk(
-      duckdb.create_data_chunk(types.map((t) => t.toLogicalType().logical_type))
-    );
+    let chunk: DuckDBDataChunk;
+    try {
+      chunk = new DuckDBDataChunk(
+        duckdb.create_data_chunk(
+          types.map((t) => t.toLogicalType().logical_type)
+        )
+      );
+    } catch (cause) {
+      // The binding knows the chunk was refused but not which type did it, so
+      // name them here. Zero columns is a legitimate chunk, so there is
+      // nothing to check on the way out; only the refusal is an error.
+      throw new Error(
+        `Cannot create a data chunk with these column types: ${types.join(', ')}`,
+        { cause }
+      );
+    }
     if (rowCount != undefined) {
       chunk.rowCount = rowCount;
     }

--- a/api/test/data-chunk-creation.test.ts
+++ b/api/test/data-chunk-creation.test.ts
@@ -1,0 +1,48 @@
+import { expect, test } from 'vitest';
+import {
+  DuckDBDataChunk,
+  INTEGER,
+  LIST,
+  STRUCT,
+  VARCHAR,
+  VARIANT,
+} from '../src';
+
+// `duckdb_create_data_chunk` returns null for a column type it will not
+// accept, rather than reporting the refusal. Wrapped and handed to JS, that
+// null looks like an empty chunk — `duckdb_data_chunk_get_column_count` reads
+// it as zero columns — so every set* is a silent no-op and appending it
+// crashes the process. VARIANT is such a type today.
+test('a data chunk cannot be created with a type DuckDB will not accept', () => {
+  expect(() => DuckDBDataChunk.create([INTEGER, VARIANT])).toThrowError(
+    'Cannot create a data chunk with these column types: INTEGER, VARIANT'
+  );
+  expect(() => DuckDBDataChunk.create([VARIANT])).toThrowError(
+    'Cannot create a data chunk with these column types: VARIANT'
+  );
+  expect(() => DuckDBDataChunk.create([LIST(VARIANT)])).toThrowError(
+    'Cannot create a data chunk with these column types: VARIANT[]'
+  );
+  expect(() =>
+    DuckDBDataChunk.create([STRUCT({ a: INTEGER, v: VARIANT })])
+  ).toThrowError('Cannot create a data chunk with these column types');
+});
+
+test('the refusal from the binding is preserved as the cause', () => {
+  try {
+    DuckDBDataChunk.create([VARIANT]);
+    expect.unreachable();
+  } catch (error) {
+    expect((error as Error).cause).toBeInstanceOf(Error);
+    expect(((error as Error).cause as Error).message).toContain(
+      'One or more column types are not supported'
+    );
+  }
+});
+
+test('accepted types, including none, still create a chunk', () => {
+  expect(DuckDBDataChunk.create([INTEGER, VARCHAR]).columnCount).toBe(2);
+  expect(DuckDBDataChunk.create([LIST(INTEGER)]).columnCount).toBe(1);
+  // Zero columns is a legitimate chunk, not a refusal.
+  expect(DuckDBDataChunk.create([]).columnCount).toBe(0);
+});

--- a/bindings/src/duckdb_node_bindings.cpp
+++ b/bindings/src/duckdb_node_bindings.cpp
@@ -2746,6 +2746,13 @@ private:
       types[i] = GetLogicalTypeFromExternal(env, types_array.Get(i));
     }
     auto data_chunk = duckdb_create_data_chunk(types.data(), types_count);
+    // Returns null for a column type it will not accept (VARIANT, for one),
+    // rather than reporting the refusal. Wrapping that null would hand JS a
+    // handle that looks like an empty chunk -- duckdb_data_chunk_get_column_count
+    // reads it as zero columns -- and crashes on first real use.
+    if (!data_chunk) {
+      throw Napi::Error::New(env, "Failed to create data chunk. One or more column types are not supported.");
+    }
     return CreateExternalForDataChunk(env, data_chunk);
   }
 

--- a/bindings/test/data_chunk.test.ts
+++ b/bindings/test/data_chunk.test.ts
@@ -14,6 +14,24 @@ suite('data chunk', () => {
     const vec1 = duckdb.data_chunk_get_vector(chunk, 1);
     expectLogicalType(duckdb.vector_get_column_type(vec1), VARCHAR);
   });
+  test('create with an unsupported column type', () => {
+    // duckdb_create_data_chunk returns null for a type it will not accept,
+    // rather than reporting the refusal. Wrapping that null would hand JS a
+    // handle that reads as zero columns and crashes on first real use.
+    const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
+    const variant_type = duckdb.create_logical_type(duckdb.Type.VARIANT);
+    expect(() => duckdb.create_data_chunk([variant_type])).toThrowError(
+      'Failed to create data chunk. One or more column types are not supported.'
+    );
+    expect(() =>
+      duckdb.create_data_chunk([int_type, variant_type])
+    ).toThrowError('Failed to create data chunk');
+  });
+  test('create with no column types', () => {
+    // Zero columns is a legitimate chunk, not a refusal.
+    const chunk = duckdb.create_data_chunk([]);
+    expect(duckdb.data_chunk_get_column_count(chunk)).toBe(0);
+  });
   test('change size', () => {
     const int_type = duckdb.create_logical_type(duckdb.Type.INTEGER);
     const chunk = duckdb.create_data_chunk([int_type]);


### PR DESCRIPTION
`duckdb_create_data_chunk` returns null for a column type it will not accept, rather than reporting the refusal. The binding wrapped that null in an `External` and handed it to JS, where it did not look like a failure at all — `duckdb_data_chunk_get_column_count` reads a null handle as zero columns, so the chunk appeared merely empty. Every `set*` was then a silent no-op, and appending it crashed the process.

```ts
const chunk = DuckDBDataChunk.create([INTEGER, VARIANT]);  // no error
chunk.setRows([[5, null]]);                                // writes nothing
appender.appendDataChunk(chunk);                           // native crash
```

VARIANT is such a type today, at the top level or nested inside a `LIST` or `STRUCT`.

## Why the check is in the binding

Measured against libduckdb directly, the handle comes back null rather than as a zero-column chunk, and the refusal is all-or-nothing:

```
[INTEGER]            handle=non-NULL columns=1
[VARIANT]            handle=NULL
[INTEGER, VARIANT]   handle=NULL
[] (zero types)      handle=non-NULL columns=0
```

Note the last line: a chunk with no columns is a legitimate thing to create, so **zero columns is not the signal — the null is.** The VARIANT logical type itself builds fine (`duckdb_create_logical_type` returns it, type id 41); it is the chunk call that refuses.

That rules out the obvious alternative of comparing `columnCount` against `types.length` in the API layer. It would have been indirect — inferring the refusal from a count that is only zero because the handle is null — and incomplete, since it leaves a null-wrapping handle reachable by anyone calling the binding directly, where *every* subsequent call is a hazard, not just the append that happened to crash.

So the check goes where the null is visible, following the convention `duckdb_result_get_chunk` already uses for exactly this case.

`DuckDBDataChunk.create` then names the types in its message, since the binding knows the chunk was refused but not which type did it, and keeps the binding's error as the `cause`. Nothing is checked on the way out — only the refusal is an error.

## Tests

- `bindings/test/data_chunk.test.ts` — the throw, and that `[]` still creates a real zero-column chunk.
- `api/test/data-chunk-creation.test.ts` — the message for top-level / `LIST(VARIANT)` / nested-in-`STRUCT`, the preserved `cause`, and that accepted types still work.

Full suites pass: bindings 453 passed / 3 skipped, api 248 passed / 1 skipped.

## Notes

This is a behaviour change in the sense that a call which previously "succeeded" now throws — but what it returned was unusable and crashed on first real use, so nothing that worked before stops working.

The underlying constraint (DuckDB will not put a VARIANT column in a data chunk) matters beyond this fix: under the V2 C API, bulk append *is* data chunks into a column data collection, with no per-value appender to fall back on. That is documented separately in `tools/capi-v2/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)