### PR TITLE
Correct what a data chunk does with VARIANT, on both surfaces

### DIFF
--- a/tools/capi-v2/.gitignore
+++ b/tools/capi-v2/.gitignore
@@ -4,3 +4,5 @@ smoke_v2
 __pycache__
 coexist_probe
 coexist_probe.duckdb
+chunk_probe
+chunk_probe_v2

--- a/tools/capi-v2/README.md
+++ b/tools/capi-v2/README.md
@@ -20,6 +20,14 @@ Both PR descriptions carry the same caveat — nothing is set in stone, more fol
 expected — so treat every count below as a snapshot. `compare_api.py` re-derives all of them
 from the headers.
 
+The preview artifacts are **rebuilt in place under the same tag**, so a local `libduckdb-v2/` goes
+stale without changing its name or URL. Between 2026-09-05 and 2026-09-12 the osx-universal
+tarball moved from 38,600,129 to 38,950,606 bytes and the dylib grew about a megabyte, while
+`duckdb_v2.h` stayed byte-for-byte identical and every function count below stayed put — an
+implementation rebuild, not a surface change. Re-run `fetch_libduckdb_v2.py` before trusting a
+measurement taken against a copy you did not just fetch; a probe that disagrees with what is
+recorded here may be measuring a different build rather than a changed answer.
+
 Companion to [`../capi-coverage`](../capi-coverage/README.md), which measures Node Neo against the
 other five C-API clients. `compare_api.py` reuses that tool's `capi_functions.py` (the canonical
 V1 function list) and `node_neo.py` (our exposure of it, and the recorded reason for each
@@ -41,6 +49,20 @@ cd tools/capi-v2 && cc -std=c11 -I libduckdb-v2 smoke_v2.c -L libduckdb-v2 -lduc
 shortest illustration of the calling convention the bindings have to adopt. `coexist_probe.c`
 builds the same way, and checks whether one database file opened through both V1 and V2 is
 detected.
+
+`chunk_probe.c` and `chunk_probe_v2.c` are a pair, asking the same question of each surface: will
+a data chunk take a VARIANT column? The V1 one builds against either library — the library we ship
+today, or the preview, which exports the V1 symbols too — which is how the answer is known to be
+the same on both sides of the 2.0 boundary. See
+[VARIANT in a data chunk](#variant-in-a-data-chunk-a-v1-defect-v2-does-not-inherit).
+
+```bash
+cd tools/capi-v2 && cc -std=c11 -I ../../bindings/libduckdb chunk_probe.c \
+    -L ../../bindings/libduckdb -lduckdb -Wl,-rpath,@loader_path/../../bindings/libduckdb \
+    -o chunk_probe && ./chunk_probe
+cd tools/capi-v2 && cc -std=c11 -I libduckdb-v2 chunk_probe_v2.c -L libduckdb-v2 -lduckdb \
+    -Wl,-rpath,@loader_path/libduckdb-v2 -o chunk_probe_v2 && ./chunk_probe_v2
+```
 
 ## Headline findings
 
@@ -700,40 +722,80 @@ list:
   `RUNTIME_INTERRUPT` so the flush can be retried, and dropped on anything else so a retry does not
   re-run a failing statement over the same rows.
 
-### VARIANT is read-only in a vector
+### VARIANT in a data chunk: a V1 defect V2 does not inherit
 
-One thing on our side of the line does not survive the move, and it is worth knowing before the
-shape question is answered: **a data chunk cannot carry a VARIANT column.**
+Worth knowing before the shape question is answered, because it runs the opposite way to the rest
+of this document: **V1 cannot put a VARIANT column in a data chunk, and V2 can.**
 
-`DuckDBVariantVector.setItem` throws for a non-null value, and is a deliberate no-op for `null` so
-that a containing struct or list can iterate every child while reading. `flush` is a no-op for the
-same reason. Nothing ever initializes that vector's memory, so appending a chunk built over a
-VARIANT column hands DuckDB uninitialized memory — which crashes the process rather than raising.
-Measured on 2026-09-07 against the current build, with both a null and a non-null value:
+`duckdb_create_data_chunk` will not accept a VARIANT logical type. The logical type itself builds
+fine — `duckdb_create_logical_type` returns it, type id 41 — and it is the chunk call that
+refuses. It refuses by **returning null**, not by reporting anything. Measured against libduckdb
+directly (`chunk_probe.c`), where the refusal is also all-or-nothing rather than partial:
 
-```ts
-const chunk = DuckDBDataChunk.create([INTEGER, VARIANT]);
-chunk.setRows([[5, null]]);
-appender.appendDataChunk(chunk);   // native crash
+```
+[INTEGER]            handle=non-NULL columns=1
+[VARIANT]            handle=NULL
+[INTEGER, VARIANT]   handle=NULL
+[] (zero types)      handle=non-NULL columns=0
 ```
 
-On V1 this is a gap rather than a wall, because the per-value path works: `appendVariant`,
+Note the last line: a chunk with no columns is a legitimate thing to create, so zero columns is
+not itself the signal. The null is.
+
+That distinction cost us a wrong diagnosis, and is worth keeping straight. A null handle read back
+through `duckdb_data_chunk_get_column_count` returns 0, so from JS the refusal *looks* like a
+chunk that merely came back empty. The binding passed the call straight through without inspecting
+the result, so that null reached JS wrapped in an External, where every subsequent call on it is a
+hazard — not only the append that happened to crash:
+
+```ts
+const chunk = DuckDBDataChunk.create([INTEGER, VARIANT]);  // null handle, no error
+chunk.setRows([[5, null]]);                                // writes nothing
+appender.appendDataChunk(chunk);                           // native crash
+```
+
+Fixed in [#487](https://github.com/duckdb/duckdb-node-neo/pull/487), in the binding, which is the
+only place the null is visible. This behaviour is unchanged in 2.0: the same probe relinked
+against the preview library returns null for the same inputs, so the V1 surface carries the defect
+across the boundary with it.
+
+On V1 it is a gap rather than a wall, because the per-value path works: `appendVariant`,
 `appendValue(v, VARIANT)`, `bindValue(…, VARIANT)` and a SQL `::variant` cast all write one, with
 `typeForValue` inferring a scalar's type when no hint is given and nested content requiring both a
 wrapper and a type (`variantValue(structValue({k: 'n'}), STRUCT({k: VARCHAR}))`).
 
-Under V2 there is no per-value path to fall back to. Bulk append *is* chunks into a collection, so
-until the vector can write, VARIANT is unwritable in bulk. That turns a known gap into a
-prerequisite, which is why it is in the deferred decisions below rather than left implicit.
+**V2 does not have the defect.** `duckdb_v2_data_chunk_create` takes a VARIANT column, and so does
+`duckdb_v2_column_data_collection_create_with_connection` — which is the one that matters, since
+the collection is what bulk append actually fills. Measured by `chunk_probe_v2.c` against the same
+preview library, borrowing the VARIANT logical type from a result schema because a context is only
+handed out inside callback scopes:
 
-The crash itself should be fixed on V1 regardless — a public call should raise, not abort — and
-independently of whether the vector ever learns to write.
+```
+[INTEGER]            -> code=0 chunk=non-NULL columns=1
+[VARIANT]            -> code=0 chunk=non-NULL columns=1
+[INTEGER, VARIANT]   -> code=0 chunk=non-NULL columns=2
+
+column data collection:
+[INTEGER, VARIANT]   -> code=0 collection=non-NULL
+```
+
+So this is not a V2 prerequisite and there is nothing to raise upstream. Losing the per-value
+appender does not cost us VARIANT.
+
+What it does do is move the remaining gap onto our side of the line. `DuckDBVariantVector` cannot
+write — `setItem` throws for a non-null value, and is a deliberate no-op for `null` so that a
+containing struct or list can iterate every child while reading. Under V1 that barely matters,
+since the per-value path is there to fall back on. Under V2 the collection is the only write path,
+so a VARIANT column in a bulk append needs that vector to learn to write. That is ours to
+implement whenever we want it, not a dependency to wait on — which is why it is not in the
+deferred decisions below.
 
 ### Net versus the V1 appender
 
 More capable: the flush does not have to be a plain INSERT, so a column subset, `ON CONFLICT`, or a
 buffer-driven UPDATE or MERGE all become reachable, and the buffer spills to disk rather than being
-memory-bound. The cost is ownership — the lifetime rules, the error semantics and that registration
+memory-bound. It also accepts a VARIANT column, which V1's own chunk path does not — see
+[VARIANT in a data chunk](#variant-in-a-data-chunk-a-v1-defect-v2-does-not-inherit). The cost is ownership — the lifetime rules, the error semantics and that registration
 leak all become ours.
 
 ## Deferred decisions
@@ -745,7 +807,6 @@ Real choices, deliberately not made yet, each with the thing that should trigger
 | What shape bulk append takes — an appender class, or helpers driving `INSERT INTO … SELECT * FROM` over a replacement-scanned collection (see [how it works](#how-bulk-append-works-without-an-appender)) | Building that part of the V2 API |
 | Whether to build the V2 bindings on `duckdb_cpp`, borrow its patterns, or ignore it | `duckdb_cpp` actually shipping in a release; it is not required either way |
 | Whether any conversion helpers are worth keeping native rather than reimplementing in TypeScript | Only if upstream ships some after all — otherwise TypeScript, which is the better choice regardless |
-| Whether `DuckDBVariantVector` gains write support, or VARIANT stays outside bulk append (see [VARIANT is read-only in a vector](#variant-is-read-only-in-a-vector)) | Building bulk append in V2. Optional on V1, where `appendVariant` is a working per-value fallback; V2 has no appender, so the chunk path is the only one and VARIANT would be unwritable in bulk without it |
 
 ## When 2.0 ships
 

--- a/tools/capi-v2/chunk_probe.c
+++ b/tools/capi-v2/chunk_probe.c
@@ -1,0 +1,65 @@
+/* Does duckdb_create_data_chunk return null for a column type it refuses, or a
+ * real chunk reporting zero columns?
+ *
+ * This matters because the two are indistinguishable from JS: reading a null
+ * handle through duckdb_data_chunk_get_column_count returns 0, so a refusal
+ * looks like a chunk that merely came back empty. If the handle is null, a
+ * binding that wraps it hands JS something that is a hazard on every call, and
+ * the check belongs in the binding rather than in the API layer.
+ *
+ * Built against the V1 library we ship today, not the 2.0 preview, because the
+ * behaviour is V1's and the bindings' -- but the answer carries into V2, where
+ * a column data collection is created from a fixed set of column types the
+ * same way.
+ *
+ *   cd tools/capi-v2 && cc -std=c11 -I ../../bindings/libduckdb chunk_probe.c \
+ *      -L ../../bindings/libduckdb -lduckdb \
+ *      -Wl,-rpath,@loader_path/../../bindings/libduckdb -o chunk_probe && ./chunk_probe
+ *
+ * Measured against DuckDB 1.5.5, and unchanged against the 2.0 preview
+ * (2026-09-12):
+ *
+ *   VARIANT logical type: created, type id=41
+ *
+ *   [INTEGER]            handle=non-NULL columns=1 size=0
+ *   [VARIANT]            handle=NULL
+ *   [INTEGER, VARIANT]   handle=NULL
+ *   [] (zero types)      handle=non-NULL columns=0 size=0
+ *
+ * So: null, all-or-nothing, and a zero-column chunk is legitimate -- zero
+ * columns is not the signal, the null is.
+ */
+#include <stdio.h>
+#include <duckdb.h>
+
+static void probe(const char *label, duckdb_logical_type *types, idx_t n) {
+  duckdb_data_chunk chunk = duckdb_create_data_chunk(types, n);
+  printf("%-20s handle=%s", label, chunk == NULL ? "NULL" : "non-NULL");
+  if (chunk != NULL) {
+    printf(" columns=%llu size=%llu",
+      (unsigned long long)duckdb_data_chunk_get_column_count(chunk),
+      (unsigned long long)duckdb_data_chunk_get_size(chunk));
+    duckdb_destroy_data_chunk(&chunk);
+  }
+  printf("\n");
+}
+
+int main(void) {
+  duckdb_logical_type i32 = duckdb_create_logical_type(DUCKDB_TYPE_INTEGER);
+  duckdb_logical_type var = duckdb_create_logical_type(DUCKDB_TYPE_VARIANT);
+  printf("VARIANT logical type: %s, type id=%d\n\n",
+         var == NULL ? "NULL" : "created", (int)duckdb_get_type_id(var));
+
+  duckdb_logical_type ok[1]  = { i32 };
+  duckdb_logical_type bad[1] = { var };
+  duckdb_logical_type mix[2] = { i32, var };
+
+  probe("[INTEGER]",          ok,  1);
+  probe("[VARIANT]",          bad, 1);
+  probe("[INTEGER, VARIANT]", mix, 2);
+  probe("[] (zero types)",    ok,  0);
+
+  duckdb_destroy_logical_type(&i32);
+  duckdb_destroy_logical_type(&var);
+  return 0;
+}

--- a/tools/capi-v2/chunk_probe_v2.c
+++ b/tools/capi-v2/chunk_probe_v2.c
@@ -1,0 +1,129 @@
+/* Does the V2 data chunk API accept a VARIANT column, where V1 does not?
+ *
+ * chunk_probe.c establishes that duckdb_create_data_chunk returns null for a
+ * VARIANT logical type, on the library we ship and on the 2.0 preview alike.
+ * This asks the same of V2 -- of duckdb_v2_data_chunk_create, and of
+ * duckdb_v2_column_data_collection_create_with_connection, which is the one
+ * that matters, since the collection is what bulk append fills when there is
+ * no appender.
+ *
+ * The VARIANT logical type is borrowed from a result schema rather than
+ * constructed: V2 builds types through a context, and a context is only handed
+ * out inside callback scopes, never to an external caller.
+ *
+ *   python3 tools/capi-v2/fetch_libduckdb_v2.py
+ *   cd tools/capi-v2 && cc -std=c11 -I libduckdb-v2 chunk_probe_v2.c \
+ *      -L libduckdb-v2 -lduckdb -Wl,-rpath,@loader_path/libduckdb-v2 \
+ *      -o chunk_probe_v2 && ./chunk_probe_v2
+ *
+ * Measured against the 2.0 preview (2026-09-12):
+ *
+ *   borrowed column 1 type: VARIANT
+ *
+ *   [INTEGER]            -> code=0 chunk=non-NULL columns=1
+ *   [VARIANT]            -> code=0 chunk=non-NULL columns=1
+ *   [INTEGER, VARIANT]   -> code=0 chunk=non-NULL columns=2
+ *
+ *   column data collection:
+ *   [INTEGER, VARIANT]   -> code=0 collection=non-NULL
+ *
+ * So the V1 refusal is not inherited. Note also that V2 reports failure through
+ * a return code plus an error handle rather than a sentinel, so a refusal here
+ * could not go unnoticed the way V1's null does.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <duckdb_v2.h>
+
+static duckdb_v2_str str(const char *s) {
+  duckdb_v2_str v; v.ptr = s; v.len = s ? strlen(s) : 0; return v;
+}
+
+#define CHECK(expr)                                                            \
+  do {                                                                         \
+    DUCKDB_V2_ERROR e = (expr);                                                \
+    if (e != DUCKDB_V2_ERROR_NONE) {                                           \
+      duckdb_v2_str t = {NULL, 0};                                             \
+      if (err) duckdb_v2_error_info_get_text(err, &t);                         \
+      printf("SETUP FAIL %s -> %d: %.*s\n", #expr, (int)e, (int)t.len,         \
+             t.ptr ? t.ptr : "");                                              \
+      return 1;                                                                \
+    }                                                                          \
+  } while (0)
+
+static void try_chunk(const char *label, duckdb_v2_logical_type_handle *types,
+                      idx_t n) {
+  duckdb_v2_data_chunk_handle chunk = NULL;
+  duckdb_v2_error_info_handle err = NULL;
+  DUCKDB_V2_ERROR e = duckdb_v2_data_chunk_create(types, n, &chunk, &err);
+  printf("%-22s -> code=%d", label, (int)e);
+  if (e == DUCKDB_V2_ERROR_NONE) {
+    idx_t cols = 0;
+    duckdb_v2_error_info_handle e2 = NULL;
+    duckdb_v2_data_chunk_get_vector_count(chunk, &cols, &e2);
+    printf(" chunk=%s columns=%llu", chunk ? "non-NULL" : "NULL",
+           (unsigned long long)cols);
+    duckdb_v2_data_chunk_destroy(&chunk);
+  } else {
+    duckdb_v2_str t = {NULL, 0};
+    if (err) duckdb_v2_error_info_get_text(err, &t);
+    printf(" msg=\"%.*s\"", (int)t.len, t.ptr ? t.ptr : "");
+    if (err) duckdb_v2_error_info_destroy(&err);
+  }
+  printf("\n");
+}
+
+int main(void) {
+  duckdb_v2_error_info_handle err = NULL;
+  duckdb_v2_environment_handle env = NULL;
+  duckdb_v2_database_handle db = NULL;
+  duckdb_v2_connection_handle conn = NULL;
+  duckdb_v2_statement_iterator_handle it = NULL;
+  duckdb_v2_sql_statement_handle st = NULL;
+  duckdb_v2_result_handle res = NULL;
+  duckdb_v2_schema_handle schema = NULL;
+
+  CHECK(duckdb_v2_create_environment(&env, &err));
+  CHECK(duckdb_v2_open(env, str(":memory:"), NULL, 0, &db, &err));
+  CHECK(duckdb_v2_connect(db, &conn, &err));
+  CHECK(duckdb_v2_parse_sql(conn, "select 1 as i, 42::variant as v", &it, &err));
+  CHECK(duckdb_v2_statement_iterator_next(it, &st, &err));
+  CHECK(duckdb_v2_statement_execute(conn, st, NULL, NULL, 0, &res, &err));
+  CHECK(duckdb_v2_result_get_schema(res, &schema, &err));
+
+  duckdb_v2_identifier_t name = {NULL, 0};
+  duckdb_v2_logical_type_handle t_int = NULL, t_var = NULL;
+  CHECK(duckdb_v2_schema_get_field(schema, 0, &name, &t_int, &err));
+  CHECK(duckdb_v2_schema_get_field(schema, 1, &name, &t_var, &err));
+
+  char text[128]; idx_t len = 0;
+  CHECK(duckdb_v2_logical_type_to_text(t_var, text, sizeof(text), &len, &err));
+  printf("borrowed column 1 type: %s\n\n", text);
+
+  duckdb_v2_logical_type_handle ok[1]  = { t_int };
+  duckdb_v2_logical_type_handle bad[1] = { t_var };
+  duckdb_v2_logical_type_handle mix[2] = { t_int, t_var };
+
+  try_chunk("[INTEGER]",          ok,  1);
+  try_chunk("[VARIANT]",          bad, 1);
+  try_chunk("[INTEGER, VARIANT]", mix, 2);
+
+  /* The collection is what bulk append actually fills in V2. */
+  printf("\ncolumn data collection:\n");
+  duckdb_v2_column_data_collection_handle coll = NULL;
+  duckdb_v2_error_info_handle cerr = NULL;
+  DUCKDB_V2_ERROR ce = duckdb_v2_column_data_collection_create_with_connection(
+      conn, mix, 2, &coll, &cerr);
+  printf("%-22s -> code=%d", "[INTEGER, VARIANT]", (int)ce);
+  if (ce == DUCKDB_V2_ERROR_NONE) {
+    printf(" collection=%s", coll ? "non-NULL" : "NULL");
+    duckdb_v2_column_data_collection_destroy(&coll);
+  } else {
+    duckdb_v2_str t = {NULL, 0};
+    if (cerr) duckdb_v2_error_info_get_text(cerr, &t);
+    printf(" msg=\"%.*s\"", (int)t.len, t.ptr ? t.ptr : "");
+    if (cerr) duckdb_v2_error_info_destroy(&cerr);
+  }
+  printf("\n");
+  return 0;
+}


### PR DESCRIPTION
#486 recorded this as a constraint that survives into V2 and blocks bulk append there. It is the reverse: **a V1 defect that V2 does not inherit.** Follows #487, which fixed the V1 half.

Documentation only — no code changes. Adds two probes so both halves are reproducible.

## The V1 half, corrected

#486 said the crash comes from `DuckDBVariantVector.setItem` being a no-op for null, leaving the vector's memory uninitialized. No variant vector is ever constructed: `duckdb_create_data_chunk` refuses a VARIANT logical type outright, and refuses by **returning null**.

From JS that looks like a chunk that merely came back empty, since reading a null handle through `duckdb_data_chunk_get_column_count` returns 0 — which is what made the diagnosis wrong twice. `chunk_probe.c` settles it:

```
[INTEGER]            handle=non-NULL columns=1
[VARIANT]            handle=NULL
[INTEGER, VARIANT]   handle=NULL
[] (zero types)      handle=non-NULL columns=0
```

Note the last line: a chunk with no columns is legitimate, so zero columns is not the signal — the null is. That is why #487 put the check in the binding, the only place the null is visible. The same probe against the 2.0 preview gives the same answers, so the V1 surface carries the defect across the boundary.

## The V2 half, which changes the conclusion

`duckdb_v2_data_chunk_create` accepts a VARIANT column, and so does `duckdb_v2_column_data_collection_create_with_connection` — the one that matters, since the collection is what bulk append fills when there is no appender. `chunk_probe_v2.c` measures both:

```
[INTEGER]            -> code=0 chunk=non-NULL columns=1
[VARIANT]            -> code=0 chunk=non-NULL columns=1
[INTEGER, VARIANT]   -> code=0 chunk=non-NULL columns=2

column data collection:
[INTEGER, VARIANT]   -> code=0 collection=non-NULL
```

It borrows the VARIANT logical type from a result schema rather than constructing one, because V2 builds types through a context and a context is only handed out inside callback scopes.

So there is no upstream prerequisite and nothing to raise with the DuckDB team. **The deferred-decision row that said otherwise is removed rather than rewritten.** Losing the per-value appender does not cost us VARIANT.

What the finding does is move the remaining gap onto our side: `DuckDBVariantVector` still cannot write. Under V1 that barely matters, with `appendVariant` and the other per-value paths to fall back on. Under V2 the collection is the only write path, so a VARIANT column in a bulk append needs that vector to learn to write — ours to implement when we want it, not a dependency to wait on, which is why it is stated in the section rather than deferred.

## The preview artifacts are rebuilt in place

Also recorded, because it nearly cost us: the preview tarballs are republished under the same tag, so a local `libduckdb-v2/` goes stale without its name or URL changing. Between 2026-09-05 and 2026-09-12 the osx-universal tarball went 38,600,129 → 38,950,606 bytes and the dylib grew about a megabyte, while `duckdb_v2.h` stayed byte-for-byte identical and every function count held — an implementation rebuild, not a surface change.

Every probe in the directory was re-run against the freshly fetched build and none of them moved: `smoke_v2`, `coexist_probe`, and both chunk probes report exactly what is documented. `compare_api.py --fetch` likewise still gives 546 / 548 / 527 and 314 exposed.

## Housekeeping

- Both new probes build in place like `smoke_v2` and `coexist_probe`, with a relative `@loader_path` rpath rather than an absolute one.
- `.gitignore` gains `chunk_probe` and `chunk_probe_v2`, so following the build instructions does not leave untracked executables behind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)