### PR TITLE
Document the write-side API in the package README

### DIFF
--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -209,6 +209,38 @@ These are:
 | `UNION` | `unionValue` |
 | `UUID` | `uuidValue` |
 
+Alternatively, `jsToDuckDBValue` converts a plain JS value to the form
+a given DuckDB type expects, so these functions need not be called
+directly:
+
+```ts
+import { jsToDuckDBValue, DATE, TIMESTAMP_MS } from '@duckdb/node-api';
+
+jsToDuckDBValue(new Date('2024-01-15T12:34:56.789Z'), TIMESTAMP_MS);
+// same as timestampMillisValue(1705322096789n)
+
+jsToDuckDBValue(new Date('2024-01-15T00:00:00.000Z'), DATE);
+// same as dateValue(19737)
+
+jsToDuckDBValue(null, DATE); // null, for any type
+```
+
+It is generic over the type, so a statically known one checks its input:
+
+```ts
+jsToDuckDBValue(new Date(), TIMESTAMP); // ok
+jsToDuckDBValue(new Date(), INTEGER);   // rejected at compile time
+```
+
+What each type accepts is given by `JSInputTypeForTypeId`, and by
+`JSInputTypeFor` when keyed by a `DuckDBType`. These are wider than
+what is read back where a second spelling is unambiguous: `BIGINT` and
+the wider integers accept `number` as well as `bigint`, and `DECIMAL`
+accepts either a double or a raw scaled `bigint`.
+
+The result is a `DuckDBValue`, which is what `appendValue`,
+`bindValue`, and `setRows` all accept.
+
 ### Stream Results
 
 Streaming results evaluate lazily when rows are read.
@@ -563,6 +595,45 @@ const columnNameAndTypeObjects = reader.columnNameAndTypeObjectsJson();
 // ]
 ```
 
+### Infer JS Types from DuckDB Types
+
+The mapping each converter applies is also available at the type level.
+`JSTypeFor` gives the JS type that `getRowsJS` and the other `JS` methods
+produce for a given DuckDB type; `JsonTypeFor` does the same for the `Json`
+methods.
+
+```ts
+import {
+  JSTypeFor,
+  JsonTypeFor,
+  DuckDBBigIntType,
+  DuckDBIntegerType,
+  DuckDBTimestampTZType,
+} from '@duckdb/node-api';
+
+type A = JSTypeFor<DuckDBIntegerType>;     // number
+type B = JSTypeFor<DuckDBBigIntType>;      // bigint
+type C = JSTypeFor<DuckDBTimestampTZType>; // Date
+
+type D = JsonTypeFor<DuckDBBigIntType>;      // string
+type E = JsonTypeFor<DuckDBTimestampTZType>; // string
+```
+
+The two differ wherever a value has no lossless JSON form: 64-bit and
+wider integers, temporal types, `DECIMAL`, `BLOB`, `BIT` and `GEOMETRY`
+render as strings, and `FLOAT` and `DOUBLE` widen to `number | string`
+so that Infinity and NaN survive.
+
+Both are also available keyed by type id, as `JSTypeForTypeId` and
+`JsonTypeForTypeId`, which is the form to use when the id is what you have:
+
+```ts
+type F = JSTypeForTypeId[DuckDBTypeId.INTEGER]; // number
+```
+
+These describe non-NULL values. Since any column can be NULL, a value read
+from one is `JSTypeFor<T> | null`.
+
 ### Fetch Chunks
 
 Fetch all chunks:
@@ -880,6 +951,87 @@ appender.flushSync();
 ```
 
 See "Specifying Values" above for how to supply values to the appender.
