### PR TITLE
Buffer rows into data chunks

### DIFF
--- a/api/src/DuckDBDataChunkWriter.ts
+++ b/api/src/DuckDBDataChunkWriter.ts
@@ -1,0 +1,144 @@
+import duckdb from '@duckdb/node-bindings';
+import type { DuckDBAppender } from './DuckDBAppender';
+import { DuckDBDataChunk } from './DuckDBDataChunk';
+import { DuckDBType } from './DuckDBType';
+import { ToDuckDBValueConverter } from './ToDuckDBValueConverter';
+import { DuckDBValue } from './values';
+
+/** Receives each data chunk a `DuckDBDataChunkWriter` fills. */
+export type DuckDBDataChunkSink = (chunk: DuckDBDataChunk) => void;
+
+/**
+ * `converter` is optional only when the rows are already `DuckDBValue`s, which
+ * is what `T` defaults to. Supply one to write some other representation —
+ * `JSToDuckDBValueConverter` for plain JS — and `T` follows from it.
+ */
+export type DuckDBDataChunkWriterOptions<T> = {
+  /**
+   * How many rows each emitted data chunk holds — its `rowCount`. Defaults to
+   * the DuckDB vector size, which is also the most a data chunk can hold.
+   */
+  readonly rowsPerDataChunk?: number;
+} & ([DuckDBValue] extends [T]
+  ? { readonly converter?: ToDuckDBValueConverter<T> }
+  : { readonly converter: ToDuckDBValueConverter<T> });
+
+/**
+ * Accumulates rows and emits them as filled data chunks, one per
+ * `rowsPerDataChunk` rows, passing each to `sink`.
+ *
+ * Rows are `DuckDBValue`s by default. Supply a converter to write some other
+ * representation; the row type follows from it.
+ *
+ *     const writer = DuckDBDataChunkWriter.forAppender(appender, {
+ *       converter: JSToDuckDBValueConverter,
+ *     });
+ *     for (const row of rows) {
+ *       writer.appendRow(row);
+ *     }
+ *     writer.flush();
+ *
+ * `flush` emits whatever is buffered, so call it when done: the last chunk is
+ * usually a partial one. Rows already grouped into chunk-sized batches need no
+ * writer — fill a `DuckDBDataChunk` and pass it to the destination directly.
+ */
+export class DuckDBDataChunkWriter<T = DuckDBValue> {
+  private readonly types: readonly DuckDBType[];
+  private readonly sink: DuckDBDataChunkSink;
+  private readonly rowsPerDataChunk: number;
+  private readonly converter?: ToDuckDBValueConverter<T>;
+  private rows: (T | null)[][] = [];
+
+  public constructor(
+    types: readonly DuckDBType[],
+    sink: DuckDBDataChunkSink,
+    options: DuckDBDataChunkWriterOptions<T> = {} as DuckDBDataChunkWriterOptions<T>
+  ) {
+    this.types = types;
+    this.sink = sink;
+    const maxRowCount = duckdb.vector_size();
+    this.rowsPerDataChunk = options.rowsPerDataChunk ?? maxRowCount;
+    // Checked here rather than left to the first flush, which is where the
+    // chunk itself would refuse it — a whole buffer's worth of rows later.
+    if (this.rowsPerDataChunk < 1 || this.rowsPerDataChunk > maxRowCount) {
+      throw new Error(
+        `rowsPerDataChunk must be between 1 and ${maxRowCount}, got ${this.rowsPerDataChunk}`
+      );
+    }
+    this.converter = options.converter;
+  }
+
+  /**
+   * A writer that appends each filled data chunk to `appender`, using the
+   * appender's own column types.
+   *
+   * Equivalent to constructing one with those types and a sink that calls
+   * `appendDataChunk`, but with nothing to keep in step by hand.
+   */
+  public static forAppender<T = DuckDBValue>(
+    appender: DuckDBAppender,
+    options: DuckDBDataChunkWriterOptions<T> = {} as DuckDBDataChunkWriterOptions<T>
+  ): DuckDBDataChunkWriter<T> {
+    const types: DuckDBType[] = [];
+    const columnCount = appender.columnCount;
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex++) {
+      types.push(appender.columnType(columnIndex));
+    }
+    return new DuckDBDataChunkWriter<T>(
+      types,
+      (chunk) => appender.appendDataChunk(chunk),
+      options
+    );
+  }
+
+  public get bufferedRowCount(): number {
+    return this.rows.length;
+  }
+
+  /**
+   * Buffers one row, emitting a data chunk once `rowsPerDataChunk` are held.
+   *
+   * The row is copied, so the same array can be reused across calls.
+   */
+  public appendRow(values: readonly (T | null)[]): void {
+    if (values.length !== this.types.length) {
+      throw new Error(
+        `Provided number of values (${values.length}) does not match number of types (${this.types.length})`
+      );
+    }
+    this.rows.push(values.slice());
+    if (this.rows.length >= this.rowsPerDataChunk) {
+      this.flush();
+    }
+  }
+
+  /**
+   * Emits the buffered rows as one data chunk. A no-op when none are
+   * buffered, so it is safe to call more than once.
+   *
+   * The buffer is emptied either way: if converting the rows fails, or the
+   * sink rejects the chunk, those rows are discarded along with the error.
+   * Appending afterwards starts a fresh chunk.
+   */
+  public flush(): void {
+    if (this.rows.length === 0) {
+      return;
+    }
+    // Taken before anything that can throw. Left in place, a batch that failed
+    // to convert or that the sink rejected would still be buffered, and later
+    // appends would grow it past `rowsPerDataChunk` and eventually past what a
+    // data chunk can hold at all — by which point the writer can no longer
+    // flush and the original error is long gone.
+    const rows = this.rows;
+    this.rows = [];
+    const chunk = DuckDBDataChunk.create(this.types);
+    if (this.converter) {
+      chunk.setRowsConverted(rows, this.converter);
+    } else {
+      // Without a converter the options type has already constrained `T` to
+      // `DuckDBValue`, which is the only thing that makes this cast sound.
+      chunk.setRows(rows as readonly (readonly DuckDBValue[])[]);
+    }
+    this.sink(chunk);
+  }
+}

