### PR TITLE
Read TIME_NS through its own JS converter

### DIFF
--- a/api/src/DuckDBValueConverters.ts
+++ b/api/src/DuckDBValueConverters.ts
@@ -21,6 +21,7 @@ import {
   DuckDBMapValue,
   DuckDBStructValue,
   DuckDBTimeTZValue,
+  DuckDBTimeNSValue,
   DuckDBTimeValue,
   DuckDBTimestampMillisecondsValue,
   DuckDBTimestampNanosecondsValue,
@@ -112,6 +113,13 @@ export function bigintFromTimeValue(value: DuckDBValue): bigint {
     return value.micros;
   }
   throw new Error(`Expected DuckDBTimeValue`);
+}
+
+export function bigintFromTimeNSValue(value: DuckDBValue): bigint {
+  if (value instanceof DuckDBTimeNSValue) {
+    return value.nanos;
+  }
+  throw new Error(`Expected DuckDBTimeNSValue`);
 }
 
 export function dateFromTimestampValue(value: DuckDBValue): Date {

--- a/api/src/JSDuckDBValueConverter.ts
+++ b/api/src/JSDuckDBValueConverter.ts
@@ -5,6 +5,7 @@ import {
   arrayFromArrayValue,
   arrayFromListValue,
   bigintFromBigIntValue,
+  bigintFromTimeNSValue,
   bigintFromTimeValue,
   booleanFromValue,
   bytesFromBitValue,
@@ -73,7 +74,7 @@ const JSConvertersByTypeId: {
   [DuckDBTypeId.SQLNULL]: nullConverter,
   [DuckDBTypeId.STRING_LITERAL]: unsupportedConverter,
   [DuckDBTypeId.INTEGER_LITERAL]: unsupportedConverter,
-  [DuckDBTypeId.TIME_NS]: bigintFromTimeValue,
+  [DuckDBTypeId.TIME_NS]: bigintFromTimeNSValue,
   [DuckDBTypeId.GEOMETRY]: bytesFromGeometryValue,
   [DuckDBTypeId.VARIANT]: fromVariantValue,
 };

--- a/api/test/time-ns.test.ts
+++ b/api/test/time-ns.test.ts
@@ -1,0 +1,51 @@
+import { assert, expect, test } from 'vitest';
+import { DuckDBTimeNSValue, TIME_NS } from '../src';
+import { withConnection } from './util/testHelpers';
+
+// TIME_NS decodes to DuckDBTimeNSValue, which carries `nanos` and is not a
+// DuckDBTimeValue. Pointing its JS converter at `bigintFromTimeValue` made
+// every TIME_NS column unreadable through the JS path, while the Json path —
+// which goes through toString — worked. See JSTypeForTypeId, which has always
+// declared TIME_NS as bigint.
+test('TIME_NS reads through the JS converters as nanoseconds', async () => {
+  await withConnection(async (connection) => {
+    const reader = await connection.runAndReadAll(
+      `select time_ns '12:34:56.123456789' as v`
+    );
+    assert.deepEqual(reader.getRowsJS(), [[45296123456789n]]);
+    assert.deepEqual(reader.getRowObjectsJS(), [{ v: 45296123456789n }]);
+    assert.deepEqual(reader.getColumnsJS(), [[45296123456789n]]);
+    // The raw path was never broken, and the two must agree.
+    assert.deepEqual(reader.getRows(), [
+      [new DuckDBTimeNSValue(45296123456789n)],
+    ]);
+    // Nor was the Json path, which renders via toString.
+    assert.deepEqual(reader.getRowsJson(), [['12:34:56.123456789']]);
+  });
+});
+
+test('TIME_NS range ends and NULL survive the JS converters', async () => {
+  await withConnection(async (connection) => {
+    const reader = await connection.runAndReadAll(
+      `select * from (values ('${TIME_NS.min}'::time_ns), ('${TIME_NS.max}'::time_ns), (null)) t(v)`
+    );
+    assert.deepEqual(reader.getColumnsJS(), [
+      [TIME_NS.min.nanos, TIME_NS.max.nanos, null],
+    ]);
+  });
+});
+
+test('a TIME value is not accepted as TIME_NS', async () => {
+  await withConnection(async (connection) => {
+    const reader = await connection.runAndReadAll(`select time '12:34:56' as v`);
+    // TIME still reads as micros, through its own converter.
+    assert.deepEqual(reader.getRowsJS(), [[45296000000n]]);
+  });
+});
+
+test('bigintFromTimeNSValue rejects a non-TIME_NS value', async () => {
+  const { bigintFromTimeNSValue } = await import('../src');
+  expect(() => bigintFromTimeNSValue(42n as never)).toThrowError(
+    'Expected DuckDBTimeNSValue'
+  );
+});

--- a/api/test/util/testJS.ts
+++ b/api/test/util/testJS.ts
@@ -21,6 +21,7 @@ import {
   SMALLINT,
   STRUCT,
   TIME,
+  TIME_NS,
   TIMESTAMP,
   TIMESTAMP_MS,
   TIMESTAMP_NS,
@@ -137,6 +138,12 @@ export function createTestJSData(): ColumnData[] {
       TIME,
       [`'${TIME.min}'`, `'${TIME.max}'`, 'null'],
       [TIME.min.micros, TIME.max.micros, null]
+    ),
+    col(
+      'time_ns',
+      TIME_NS,
+      [`'${TIME_NS.min}'`, `'${TIME_NS.max}'`, 'null'],
+      [TIME_NS.min.nanos, TIME_NS.max.nanos, null]
     ),
     col(
       'timestamp',


### PR DESCRIPTION
`JSConvertersByTypeId` mapped TIME_NS to `bigintFromTimeValue`, which accepts only a `DuckDBTimeValue`. A TIME_NS column decodes to `DuckDBTimeNSValue` — a separate class carrying `nanos`, not a subclass carrying `micros` — so **every TIME_NS column was unreadable through the JS path**:

```
select time_ns '12:34:56.123456789'

  getRowsJS()   -> Error: Expected DuckDBTimeValue
  getRows()     -> DuckDBTimeNSValue        (never broken)
  getRowsJson() -> '12:34:56.123456789'     (never broken, renders via toString)
```

Adds `bigintFromTimeNSValue` and points the entry at it, returning nanoseconds to match the value's own units — as TIME returns microseconds.

`JSTypeForTypeId` already declared TIME_NS as `bigint` and needs no change. The table was right and the converter was wrong, so this makes a documented type reachable rather than changing what it claims.

## Why nothing caught it

TIME_NS was missing from `test/util/testJS.ts`, which drives the JS-path tests in `results.test.ts` — the type was simply never exercised through those accessors. Adding it there covers TIME_NS through all four (`getRowsJS`, `getRowObjectsJS`, `getColumnsJS`, `getColumnsObjectJS`) and is what makes the regression loud: reverting the one-line map change now fails **8 tests across two files**, not just the new one.

`test/time-ns.test.ts` adds focused coverage — agreement between the JS, raw and Json paths, range ends and NULL, that TIME still reads as micros, and that the new converter rejects a non-TIME_NS value.

## Checked the rest of the table

Ran all 56 columns of `test_all_types()` through both converter paths looking for the same class of defect. TIME_NS is the only type mismatch.

Five columns do throw on the JS path — `date`, `timestamp`, `timestamp_s`, `timestamp_ms`, `timestamp_tz` — but those are the deliberate range errors for values outside what a JS `Date` can represent, which `test_all_types()` includes by design, and they report as such (`DATE value out of range for JS Date: -2147483646 days`). Not a second bug.

Full suite: 252 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)