+
+### Append Data Chunk of JS Values
+
+`setRowsConverted` and `setColumnsConverted` fill a data chunk from
+values in another representation, converting on the way in.
+`JSToDuckDBValueConverter` converts from plain JS, so a `Date` can be
+written to a `TIMESTAMP` column without constructing a
+`DuckDBTimestampValue` first:
+
+```ts
+import {
+  DuckDBDataChunk,
+  JSToDuckDBValueConverter,
+  INTEGER,
+  TIMESTAMP,
+  VARCHAR,
+} from '@duckdb/node-api';
+
+await connection.run(
+  `create or replace table target_table(
+    i integer, v varchar, t timestamp
+  )`
+);
+
+const appender = await connection.createAppender('target_table');
+
+const chunk = DuckDBDataChunk.create([INTEGER, VARCHAR, TIMESTAMP]);
+chunk.setRowsConverted(
+  [
+    [42, 'duck', new Date('2024-01-15T12:34:56.000Z')],
+    [123, 'mallard', null],
+  ],
+  JSToDuckDBValueConverter
+);
+
+appender.appendDataChunk(chunk);
+appender.flushSync();
+```
+
+The column types come from the chunk, so no types are passed to the
+converter. `setColumnValuesConverted` does the same for a single
+column.
+
+### Buffer Rows Into Data Chunks
+
+`DuckDBDataChunkWriter` accumulates rows and emits them as filled data
+chunks, for callers producing a row at a time. `forAppender` takes the
+column types from the appender:
+
+```ts
+import {
+  DuckDBDataChunkWriter,
+  JSToDuckDBValueConverter,
+} from '@duckdb/node-api';
+
+await connection.run(
+  `create or replace table target_table(i integer, v varchar)`
+);
+
+const appender = await connection.createAppender('target_table');
+
+const writer = DuckDBDataChunkWriter.forAppender(appender, {
+  converter: JSToDuckDBValueConverter,
+});
+
+writer.appendRow([42, 'duck']);
+writer.appendRow([123, 'mallard']);
+writer.appendRow([17, 'goose']);
+
+// Emits the buffered rows. The last chunk is usually a partial one.
+writer.flush();
+appender.closeSync();
+```
+
+A chunk is emitted every `rowsPerDataChunk` rows, which defaults to the
+DuckDB vector size. Omit the converter to write `DuckDBValue`s instead.
+Rows are copied as they are appended, so the same array can be reused
+across calls.
+
+Callers who already have rows in chunk-sized batches do not need a writer;
+filling a data chunk directly, as above, avoids the buffering.
 
 ### Scalar Functions
 

--- a/api/pkgs/@duckdb/node-api/README.md
+++ b/api/pkgs/@duckdb/node-api/README.md
@@ -668,7 +668,8 @@ Get chunk data:
 ```ts
 const rows = chunk.getRows();
 
-const rowObjects = chunk.getRowObjects(result.deduplicatedColumnNames());
+const rowObjects =
+  chunk.getRowObjects(result.deduplicatedColumnNames());
 
 const columns = chunk.getColumns();
 
@@ -1115,7 +1116,8 @@ connection.registerTableFunction(
       const { count } = info.bindData as { count: number };
       const initData = info.initData as { nextRow: number };
       const chunkSize = Math.min(2048, count - initData.nextRow);
-      // Set the row count before writing: that is what sizes the vectors.
+      // Set the row count before writing: that is what sizes the
+      // vectors.
       // A row count of zero reports that the scan is finished.
       output.rowCount = chunkSize;
       if (chunkSize > 0) {
@@ -1129,7 +1131,8 @@ connection.registerTableFunction(
     },
   })
 );
-const reader = await connection.runAndReadAll('select * from my_range(3)');
+const reader =
+  await connection.runAndReadAll('select * from my_range(3)');
 const rows = reader.getRows();
 // [ [ 0 ], [ 1 ], [ 2 ] ]
 ```
@@ -1257,8 +1260,9 @@ const reader = await connection.streamAndReadAll(sql, values, types);
 const reader = await connection.streamAndReadUntil(sql, targetRowCount);
 const reader =
   await connection.streamAndReadUntil(sql, targetRowCount, values);
-const reader =
-  await connection.streamAndReadUntil(sql, targetRowCount, values, types);
+const reader = await connection.streamAndReadUntil(
+  sql, targetRowCount, values, types
+);
 
 // Prepared Statements
 
@@ -1269,7 +1273,8 @@ const prepared = await connection.prepare(sql);
 prepared.bind(values);
 prepared.bind(values, types);
 
-// Run the prepared statement. These mirror the methods on the connection.
+// Run the prepared statement. These mirror the methods on the
+// connection.
 const result = prepared.run();
 
 const reader = prepared.runAndRead();
@@ -1289,11 +1294,11 @@ const pending = await connection.start(sql);
 const pending = await connection.start(sql, values);
 const pending = await connection.start(sql, values, types);
 