--- a/api/src/duckdb.ts
+++ b/api/src/duckdb.ts
@@ -10,6 +10,7 @@ export * from './DuckDBAppender';
 export * from './DuckDBClientContext';
 export * from './DuckDBConnection';
 export * from './DuckDBDataChunk';
+export * from './DuckDBDataChunkWriter';
 export * from './DuckDBExtractedStatements';
 export * from './DuckDBInstance';
 export * from './DuckDBInstanceCache';

--- a/api/test/data-chunk-writer.test.ts
+++ b/api/test/data-chunk-writer.test.ts
@@ -1,0 +1,330 @@
+import { expect, test } from 'vitest';
+import duckdb from '@duckdb/node-bindings';
+import {
+  DuckDBConnection,
+  DuckDBDataChunk,
+  DuckDBDataChunkWriter,
+  DuckDBInstance,
+  JSToDuckDBValueConverter,
+  DATE,
+  INTEGER,
+  JS,
+  TIMESTAMP_MS,
+  UUID,
+  VARCHAR,
+  dateValue,
+} from '../src';
+
+async function connect(): Promise<DuckDBConnection> {
+  return (await DuckDBInstance.create(':memory:')).connect();
+}
+
+test('rows are emitted as one data chunk per rowsPerDataChunk', () => {
+  const emitted: number[] = [];
+  const writer = new DuckDBDataChunkWriter(
+    [INTEGER],
+    (chunk) => emitted.push(chunk.rowCount),
+    { rowsPerDataChunk: 3 }
+  );
+  for (let i = 0; i < 7; i++) {
+    writer.appendRow([i]);
+  }
+  expect(emitted).toEqual([3, 3]);
+  expect(writer.bufferedRowCount).toBe(1);
+  writer.flush();
+  expect(emitted).toEqual([3, 3, 1]);
+  expect(writer.bufferedRowCount).toBe(0);
+});
+
+test('flush is a no-op when nothing is buffered', () => {
+  let emitted = 0;
+  const writer = new DuckDBDataChunkWriter([INTEGER], () => emitted++);
+  writer.flush();
+  expect(emitted).toBe(0);
+  writer.appendRow([1]);
+  writer.flush();
+  writer.flush();
+  expect(emitted).toBe(1);
+});
+
+test('rowsPerDataChunk defaults to the DuckDB vector size', () => {
+  const emitted: number[] = [];
+  const writer = new DuckDBDataChunkWriter([INTEGER], (chunk) =>
+    emitted.push(chunk.rowCount)
+  );
+  const size = duckdb.vector_size();
+  for (let i = 0; i < size; i++) {
+    writer.appendRow([i]);
+  }
+  expect(emitted).toEqual([size]);
+});
+
+test('a row whose length does not match the types is refused', () => {
+  const writer = new DuckDBDataChunkWriter([INTEGER, VARCHAR], () => {});
+  expect(() => writer.appendRow([1])).toThrowError(
+    'Provided number of values (1) does not match number of types (2)'
+  );
+  expect(() => writer.appendRow([1, 'x', 2])).toThrowError(
+    'Provided number of values (3) does not match number of types (2)'
+  );
+});
+
+test('rows written through an appender round-trip', async () => {
+  const connection = await connect();
+  await connection.run(
+    `create table t (x integer, s varchar, ts timestamp_ms)`
+  );
+  const appender = await connection.createAppender('t');
+  const writer = new DuckDBDataChunkWriter(
+    [INTEGER, VARCHAR, TIMESTAMP_MS],
+    (chunk: DuckDBDataChunk) => appender.appendDataChunk(chunk),
+    { rowsPerDataChunk: 100, converter: JSToDuckDBValueConverter }
+  );
+  const when = new Date('2024-01-15T12:34:56.789Z');
+  for (let i = 0; i < 250; i++) {
+    writer.appendRow([i, `row-${i}`, when]);
+  }
+  writer.flush();
+  appender.closeSync();
+
+  const reader = await connection.runAndReadAll(
+    `select count(*) as n, sum(x) as total, max(ts) as latest from t`
+  );
+  expect(reader.getRowsJS()).toEqual([[250n, 31125n, when]]);
+});
+
+test('values are converted, so nulls and JS types pass through', async () => {
+  const connection = await connect();
+  await connection.run(`create table t (x integer, s varchar)`);
+  const appender = await connection.createAppender('t');
+  const writer = new DuckDBDataChunkWriter([INTEGER, VARCHAR], (chunk) =>
+    appender.appendDataChunk(chunk), { converter: JSToDuckDBValueConverter }
+  );
+  writer.appendRow([1, 'x']);
+  writer.appendRow([null, null]);
+  writer.flush();
+  appender.closeSync();
+
+  const reader = await connection.runAndReadAll(`select * from t order by x`);
+  expect(reader.getRowsJS()).toEqual([
+    [1, 'x'],
+    [null, null],
+  ]);
+});
+
+test('without a converter, rows are DuckDBValues', async () => {
+  const connection = await connect();
+  await connection.run(`create table t (x integer, s varchar, d date)`);
+  const appender = await connection.createAppender('t');
+  // No converter: DuckDBValue in, DuckDBDataChunk.setRows used directly.
+  const writer = new DuckDBDataChunkWriter([INTEGER, VARCHAR, DATE], (chunk) =>
+    appender.appendDataChunk(chunk)
+  );
+  writer.appendRow([1, 'x', dateValue(19737)]);
+  writer.appendRow([2, null, null]);
+  writer.flush();
+  appender.closeSync();
+
+  const reader = await connection.runAndReadAll(`select * from t order by x`);
+  expect(reader.getRows()).toEqual([
+    [1, 'x', dateValue(19737)],
+    [2, null, null],
+  ]);
+});
+
+test('a reused row array is copied, not aliased', async () => {
+  const connection = await connect();
+  await connection.run(`create table t (x integer, s varchar)`);
+  const appender = await connection.createAppender('t');
+  const writer = new DuckDBDataChunkWriter(
+    [INTEGER, VARCHAR],
+    (chunk) => appender.appendDataChunk(chunk),
+    { converter: JSToDuckDBValueConverter }
+  );
+  // One scratch array, mutated between calls. Without the copy in appendRow
+  // every buffered row would alias it and the table would hold row 4 five
+  // times over.
+  const scratch: [number, string] = [0, ''];
+  for (let i = 0; i < 5; i++) {
+    scratch[0] = i;
+    scratch[1] = `row-${i}`;
+    writer.appendRow(scratch);
+  }
+  writer.flush();
+  appender.closeSync();
+
+  const reader = await connection.runAndReadAll(`select * from t order by x`);
+  expect(reader.getRowsJS()).toEqual([
+    [0, 'row-0'],
+    [1, 'row-1'],
+    [2, 'row-2'],
+    [3, 'row-3'],
+    [4, 'row-4'],
+  ]);
+});
+
+test('the row type is checked against the converter', () => {
+  const sink = () => {};
+  void (() => {
+    const raw = new DuckDBDataChunkWriter([INTEGER, DATE], sink);
+    // @ts-expect-error a JS Date is not a DuckDBValue; supply a converter
+    raw.appendRow([1, new Date()]);
+    raw.appendRow([1, dateValue(0)]);
+
+    const js = new DuckDBDataChunkWriter([INTEGER, DATE], sink, {
+      converter: JSToDuckDBValueConverter,
+    });
+    js.appendRow([1, new Date()]);
+
+    // @ts-expect-error a converter is required once the rows are not DuckDBValues
+    new DuckDBDataChunkWriter<JS>([INTEGER], sink, {});
+  });
+  expect(true).toBe(true);
+});
+
+test('rowsPerDataChunk is validated when the writer is made', () => {
+  const max = duckdb.vector_size();
+  // A data chunk cannot hold more than the vector size. Left unchecked this
+  // surfaces at the first flush, a whole buffer's worth of rows later.
+  expect(
+    () =>
+      new DuckDBDataChunkWriter([INTEGER], () => {}, {
+        rowsPerDataChunk: max + 1,
+      })
+  ).toThrowError(`rowsPerDataChunk must be between 1 and ${max}, got ${max + 1}`);
+  expect(
+    () =>
+      new DuckDBDataChunkWriter([INTEGER], () => {}, { rowsPerDataChunk: 0 })
+  ).toThrowError(`rowsPerDataChunk must be between 1 and ${max}, got 0`);
+  expect(
+    () =>
+      new DuckDBDataChunkWriter([INTEGER], () => {}, { rowsPerDataChunk: max })
+  ).not.toThrow();
+});
+
+test('forAppender takes its column types from the appender', async () => {
+  const connection = await connect();
+  await connection.run(
+    `create table t (x integer, s varchar, ts timestamp_ms)`
+  );
+  const appender = await connection.createAppender('t');
+  // No types argument, and no sink: both come from the appender.
+  const writer = DuckDBDataChunkWriter.forAppender(appender, {
+    converter: JSToDuckDBValueConverter,
+  });
+  const when = new Date('2024-01-15T12:34:56.789Z');
+  for (let i = 0; i < 250; i++) {
+    writer.appendRow([i, `row-${i}`, when]);
+  }
+  writer.flush();
+  appender.closeSync();
+
+  const reader = await connection.runAndReadAll(
+    `select count(*) as n, sum(x) as total, max(ts) as latest from t`
+  );
+  expect(reader.getRowsJS()).toEqual([[250n, 31125n, when]]);
+});
+
+test('forAppender without a converter takes DuckDBValues', async () => {
+  const connection = await connect();
+  await connection.run(`create table t (x integer, d date)`);
+  const appender = await connection.createAppender('t');
+  const writer = DuckDBDataChunkWriter.forAppender(appender);
+  writer.appendRow([1, dateValue(19737)]);
+  writer.flush();
+  appender.closeSync();
+
+  const reader = await connection.runAndReadAll(`select * from t`);
+  expect(reader.getRows()).toEqual([[1, dateValue(19737)]]);
+});
+
+test('forAppender keeps the row type checked', async () => {
+  const connection = await connect();
+  await connection.run(`create table t (x integer, d date)`);
+  const appender = await connection.createAppender('t');
+  void (() => {
+    const raw = DuckDBDataChunkWriter.forAppender(appender);
+    // @ts-expect-error a JS Date is not a DuckDBValue; supply a converter
+    raw.appendRow([1, new Date()]);
+
+    const js = DuckDBDataChunkWriter.forAppender(appender, {
+      converter: JSToDuckDBValueConverter,
+    });
+    js.appendRow([1, new Date()]);
+
+    // @ts-expect-error a converter is required once the rows are not DuckDBValues
+    DuckDBDataChunkWriter.forAppender<JS>(appender, {});
+  });
+  expect(appender.columnCount).toBe(2);
+  appender.closeSync();
+});
+
+test('a failed flush empties the buffer rather than retaining it', () => {
+  // Retained rows would grow past rowsPerDataChunk on later appends, and
+  // eventually past what a data chunk can hold, leaving the writer unable to
+  // flush at all.
+  const writer = new DuckDBDataChunkWriter([INTEGER, UUID], () => {}, {
+    rowsPerDataChunk: 4,
+    converter: JSToDuckDBValueConverter,
+  });
+  const uuid = '10203040-5060-7080-90a0-b0c0d0e0f000';
+  for (let i = 0; i < 3; i++) {
+    writer.appendRow([i, uuid]);
+  }
+  expect(() => writer.appendRow([3, 'not-a-uuid'])).toThrowError(
+    'Failed to set column 1 (UUID)'
+  );
+  expect(writer.bufferedRowCount).toBe(0);
+
+  // The writer still works afterwards: one bad row does not poison it. A bad
+  // value is only detected when a flush is triggered, so it sits in the buffer
+  // until then — here by an explicit flush rather than by reaching capacity.
+  const emitted: number[] = [];
+  const recovered = new DuckDBDataChunkWriter(
+    [INTEGER, UUID],
+    (chunk) => emitted.push(chunk.rowCount),
+    { rowsPerDataChunk: 100, converter: JSToDuckDBValueConverter }
+  );
+  recovered.appendRow([0, uuid]);
+  expect(() => recovered.appendRow([1, 'not-a-uuid'])).not.toThrow();
+  expect(recovered.bufferedRowCount).toBe(2);
+  expect(() => recovered.flush()).toThrowError('Failed to set column 1 (UUID)');
+  expect(recovered.bufferedRowCount).toBe(0);
+  expect(emitted).toEqual([]);
+
+  recovered.appendRow([2, uuid]);
+  recovered.flush();
+  expect(emitted).toEqual([1]);
+});
+
+test('a rejecting sink cannot grow the buffer past the maximum', () => {
+  const max = duckdb.vector_size();
+  let failing = true;
+  const emitted: number[] = [];
+  const writer = new DuckDBDataChunkWriter(
+    [INTEGER],
+    (chunk) => {
+      if (failing) {
+        throw new Error('sink down');
+      }
+      emitted.push(chunk.rowCount);
+    },
+    { rowsPerDataChunk: max, converter: JSToDuckDBValueConverter }
+  );
+  let thrown = 0;
+  for (let i = 0; i < max + 5; i++) {
+    try {
+      writer.appendRow([i]);
+    } catch {
+      thrown++;
+    }
+  }
+  expect(thrown).toBe(1);
+  expect(writer.bufferedRowCount).toBeLessThan(max);
+  expect(writer.bufferedRowCount).toBe(5);
+
+  // And once the sink recovers, the writer flushes normally.
+  failing = false;
+  writer.flush();
+  expect(emitted).toEqual([5]);
+});