-// The methods beginning with "startThenRead" provide some, but not full,
-// cooperative multithreading. They use pending results to split processing
-// into short tasks, but they fully materialize the result, which can
-// take some time (and memory). For full cooperative multithreading,
-// see the "startStreamThenRead" methods below.
+// The methods beginning with "startThenRead" provide some, but not
+// full, cooperative multithreading. They use pending results to split
+// processing into short tasks, but they fully materialize the result,
+// which can take some time (and memory). For full cooperative
+// multithreading, see the "startStreamThenRead" methods below.
 const reader = await connection.startThenRead(sql);
 const reader = await connection.startThenRead(sql, values);
 const reader = await connection.startThenRead(sql, values, types);
@@ -1305,8 +1310,9 @@ const reader = await connection.startThenReadAll(sql, values, types);
 const reader = await connection.startThenReadUntil(sql, targetRowCount);
 const reader =
   await connection.startThenReadUntil(sql, targetRowCount, values);
-const reader =
-  await connection.startThenReadUntil(sql, targetRowCount, values, types);
+const reader = await connection.startThenReadUntil(
+  sql, targetRowCount, values, types
+);
 
 // Create a pending, streaming result.
 const pending = await connection.startStream(sql);
@@ -1329,8 +1335,9 @@ const reader =
 
 const reader =
   await connection.startStreamThenReadUntil(sql, targetRowCount);
-const reader =
-  await connection.startStreamThenReadUntil(sql, targetRowCount, values);
+const reader = await connection.startStreamThenReadUntil(
+  sql, targetRowCount, values
+);
 const reader = await connection.startStreamThenReadUntil(
   sql, targetRowCount, values, types);
 

--- a/api/test/readme-write-examples.test.ts
+++ b/api/test/readme-write-examples.test.ts
@@ -1,0 +1,86 @@
+// Runs the examples from the write-side sections of the package README, so
+// they cannot drift from the API they document. Kept in step with:
+//   "Specifying Values", "Infer JS Types from DuckDB Types",
+//   "Append Data Chunk of JS Values", "Buffer Rows Into Data Chunks"
+import { expect, test } from 'vitest';
+import {
+  DATE, DuckDBBigIntType, DuckDBDataChunk, DuckDBDataChunkWriter, DuckDBInstance,
+  DuckDBIntegerType, DuckDBTimestampTZType, DuckDBTypeId, INTEGER, JSToDuckDBValueConverter,
+  JSTypeFor, JSTypeForTypeId, JsonTypeFor, TIMESTAMP, TIMESTAMP_MS, VARCHAR,
+  dateValue, jsToDuckDBValue, timestampMillisValue,
+} from '../src';
+
+// --- "Specifying Values" additions ---
+test('README: jsToDuckDBValue examples', () => {
+  expect(jsToDuckDBValue(new Date('2024-01-15T12:34:56.789Z'), TIMESTAMP_MS))
+    .toEqual(timestampMillisValue(1705322096789n));
+  expect(jsToDuckDBValue(new Date('2024-01-15T00:00:00.000Z'), DATE))
+    .toEqual(dateValue(19737));
+  expect(jsToDuckDBValue(null, DATE)).toBeNull();
+  void (() => {
+    jsToDuckDBValue(new Date(), TIMESTAMP);
+    // @ts-expect-error README claims this is rejected at compile time
+    jsToDuckDBValue(new Date(), INTEGER);
+  });
+});
+
+// --- "Infer JS Types from DuckDB Types" ---
+type Eq<A, B> = (<G>() => G extends A ? 1 : 2) extends <G>() => G extends B ? 1 : 2 ? true : false;
+type Assert<T extends true> = T;
+export type _README = [
+  Assert<Eq<JSTypeFor<DuckDBIntegerType>, number>>,
+  Assert<Eq<JSTypeFor<DuckDBBigIntType>, bigint>>,
+  Assert<Eq<JSTypeFor<DuckDBTimestampTZType>, Date>>,
+  Assert<Eq<JsonTypeFor<DuckDBBigIntType>, string>>,
+  Assert<Eq<JsonTypeFor<DuckDBTimestampTZType>, string>>,
+  Assert<Eq<JSTypeForTypeId[DuckDBTypeId.INTEGER], number>>,
+];
+
+// --- "Append Data Chunk of JS Values" ---
+test('README: setRowsConverted example', async () => {
+  const connection = await (await DuckDBInstance.create(':memory:')).connect();
+  await connection.run(
+    `create or replace table target_table(
+      i integer, v varchar, t timestamp
+    )`
+  );
+  const appender = await connection.createAppender('target_table');
+  const chunk = DuckDBDataChunk.create([INTEGER, VARCHAR, TIMESTAMP]);
+  chunk.setRowsConverted(
+    [
+      [42, 'duck', new Date('2024-01-15T12:34:56.000Z')],
+      [123, 'mallard', null],
+    ],
+    JSToDuckDBValueConverter
+  );
+  appender.appendDataChunk(chunk);
+  appender.flushSync();
+
+  const reader = await connection.runAndReadAll(`select * from target_table order by i`);
+  expect(reader.getRowsJS()).toEqual([
+    [42, 'duck', new Date('2024-01-15T12:34:56.000Z')],
+    [123, 'mallard', null],
+  ]);
+});
+
+// --- "Buffer Rows Into Data Chunks" ---
+test('README: DuckDBDataChunkWriter example', async () => {
+  const connection = await (await DuckDBInstance.create(':memory:')).connect();
+  await connection.run(`create or replace table target_table(i integer, v varchar)`);
+  const appender = await connection.createAppender('target_table');
+  const writer = DuckDBDataChunkWriter.forAppender(appender, {
+    converter: JSToDuckDBValueConverter,
+  });
+  writer.appendRow([42, 'duck']);
+  writer.appendRow([123, 'mallard']);
+  writer.appendRow([17, 'goose']);
+  writer.flush();
+  appender.closeSync();
+
+  const reader = await connection.runAndReadAll(`select * from target_table order by i`);
+  expect(reader.getRowsJS()).toEqual([
+    [17, 'goose'],
+    [42, 'duck'],
+    [123, 'mallard'],
+  ]);
+});