### PR DESCRIPTION
`DuckDBDataChunk.setRowsConverted` (#491) takes rows a chunk at a time. A caller producing a row at a time, with no natural batch boundary, has to do the batching — four lines, but four lines every such caller writes. `DuckDBDataChunkWriter` holds the buffer instead:

```ts
const writer = DuckDBDataChunkWriter.forAppender(appender, {
  converter: JSToDuckDBValueConverter,
});
for (const row of rows) writer.appendRow(row);
writer.flush();
```

It only buffers. Rows are `DuckDBValue`s by default and go through `setRows`; supplying a converter switches to `setRowsConverted` and the row type follows from it. Either way the conversion stays in `DuckDBDataChunk`, called once per filled chunk, so this adds no second path through it.

## The converter is optional only where omitting it is sound

The options type is conditional on the row type, so it becomes required as soon as the rows are not `DuckDBValue`s, and the row type is inferred from the converter when one is given. That is also what makes the single cast in `flush` sound.

```ts
new DuckDBDataChunkWriter(types, sink)            // DuckDBValue rows
new DuckDBDataChunkWriter(types, sink, { converter: JSToDuckDBValueConverter })
new DuckDBDataChunkWriter<JS>(types, sink, {})    // rejected: converter missing
raw.appendRow([1, new Date()])                    // rejected: not a DuckDBValue
```

## `forAppender`

Covers the common destination, taking the column types from the appender's own `columnCount` and `columnType` — there is no types argument to get wrong and none to disagree with the table, where previously two sources had to be kept in step by hand.

A factory on the writer rather than a method on `DuckDBAppender`, because the destination is what varies — which is why the sink is a hook at all. V2 has no appender, and bulk append there fills a column data collection, so that entry point belongs beside this one rather than on a class V2 replaces. It also keeps `DuckDBAppender` a thin wrapper over `duckdb_appender_*`. The import is type-only, so the writer gains no runtime dependency on it.

## Three things worth a reviewer's attention

**`rowsPerDataChunk` is validated at construction.** It is the row count of each emitted chunk, bounded by the vector size. Left unchecked, a larger value was accepted and then refused by the chunk at the first flush — a whole buffer's worth of rows later, from a message naming neither the option nor the writer.

**`appendRow` copies the row, and that is load-bearing.** The writer retains rows across calls, which nothing else in the API does, so without the copy a caller reusing one array would have every buffered row alias it. Five appends of a mutated scratch array produced five copies of row 4, silently:

```
without the copy:  [[4,"row-4"],[4,"row-4"],[4,"row-4"],[4,"row-4"],[4,"row-4"]]
with the copy:     [[0,"row-0"],[1,"row-1"],[2,"row-2"],[3,"row-3"],[4,"row-4"]]
```

It costs nothing measurable — 46ms against 48ms over 200k rows, inside the run-to-run spread.

**`flush` empties the buffer before anything that can throw.** It used to clear it last, so a value that failed to convert or a sink that rejected the chunk left the rows in place, and later appends grew that same buffer past `rowsPerDataChunk` and eventually past what a data chunk can hold:

```
failing sink, 2053 appends: buffered=2053 (max=2048)
flush after sink recovers -> A data chunk cannot have more than 2048 rows
```

By then the writer could not flush at all, and the original error was long gone. A single bad value had the same effect, poisoning the writer permanently. Taking the rows out first bounds the buffer at `rowsPerDataChunk`, which the constructor bounds by the vector size, so a chunk is never asked to hold more rows than it can. The trade-off is that a failed batch is dropped with its error rather than retried forever — the rule upstream's own appender applies to non-retryable failures.

## Cost

Over 200k rows of (INTEGER, VARCHAR, TIMESTAMP_MS), best of three passes each:

| | best | all passes |
|---|---|---|
| per-value appender calls | 175ms | 199/175/182 |
| filling data chunks directly | 39ms | 48/39/42 |
| through this writer | 41ms | 48/46/41 |

So the buffering costs about 5% over doing it by hand, and the per-run spreads overlap — on this workload it is within noise. A caller who already has rows in chunk-sized batches should still skip the writer and fill a chunk directly.

## Note

A bad value is only detected when a flush is triggered, not at `appendRow`, so it can sit in the buffer for up to `rowsPerDataChunk - 1` appends before surfacing. That is inherent to batching, but worth knowing.

Full suite: 282 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)