### PR DESCRIPTION
Four things landed recently with nothing in the README to find them by: `jsToDuckDBValue` and the input tables (#491), the converted setters on `DuckDBDataChunk` (#491), `DuckDBDataChunkWriter` (#492), and the read-side type mappings (#482).

Two commits: the new sections, then a wrapping fix to code examples that predate them.

## Where the sections went

Each is placed where the gap it closes is already described, rather than grouped at the end:

- **`jsToDuckDBValue`** — appended to "Specifying Values", directly under its table of 18 per-type construction functions, since it is the way to avoid calling them. Also covers `JSInputTypeForTypeId` / `JSInputTypeFor` and notes these are wider than what is read back.
- **"Infer JS Types from DuckDB Types"** — after "Convert Result Data", covering `JSTypeFor` / `JsonTypeFor` and the id-keyed forms, with the JS/Json divergence spelled out.
- **"Append Data Chunk of JS Values"** — after "Append Data Chunk", for `setRowsConverted` / `setColumnsConverted`.
- **"Buffer Rows Into Data Chunks"** — `DuckDBDataChunkWriter` and `forAppender`.

The two index sections at the end ("Ways to run SQL", "Ways to get result data") are read-side only, so nothing was added there.

## The examples are executed, not eyeballed

`readme-write-examples.test.ts` runs every example from these sections and asserts its output, including the two that claim a compile error (via `@ts-expect-error`). A README example cannot quietly stop working.

This is not existing practice in this repo, so it is easy to drop if the precedent is unwanted — but examples are the part of a README most likely to rot, and it already earned its keep: it caught the reshaped `create or replace` statement when the width fix changed it.

## The width limit is 72, measured

The npm readme column **caps at 731px however wide the window** — identical at 1920px and 2560px. That leaves 701px of content, and npm renders code in 16px monospace advancing 9.633px per character, so **72 characters fit** and anything longer scrolls.

The second commit wraps nine pre-existing code lines that exceeded it, at 73 to 75:

| | |
|---|---|
| comments re-flowed | 5 |
| statements broken at the argument list or assignment | 4 |

```ts
const reader =
  await connection.runAndReadAll('select * from my_range(3)');

const reader = await connection.startThenReadUntil(
  sql, targetRowCount, values, types
);
```

Only the wrapping changes — every statement is the same call with the same arguments, and the reshaped ones were extracted and type-checked to confirm they still parse.

Six of the nine are in "Ways to run SQL" and the sections around it, which suggests those were written against a wider margin than the rest of the file.

Prose is wrapped to 75, where going over costs nothing because it reflows.

Full suite: 285 passed, 1 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)